### PR TITLE
feat(core,azure): poll Azure ARM long-running operations

### DIFF
--- a/packages/azure/src/client.ts
+++ b/packages/azure/src/client.ts
@@ -32,6 +32,7 @@ import {
   AzureParseError,
 } from "./errors.ts";
 import { Credentials } from "./credentials.ts";
+import { pollLongRunning } from "./lro.ts";
 
 // Re-export for backwards compatibility
 export { UnknownAzureError } from "./errors.ts";
@@ -194,4 +195,11 @@ export const API = makeAPI<Credentials>({
     }
     return parts;
   },
+
+  /**
+   * Drive ARM long-running operations (ops whose `Http` trait carries a
+   * `longRunning` marker) to completion: poll the async monitor and resolve the
+   * provisioned resource before the result is decoded. See `./lro.ts`.
+   */
+  pollLongRunning,
 });

--- a/packages/azure/src/errors.ts
+++ b/packages/azure/src/errors.ts
@@ -358,3 +358,23 @@ export class AzureParseError extends Schema.TaggedErrorClass<AzureParseError>()(
     cause: Schema.Unknown,
   },
 ).pipe(Category.withParseError) {}
+
+/**
+ * A long-running operation reached a non-success terminal state
+ * (`Failed` or `Canceled`). `status` is the terminal provisioning/operation
+ * status; `code`/`message`/`target` carry ARM's `error` envelope when present.
+ *
+ * Deliberately uncategorized so it is **not** auto-retried: the server already
+ * ran the operation to a terminal failure, and silently re-issuing the request
+ * (a create/update) is unsafe. Callers can opt into retrying explicitly.
+ */
+export class AzureLongRunningOperationFailed extends Schema.TaggedErrorClass<AzureLongRunningOperationFailed>()(
+  "AzureLongRunningOperationFailed",
+  {
+    status: Schema.optional(Schema.String),
+    code: Schema.optional(Schema.String),
+    message: Schema.optional(Schema.String),
+    target: Schema.optional(Schema.String),
+    body: Schema.Unknown,
+  },
+) {}

--- a/packages/azure/src/lro.ts
+++ b/packages/azure/src/lro.ts
@@ -1,0 +1,225 @@
+/**
+ * Azure ARM long-running-operation (LRO) poller.
+ *
+ * ARM mutating operations (PUT/PATCH/POST/DELETE) frequently return a `201`/`202`
+ * ack and complete asynchronously. This poller drives the ack to a terminal
+ * state and resolves the final resource, so callers receive a provisioned
+ * resource instead of the intermediate ack body.
+ *
+ * Polling is expressed with Effect's built-in `Effect.repeat` + `Schedule`: the
+ * monitor GET repeats `until` it observes a terminal state, spaced by a schedule
+ * that honors each response's `Retry-After` header. The monitor style and final
+ * resolution are selected with `Match` rather than branching.
+ *
+ * Wired into the client via `makeAPI({ ..., pollLongRunning })`; the core client
+ * invokes it whenever an operation's `Http` trait carries a `longRunning` marker
+ * and the response is an async ack.
+ *
+ * See https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/async-api-reference.md
+ */
+import * as Data from "effect/Data";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import { flow } from "effect/Function";
+import * as Match from "effect/Match";
+import * as Option from "effect/Option";
+import * as Schedule from "effect/Schedule";
+import * as Schema from "effect/Schema";
+import * as Headers from "effect/unstable/http/Headers";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import type * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
+import type * as UrlParams from "effect/unstable/http/UrlParams";
+import { parseRetryAfter } from "@distilled.cloud/core/retry-after";
+import { AzureLongRunningOperationFailed } from "./errors.ts";
+
+/** Poll interval used when a monitor response carries no `Retry-After`. */
+const DEFAULT_POLL_INTERVAL = Duration.seconds(1);
+
+/** A decoded JSON response: status + headers + tolerant body. */
+interface JsonResponse {
+  status: number;
+  headers: Headers.Headers;
+  body: unknown;
+}
+
+/**
+ * A custom HTTP client that carries the operation's auth + JSON `Accept` on
+ * every ARM request and decodes responses to {@link JsonResponse} (tolerating
+ * empty/non-JSON bodies, e.g. a `202` ack). Mirrors the configured-client
+ * factories in alchemy (`makeHttpStateStore`) and opencode (`Account`).
+ */
+const makeArmClient = (
+  base: HttpClient.HttpClient,
+  authHeaders: Headers.Input,
+) => {
+  const client = base.pipe(
+    HttpClient.mapRequest(
+      flow(
+        HttpClientRequest.setHeaders(authHeaders),
+        HttpClientRequest.acceptJson,
+      ),
+    ),
+  );
+  const get = (
+    url: string,
+    urlParams?: UrlParams.UrlParams,
+  ): Effect.Effect<JsonResponse, unknown> =>
+    client.get(url, { urlParams }).pipe(
+      Effect.flatMap((res) =>
+        res.json.pipe(
+          Effect.catch(() => Effect.succeed(undefined)),
+          Effect.map((body) => ({
+            status: res.status,
+            headers: res.headers,
+            body,
+          })),
+        ),
+      ),
+    );
+  return { get } as const;
+};
+
+/** The async-operation monitor fields the poller acts on. */
+const MonitorBody = Schema.Struct({
+  status: Schema.optional(Schema.String),
+  error: Schema.optional(
+    Schema.Struct({
+      code: Schema.optional(Schema.String),
+      message: Schema.optional(Schema.String),
+      target: Schema.optional(Schema.String),
+    }),
+  ),
+});
+type Monitor = typeof MonitorBody.Type;
+const readMonitor = Schema.decodeUnknownOption(MonitorBody);
+const monitorOf = (body: unknown): Monitor =>
+  readMonitor(body).pipe(Option.getOrElse((): Monitor => ({})));
+
+/** Terminal classification of an ARM provisioning/operation status. */
+type ProvisioningState = Data.TaggedEnum<{
+  InProgress: {};
+  Succeeded: {};
+  Failed: { readonly status: string };
+}>;
+const ProvisioningState = Data.taggedEnum<ProvisioningState>();
+
+const classify = (status: string | undefined): ProvisioningState =>
+  Match.value(status).pipe(
+    Match.when("Succeeded", () => ProvisioningState.Succeeded()),
+    Match.whenOr("Failed", "Canceled", "Cancelled", (status) =>
+      ProvisioningState.Failed({ status }),
+    ),
+    Match.orElse(() => ProvisioningState.InProgress()),
+  );
+
+/** How the operation reports completion, derived from the ack's headers. */
+type Strategy = Data.TaggedEnum<{
+  AsyncOperation: { readonly url: string };
+  Location: { readonly url: string };
+  Direct: {};
+}>;
+const Strategy = Data.taggedEnum<Strategy>();
+
+const strategyOf = (headers: Headers.Headers): Strategy =>
+  Headers.get(headers, "azure-asyncoperation").pipe(
+    Option.orElse(() => Headers.get(headers, "operation-location")),
+    Option.map((url) => Strategy.AsyncOperation({ url })),
+    Option.orElse(() =>
+      Headers.get(headers, "location").pipe(
+        Option.map((url) => Strategy.Location({ url })),
+      ),
+    ),
+    Option.getOrElse(() => Strategy.Direct()),
+  );
+
+/**
+ * Poll cadence: each wait honors the most recent response's `Retry-After`
+ * (falling back to `DEFAULT_POLL_INTERVAL`). `passthrough` exposes the response
+ * to `modifyDelay` so the delay can be derived from its headers.
+ */
+const pollSchedule = Schedule.spaced(DEFAULT_POLL_INTERVAL).pipe(
+  Schedule.setInputType<JsonResponse>(),
+  Schedule.passthrough,
+  Schedule.modifyDelay((latest) =>
+    Effect.succeed(parseRetryAfter(latest.headers) ?? DEFAULT_POLL_INTERVAL),
+  ),
+);
+
+/** Fail when an async-operation monitor settled on `Failed`/`Canceled`. */
+const ensureSucceeded = (
+  terminal: JsonResponse,
+): Effect.Effect<JsonResponse, AzureLongRunningOperationFailed> => {
+  const monitor = monitorOf(terminal.body);
+  return ProvisioningState.$match(classify(monitor.status), {
+    Failed: ({ status }) =>
+      Effect.fail(
+        new AzureLongRunningOperationFailed({
+          status,
+          code: monitor.error?.code,
+          message: monitor.error?.message,
+          target: monitor.error?.target,
+          body: terminal.body,
+        }),
+      ),
+    Succeeded: () => Effect.succeed(terminal),
+    InProgress: () => Effect.succeed(terminal),
+  });
+};
+
+/**
+ * Drive an ARM async operation to completion and return the final resource body.
+ *
+ * Two monitor styles are supported:
+ *   - **async-operation** (`Azure-AsyncOperation` / `Operation-Location`): poll
+ *     the monitor's JSON `status` until terminal; a `Failed`/`Canceled` status
+ *     surfaces as `AzureLongRunningOperationFailed`.
+ *   - **location** (`Location`): poll the URL until it stops returning `202`.
+ *
+ * The provisioned resource is then resolved per `finalStateVia`: `location`
+ * yields the terminal monitor body directly, otherwise the resource is fetched
+ * from the original request URI (carrying the original query so `api-version`
+ * is preserved).
+ */
+export const pollLongRunning = (args: {
+  response: HttpClientResponse.HttpClientResponse;
+  request: HttpClientRequest.HttpClientRequest;
+  client: HttpClient.HttpClient;
+  method: string;
+  authHeaders: Record<string, string>;
+  finalStateVia?: string;
+}): Effect.Effect<unknown, unknown> => {
+  const { response, request, client, authHeaders, finalStateVia } = args;
+
+  const http = makeArmClient(client, authHeaders);
+
+  const pollUntil = (url: string, until: (response: JsonResponse) => boolean) =>
+    http.get(url).pipe(Effect.repeat({ schedule: pollSchedule, until }));
+
+  const resolveFinal = (
+    terminal: JsonResponse,
+  ): Effect.Effect<unknown, unknown> =>
+    Match.value(finalStateVia).pipe(
+      // `final-state-via: location` → the terminal response carries the resource.
+      Match.when("location", () => Effect.succeed(terminal.body)),
+      // Otherwise the provisioned resource lives at the original request URI.
+      Match.orElse(() =>
+        http
+          .get(request.url, request.urlParams)
+          .pipe(Effect.map((final) => final.body)),
+      ),
+    );
+
+  return Strategy.$match(strategyOf(response.headers), {
+    AsyncOperation: ({ url }) =>
+      pollUntil(
+        url,
+        (fetched) =>
+          !ProvisioningState.$is("InProgress")(
+            classify(monitorOf(fetched.body).status),
+          ),
+      ),
+    Location: ({ url }) => pollUntil(url, (fetched) => fetched.status !== 202),
+    Direct: () => http.get(request.url, request.urlParams),
+  }).pipe(Effect.flatMap(ensureSucceeded), Effect.flatMap(resolveFinal));
+};

--- a/packages/azure/src/lro.ts
+++ b/packages/azure/src/lro.ts
@@ -176,10 +176,11 @@ const ensureSucceeded = (
  *     surfaces as `AzureLongRunningOperationFailed`.
  *   - **location** (`Location`): poll the URL until it stops returning `202`.
  *
- * The provisioned resource is then resolved per `finalStateVia`: `location`
- * yields the terminal monitor body directly, otherwise the resource is fetched
- * from the original request URI (carrying the original query so `api-version`
- * is preserved).
+ * The provisioned resource is then resolved per ARM's rules (mirroring
+ * `@azure/core-lro`'s `findResourceLocation`): a `PUT`/`PATCH` resource — and
+ * any `original-uri` operation — lives at the original request URI and is
+ * fetched there (the `Location` body for a create is only a stub); otherwise
+ * the terminal poll body is the result.
  */
 export const pollLongRunning = (args: {
   response: HttpClientResponse.HttpClientResponse;
@@ -189,25 +190,29 @@ export const pollLongRunning = (args: {
   authHeaders: Record<string, string>;
   finalStateVia?: string;
 }): Effect.Effect<unknown, unknown> => {
-  const { response, request, client, authHeaders, finalStateVia } = args;
+  const { response, request, client, method, authHeaders, finalStateVia } =
+    args;
 
   const http = makeArmClient(client, authHeaders);
 
   const pollUntil = (url: string, until: (response: JsonResponse) => boolean) =>
     http.get(url).pipe(Effect.repeat({ schedule: pollSchedule, until }));
 
+  // GET the original request URI for the full resource (carry the original
+  // query so `api-version` is preserved).
+  const fetchResource = () =>
+    http.get(request.url, request.urlParams).pipe(Effect.map((r) => r.body));
+
   const resolveFinal = (
     terminal: JsonResponse,
   ): Effect.Effect<unknown, unknown> =>
-    Match.value(finalStateVia).pipe(
-      // `final-state-via: location` → the terminal response carries the resource.
-      Match.when("location", () => Effect.succeed(terminal.body)),
-      // Otherwise the provisioned resource lives at the original request URI.
-      Match.orElse(() =>
-        http
-          .get(request.url, request.urlParams)
-          .pipe(Effect.map((final) => final.body)),
-      ),
+    Match.value({ method, finalStateVia }).pipe(
+      // PUT/PATCH create/modify a resource that lives at the request URI.
+      Match.when({ method: "PUT" }, fetchResource),
+      Match.when({ method: "PATCH" }, fetchResource),
+      Match.when({ finalStateVia: "original-uri" }, fetchResource),
+      // POST/DELETE (location / async-operation): the terminal poll body is it.
+      Match.orElse(() => Effect.succeed(terminal.body)),
     );
 
   return Strategy.$match(strategyOf(response.headers), {

--- a/packages/azure/src/services/analysisservices.ts
+++ b/packages/azure/src/services/analysisservices.ts
@@ -179,6 +179,7 @@ export const ServersCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AnalysisServices/servers/{serverName}",
     apiVersion: "2017-08-01",
+    longRunning: {},
   }),
 );
 export type ServersCreateInput = typeof ServersCreateInput.Type;
@@ -218,6 +219,7 @@ export const ServersDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AnalysisServices/servers/{serverName}",
     apiVersion: "2017-08-01",
+    longRunning: {},
   }),
 );
 export type ServersDeleteInput = typeof ServersDeleteInput.Type;
@@ -618,6 +620,7 @@ export const ServersResumeInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AnalysisServices/servers/{serverName}/resume",
     apiVersion: "2017-08-01",
+    longRunning: {},
   }),
 );
 export type ServersResumeInput = typeof ServersResumeInput.Type;
@@ -644,6 +647,7 @@ export const ServersSuspendInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AnalysisServices/servers/{serverName}/suspend",
     apiVersion: "2017-08-01",
+    longRunning: {},
   }),
 );
 export type ServersSuspendInput = typeof ServersSuspendInput.Type;
@@ -716,6 +720,7 @@ export const ServersUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AnalysisServices/servers/{serverName}",
     apiVersion: "2017-08-01",
+    longRunning: {},
   }),
 );
 export type ServersUpdateInput = typeof ServersUpdateInput.Type;

--- a/packages/azure/src/services/apicenter.ts
+++ b/packages/azure/src/services/apicenter.ts
@@ -140,6 +140,7 @@ export const ApiDefinitionsExportSpecificationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiCenter/services/{serviceName}/workspaces/{workspaceName}/apis/{apiName}/versions/{versionName}/definitions/{definitionName}/exportSpecification",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ApiDefinitionsExportSpecificationInput =
@@ -255,6 +256,7 @@ export const ApiDefinitionsImportSpecificationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiCenter/services/{serviceName}/workspaces/{workspaceName}/apis/{apiName}/versions/{versionName}/definitions/{definitionName}/importSpecification",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ApiDefinitionsImportSpecificationInput =
@@ -1725,6 +1727,7 @@ export const ServicesExportMetadataSchemaInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiCenter/services/{serviceName}/exportMetadataSchema",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServicesExportMetadataSchemaInput =

--- a/packages/azure/src/services/apimanagement.ts
+++ b/packages/azure/src/services/apimanagement.ts
@@ -153,6 +153,7 @@ export const ApiCreateOrUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/apis/{apiId}",
     apiVersion: "2024-05-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ApiCreateOrUpdateInput = typeof ApiCreateOrUpdateInput.Type;
@@ -194,6 +195,7 @@ export const ApiDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/apis/{apiId}",
     apiVersion: "2024-05-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ApiDeleteInput = typeof ApiDeleteInput.Type;
@@ -793,6 +795,7 @@ export const ApiGatewayConfigConnectionCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/gateways/{gatewayName}/configConnections/{configConnectionName}",
       apiVersion: "2024-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ApiGatewayConfigConnectionCreateOrUpdateInput =
@@ -835,6 +838,7 @@ export const ApiGatewayConfigConnectionDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/gateways/{gatewayName}/configConnections/{configConnectionName}",
       apiVersion: "2024-05-01",
+      longRunning: {},
     }),
   );
 export type ApiGatewayConfigConnectionDeleteInput =
@@ -1015,6 +1019,7 @@ export const ApiGatewayCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/gateways/{gatewayName}",
       apiVersion: "2024-05-01",
+      longRunning: {},
     }),
   );
 export type ApiGatewayCreateOrUpdateInput =
@@ -1056,6 +1061,7 @@ export const ApiGatewayDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/gateways/{gatewayName}",
     apiVersion: "2024-05-01",
+    longRunning: {},
   }),
 );
 export type ApiGatewayDeleteInput = typeof ApiGatewayDeleteInput.Type;
@@ -1250,6 +1256,7 @@ export const ApiGatewayUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/gateways/{gatewayName}",
     apiVersion: "2024-05-01",
+    longRunning: {},
   }),
 );
 export type ApiGatewayUpdateInput = typeof ApiGatewayUpdateInput.Type;
@@ -2305,6 +2312,7 @@ export const ApiManagementServiceApplyNetworkConfigurationUpdatesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/applynetworkconfigurationupdates",
       apiVersion: "2024-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ApiManagementServiceApplyNetworkConfigurationUpdatesInput =
@@ -2358,6 +2366,7 @@ export const ApiManagementServiceBackupInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/backup",
       apiVersion: "2024-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ApiManagementServiceBackupInput =
@@ -2676,6 +2685,7 @@ export const ApiManagementServiceCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}",
       apiVersion: "2024-05-01",
+      longRunning: {},
     }),
   );
 export type ApiManagementServiceCreateOrUpdateInput =
@@ -2717,6 +2727,7 @@ export const ApiManagementServiceDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}",
       apiVersion: "2024-05-01",
+      longRunning: {},
     }),
   );
 export type ApiManagementServiceDeleteInput =
@@ -2956,6 +2967,7 @@ export const ApiManagementServiceMigrateToStv2Input =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/migrateToStv2",
       apiVersion: "2024-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ApiManagementServiceMigrateToStv2Input =
@@ -3009,6 +3021,7 @@ export const ApiManagementServiceRestoreInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/restore",
       apiVersion: "2024-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ApiManagementServiceRestoreInput =
@@ -3350,6 +3363,7 @@ export const ApiManagementServiceUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}",
       apiVersion: "2024-05-01",
+      longRunning: {},
     }),
   );
 export type ApiManagementServiceUpdateInput =
@@ -4981,6 +4995,7 @@ export const ApiSchemaCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/apis/{apiId}/schemas/{schemaId}",
       apiVersion: "2024-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ApiSchemaCreateOrUpdateInput =
@@ -8298,6 +8313,7 @@ export const DeletedServicesPurgeInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.ApiManagement/locations/{location}/deletedservices/{serviceName}",
       apiVersion: "2024-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeletedServicesPurgeInput = typeof DeletedServicesPurgeInput.Type;
@@ -10426,6 +10442,7 @@ export const GlobalSchemaCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/schemas/{schemaId}",
       apiVersion: "2024-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type GlobalSchemaCreateOrUpdateInput =
@@ -12056,6 +12073,7 @@ export const NamedValueCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/namedValues/{namedValueId}",
       apiVersion: "2024-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NamedValueCreateOrUpdateInput =
@@ -12266,6 +12284,7 @@ export const NamedValueRefreshSecretInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/namedValues/{namedValueId}/refreshSecret",
       apiVersion: "2024-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NamedValueRefreshSecretInput =
@@ -12314,6 +12333,7 @@ export const NamedValueUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/namedValues/{namedValueId}",
     apiVersion: "2024-05-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type NamedValueUpdateInput = typeof NamedValueUpdateInput.Type;
@@ -13589,6 +13609,7 @@ export const PerformConnectivityCheckAsyncInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/connectivityCheck",
       apiVersion: "2024-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PerformConnectivityCheckAsyncInput =
@@ -13823,6 +13844,7 @@ export const PolicyFragmentCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/policyFragments/{id}",
       apiVersion: "2024-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PolicyFragmentCreateOrUpdateInput =
@@ -14370,6 +14392,7 @@ export const PolicyRestrictionValidationsByServiceInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/validatePolicies",
       apiVersion: "2024-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PolicyRestrictionValidationsByServiceInput =
@@ -14679,6 +14702,7 @@ export const PortalRevisionCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/portalRevisions/{portalRevisionId}",
       apiVersion: "2024-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PortalRevisionCreateOrUpdateInput =
@@ -14835,6 +14859,7 @@ export const PortalRevisionUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/portalRevisions/{portalRevisionId}",
       apiVersion: "2024-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PortalRevisionUpdateInput = typeof PortalRevisionUpdateInput.Type;
@@ -14892,6 +14917,7 @@ export const PrivateEndpointConnectionCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2024-05-01",
+      longRunning: {},
     }),
   );
 export type PrivateEndpointConnectionCreateOrUpdateInput =
@@ -14936,6 +14962,7 @@ export const PrivateEndpointConnectionDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2024-05-01",
+      longRunning: {},
     }),
   );
 export type PrivateEndpointConnectionDeleteInput =
@@ -19787,6 +19814,7 @@ export const TenantConfigurationDeployInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/tenant/{configurationName}/deploy",
       apiVersion: "2024-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type TenantConfigurationDeployInput =
@@ -19879,6 +19907,7 @@ export const TenantConfigurationSaveInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/tenant/{configurationName}/save",
       apiVersion: "2024-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type TenantConfigurationSaveInput =
@@ -19929,6 +19958,7 @@ export const TenantConfigurationValidateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/tenant/{configurationName}/validate",
       apiVersion: "2024-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type TenantConfigurationValidateInput =
@@ -20074,6 +20104,7 @@ export const UserDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/users/{userId}",
     apiVersion: "2024-05-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type UserDeleteInput = typeof UserDeleteInput.Type;
@@ -20620,6 +20651,7 @@ export const WorkspaceApiCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/workspaces/{workspaceId}/apis/{apiId}",
       apiVersion: "2024-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkspaceApiCreateOrUpdateInput =
@@ -22791,6 +22823,7 @@ export const WorkspaceApiSchemaCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/workspaces/{workspaceId}/apis/{apiId}/schemas/{schemaId}",
       apiVersion: "2024-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkspaceApiSchemaCreateOrUpdateInput =
@@ -24755,6 +24788,7 @@ export const WorkspaceGlobalSchemaCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/workspaces/{workspaceId}/schemas/{schemaId}",
       apiVersion: "2024-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkspaceGlobalSchemaCreateOrUpdateInput =
@@ -25665,6 +25699,7 @@ export const WorkspaceNamedValueCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/workspaces/{workspaceId}/namedValues/{namedValueId}",
       apiVersion: "2024-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkspaceNamedValueCreateOrUpdateInput =
@@ -25900,6 +25935,7 @@ export const WorkspaceNamedValueRefreshSecretInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/workspaces/{workspaceId}/namedValues/{namedValueId}/refreshSecret",
       apiVersion: "2024-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkspaceNamedValueRefreshSecretInput =
@@ -25950,6 +25986,7 @@ export const WorkspaceNamedValueUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/workspaces/{workspaceId}/namedValues/{namedValueId}",
       apiVersion: "2024-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkspaceNamedValueUpdateInput =
@@ -26588,6 +26625,7 @@ export const WorkspacePolicyFragmentCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/workspaces/{workspaceId}/policyFragments/{id}",
       apiVersion: "2024-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkspacePolicyFragmentCreateOrUpdateInput =

--- a/packages/azure/src/services/app.ts
+++ b/packages/azure/src/services/app.ts
@@ -43,6 +43,7 @@ export const AgentsConnectorsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/agents/{agentName}/connectors/{connectorName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AgentsConnectorsCreateOrUpdateInput =
@@ -99,6 +100,7 @@ export const AgentsConnectorsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/agents/{agentName}/connectors/{connectorName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AgentsConnectorsDeleteInput =
@@ -474,6 +476,7 @@ export const AgentsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/agents/{agentName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AgentsCreateOrUpdateInput = typeof AgentsCreateOrUpdateInput.Type;
@@ -526,6 +529,7 @@ export const AgentsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/agents/{agentName}",
     apiVersion: "2026-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type AgentsDeleteInput = typeof AgentsDeleteInput.Type;
@@ -763,6 +767,7 @@ export const AgentSpacesConnectorsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/agentSpaces/{agentSpaceName}/connectors/{connectorName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AgentSpacesConnectorsCreateOrUpdateInput =
@@ -819,6 +824,7 @@ export const AgentSpacesConnectorsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/agentSpaces/{agentSpaceName}/connectors/{connectorName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AgentSpacesConnectorsDeleteInput =
@@ -1192,6 +1198,7 @@ export const AgentSpacesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/agentSpaces/{agentSpaceName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AgentSpacesCreateOrUpdateInput =
@@ -1248,6 +1255,7 @@ export const AgentSpacesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/agentSpaces/{agentSpaceName}",
     apiVersion: "2026-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type AgentSpacesDeleteInput = typeof AgentSpacesDeleteInput.Type;
@@ -1523,6 +1531,7 @@ export const AgentSpacesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/agentSpaces/{agentSpaceName}",
     apiVersion: "2026-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type AgentSpacesUpdateInput = typeof AgentSpacesUpdateInput.Type;
@@ -1573,6 +1582,7 @@ export const AgentsStartInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/agents/{agentName}/start",
     apiVersion: "2026-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type AgentsStartInput = typeof AgentsStartInput.Type;
@@ -1622,6 +1632,7 @@ export const AgentsStopInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/agents/{agentName}/stop",
     apiVersion: "2026-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type AgentsStopInput = typeof AgentsStopInput.Type;
@@ -1744,6 +1755,7 @@ export const AgentsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/agents/{agentName}",
     apiVersion: "2026-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type AgentsUpdateInput = typeof AgentsUpdateInput.Type;
@@ -2261,6 +2273,7 @@ export const ConnectedEnvironmentsCertificatesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/connectedEnvironments/{connectedEnvironmentName}/certificates/{certificateName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ConnectedEnvironmentsCertificatesCreateOrUpdateInput =
@@ -2318,6 +2331,7 @@ export const ConnectedEnvironmentsCertificatesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/connectedEnvironments/{connectedEnvironmentName}/certificates/{certificateName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ConnectedEnvironmentsCertificatesDeleteInput =
@@ -2482,6 +2496,7 @@ export const ConnectedEnvironmentsCertificatesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/connectedEnvironments/{connectedEnvironmentName}/certificates/{certificateName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ConnectedEnvironmentsCertificatesUpdateInput =
@@ -2631,6 +2646,7 @@ export const ConnectedEnvironmentsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/connectedEnvironments/{connectedEnvironmentName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ConnectedEnvironmentsCreateOrUpdateInput =
@@ -2725,6 +2741,7 @@ export const ConnectedEnvironmentsDaprComponentsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/connectedEnvironments/{connectedEnvironmentName}/daprComponents/{componentName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ConnectedEnvironmentsDaprComponentsCreateOrUpdateInput =
@@ -2784,6 +2801,7 @@ export const ConnectedEnvironmentsDaprComponentsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/connectedEnvironments/{connectedEnvironmentName}/daprComponents/{componentName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ConnectedEnvironmentsDaprComponentsDeleteInput =
@@ -2993,6 +3011,7 @@ export const ConnectedEnvironmentsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/connectedEnvironments/{connectedEnvironmentName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ConnectedEnvironmentsDeleteInput =
@@ -3252,6 +3271,7 @@ export const ConnectedEnvironmentsStoragesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/connectedEnvironments/{connectedEnvironmentName}/storages/{storageName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ConnectedEnvironmentsStoragesCreateOrUpdateInput =
@@ -3308,6 +3328,7 @@ export const ConnectedEnvironmentsStoragesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/connectedEnvironments/{connectedEnvironmentName}/storages/{storageName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ConnectedEnvironmentsStoragesDeleteInput =
@@ -4449,6 +4470,7 @@ export const ContainerAppsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ContainerAppsCreateOrUpdateInput =
@@ -4504,6 +4526,7 @@ export const ContainerAppsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ContainerAppsDeleteInput = typeof ContainerAppsDeleteInput.Type;
@@ -5694,6 +5717,7 @@ export const ContainerAppsSessionPoolsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/sessionPools/{sessionPoolName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ContainerAppsSessionPoolsCreateOrUpdateInput =
@@ -5748,6 +5772,7 @@ export const ContainerAppsSessionPoolsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/sessionPools/{sessionPoolName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ContainerAppsSessionPoolsDeleteInput =
@@ -6072,6 +6097,7 @@ export const ContainerAppsSessionPoolsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/sessionPools/{sessionPoolName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ContainerAppsSessionPoolsUpdateInput =
@@ -6164,6 +6190,7 @@ export const ContainerAppsSourceControlsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/sourcecontrols/{sourceControlName}",
       apiVersion: "2026-01-01",
+      longRunning: {},
     }),
   );
 export type ContainerAppsSourceControlsCreateOrUpdateInput =
@@ -6220,6 +6247,7 @@ export const ContainerAppsSourceControlsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/sourcecontrols/{sourceControlName}",
       apiVersion: "2026-01-01",
+      longRunning: {},
     }),
   );
 export type ContainerAppsSourceControlsDeleteInput =
@@ -6382,6 +6410,7 @@ export const ContainerAppsStartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/start",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ContainerAppsStartInput = typeof ContainerAppsStartInput.Type;
@@ -6434,6 +6463,7 @@ export const ContainerAppsStopInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/stop",
     apiVersion: "2026-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ContainerAppsStopInput = typeof ContainerAppsStopInput.Type;
@@ -6898,6 +6928,7 @@ export const ContainerAppsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}",
       apiVersion: "2026-01-01",
+      longRunning: {},
     }),
   );
 export type ContainerAppsUpdateInput = typeof ContainerAppsUpdateInput.Type;
@@ -7410,6 +7441,7 @@ export const HttpRouteConfigDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/httpRouteConfigs/{httpRouteName}",
       apiVersion: "2026-01-01",
+      longRunning: {},
     }),
   );
 export type HttpRouteConfigDeleteInput = typeof HttpRouteConfigDeleteInput.Type;
@@ -7732,6 +7764,7 @@ export const JavaComponentsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/javaComponents/{name}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type JavaComponentsCreateOrUpdateInput =
@@ -7790,6 +7823,7 @@ export const JavaComponentsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/javaComponents/{name}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type JavaComponentsDeleteInput = typeof JavaComponentsDeleteInput.Type;
@@ -7989,6 +8023,7 @@ export const JavaComponentsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/javaComponents/{name}",
       apiVersion: "2026-01-01",
+      longRunning: {},
     }),
   );
 export type JavaComponentsUpdateInput = typeof JavaComponentsUpdateInput.Type;
@@ -8374,6 +8409,7 @@ export const JobsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/jobs/{jobName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type JobsCreateOrUpdateInput = typeof JobsCreateOrUpdateInput.Type;
@@ -8422,6 +8458,7 @@ export const JobsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/jobs/{jobName}",
     apiVersion: "2026-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type JobsDeleteInput = typeof JobsDeleteInput.Type;
@@ -9010,6 +9047,7 @@ export const JobsStartInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/jobs/{jobName}/start",
     apiVersion: "2026-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type JobsStartInput = typeof JobsStartInput.Type;
@@ -9044,6 +9082,7 @@ export const JobsStopExecutionInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/jobs/{jobName}/executions/{jobExecutionName}/stop",
     apiVersion: "2026-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type JobsStopExecutionInput = typeof JobsStopExecutionInput.Type;
@@ -9074,6 +9113,7 @@ export const JobsStopMultipleExecutionsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/jobs/{jobName}/stop",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type JobsStopMultipleExecutionsInput =
@@ -9401,6 +9441,7 @@ export const JobsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/jobs/{jobName}",
     apiVersion: "2026-01-01",
+    longRunning: {},
   }),
 );
 export type JobsUpdateInput = typeof JobsUpdateInput.Type;
@@ -10017,6 +10058,7 @@ export const ManagedCertificatesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/managedCertificates/{managedCertificateName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ManagedCertificatesCreateOrUpdateInput =
@@ -10480,6 +10522,7 @@ export const ManagedEnvironmentPrivateEndpointConnectionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2026-01-01",
+      longRunning: {},
     }),
   );
 export type ManagedEnvironmentPrivateEndpointConnectionsCreateOrUpdateInput =
@@ -10539,6 +10582,7 @@ export const ManagedEnvironmentPrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2026-01-01",
+      longRunning: {},
     }),
   );
 export type ManagedEnvironmentPrivateEndpointConnectionsDeleteInput =
@@ -10945,6 +10989,7 @@ export const ManagedEnvironmentsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}",
       apiVersion: "2026-01-01",
+      longRunning: {},
     }),
   );
 export type ManagedEnvironmentsCreateOrUpdateInput =
@@ -11001,6 +11046,7 @@ export const ManagedEnvironmentsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}",
       apiVersion: "2026-01-01",
+      longRunning: {},
     }),
   );
 export type ManagedEnvironmentsDeleteInput =
@@ -11834,6 +11880,7 @@ export const ManagedEnvironmentsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}",
       apiVersion: "2026-01-01",
+      longRunning: {},
     }),
   );
 export type ManagedEnvironmentsUpdateInput =

--- a/packages/azure/src/services/appcomplianceautomation.ts
+++ b/packages/azure/src/services/appcomplianceautomation.ts
@@ -471,6 +471,7 @@ export const ProviderActionsOnboardInput =
       method: "POST",
       path: "/providers/Microsoft.AppComplianceAutomation/onboard",
       apiVersion: "2024-06-27",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ProviderActionsOnboardInput =
@@ -505,6 +506,7 @@ export const ProviderActionsTriggerEvaluationInput =
       method: "POST",
       path: "/providers/Microsoft.AppComplianceAutomation/triggerEvaluation",
       apiVersion: "2024-06-27",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ProviderActionsTriggerEvaluationInput =
@@ -633,6 +635,7 @@ export const ReportCreateOrUpdateInput =
       method: "PUT",
       path: "/providers/Microsoft.AppComplianceAutomation/reports/{reportName}",
       apiVersion: "2024-06-27",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ReportCreateOrUpdateInput = typeof ReportCreateOrUpdateInput.Type;
@@ -681,6 +684,7 @@ export const ReportDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/providers/Microsoft.AppComplianceAutomation/reports/{reportName}",
     apiVersion: "2024-06-27",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ReportDeleteInput = typeof ReportDeleteInput.Type;
@@ -708,6 +712,7 @@ export const ReportFixInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/providers/Microsoft.AppComplianceAutomation/reports/{reportName}/fix",
     apiVersion: "2024-06-27",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ReportFixInput = typeof ReportFixInput.Type;
@@ -968,6 +973,7 @@ export const ReportSyncCertRecordInput =
       method: "POST",
       path: "/providers/Microsoft.AppComplianceAutomation/reports/{reportName}/syncCertRecord",
       apiVersion: "2024-06-27",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReportSyncCertRecordInput = typeof ReportSyncCertRecordInput.Type;
@@ -1092,6 +1098,7 @@ export const ReportUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/providers/Microsoft.AppComplianceAutomation/reports/{reportName}",
     apiVersion: "2024-06-27",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ReportUpdateInput = typeof ReportUpdateInput.Type;
@@ -1137,6 +1144,7 @@ export const ReportVerifyInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/providers/Microsoft.AppComplianceAutomation/reports/{reportName}/verify",
     apiVersion: "2024-06-27",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ReportVerifyInput = typeof ReportVerifyInput.Type;
@@ -1404,6 +1412,7 @@ export const SnapshotDownloadInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/providers/Microsoft.AppComplianceAutomation/reports/{reportName}/snapshots/{snapshotName}/download",
     apiVersion: "2024-06-27",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type SnapshotDownloadInput = typeof SnapshotDownloadInput.Type;

--- a/packages/azure/src/services/appconfiguration.ts
+++ b/packages/azure/src/services/appconfiguration.ts
@@ -147,6 +147,7 @@ export const ConfigurationStoresCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppConfiguration/configurationStores/{configStoreName}",
       apiVersion: "2024-06-01",
+      longRunning: {},
     }),
   );
 export type ConfigurationStoresCreateInput =
@@ -179,6 +180,7 @@ export const ConfigurationStoresDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppConfiguration/configurationStores/{configStoreName}",
       apiVersion: "2024-06-01",
+      longRunning: {},
     }),
   );
 export type ConfigurationStoresDeleteInput =
@@ -461,6 +463,7 @@ export const ConfigurationStoresPurgeDeletedInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.AppConfiguration/locations/{location}/deletedConfigurationStores/{configStoreName}/purge",
       apiVersion: "2024-06-01",
+      longRunning: {},
     }),
   );
 export type ConfigurationStoresPurgeDeletedInput =
@@ -586,6 +589,7 @@ export const ConfigurationStoresUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppConfiguration/configurationStores/{configStoreName}",
       apiVersion: "2024-06-01",
+      longRunning: {},
     }),
   );
 export type ConfigurationStoresUpdateInput =
@@ -682,6 +686,7 @@ export const KeyValuesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppConfiguration/configurationStores/{configStoreName}/keyValues/{keyValueName}",
     apiVersion: "2024-06-01",
+    longRunning: {},
   }),
 );
 export type KeyValuesDeleteInput = typeof KeyValuesDeleteInput.Type;
@@ -939,6 +944,7 @@ export const PrivateEndpointConnectionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppConfiguration/configurationStores/{configStoreName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2024-06-01",
+      longRunning: {},
     }),
   );
 export type PrivateEndpointConnectionsCreateOrUpdateInput =
@@ -1007,6 +1013,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppConfiguration/configurationStores/{configStoreName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2024-06-01",
+      longRunning: {},
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =
@@ -1296,6 +1303,7 @@ export const ReplicasCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppConfiguration/configurationStores/{configStoreName}/replicas/{replicaName}",
     apiVersion: "2024-06-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type ReplicasCreateInput = typeof ReplicasCreateInput.Type;
@@ -1355,6 +1363,7 @@ export const ReplicasDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppConfiguration/configurationStores/{configStoreName}/replicas/{replicaName}",
     apiVersion: "2024-06-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type ReplicasDeleteInput = typeof ReplicasDeleteInput.Type;
@@ -1556,6 +1565,7 @@ export const SnapshotsCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppConfiguration/configurationStores/{configStoreName}/snapshots/{snapshotName}",
     apiVersion: "2024-06-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type SnapshotsCreateInput = typeof SnapshotsCreateInput.Type;

--- a/packages/azure/src/services/appplatform.ts
+++ b/packages/azure/src/services/appplatform.ts
@@ -22,6 +22,7 @@ export const ApiPortalCustomDomainsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/apiPortals/{apiPortalName}/domains/{domainName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type ApiPortalCustomDomainsCreateOrUpdateInput =
@@ -67,6 +68,7 @@ export const ApiPortalCustomDomainsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/apiPortals/{apiPortalName}/domains/{domainName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type ApiPortalCustomDomainsDeleteInput =
@@ -254,6 +256,7 @@ export const ApiPortalsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/apiPortals/{apiPortalName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type ApiPortalsCreateOrUpdateInput =
@@ -301,6 +304,7 @@ export const ApiPortalsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/apiPortals/{apiPortalName}",
     apiVersion: "2023-12-01",
+    longRunning: {},
   }),
 );
 export type ApiPortalsDeleteInput = typeof ApiPortalsDeleteInput.Type;
@@ -478,6 +482,7 @@ export const ApmsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/apms/{apmName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type ApmsCreateOrUpdateInput = typeof ApmsCreateOrUpdateInput.Type;
@@ -521,6 +526,7 @@ export const ApmsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/apms/{apmName}",
     apiVersion: "2023-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ApmsDeleteInput = typeof ApmsDeleteInput.Type;
@@ -711,6 +717,7 @@ export const ApplicationAcceleratorsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/applicationAccelerators/{applicationAcceleratorName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type ApplicationAcceleratorsCreateOrUpdateInput =
@@ -756,6 +763,7 @@ export const ApplicationAcceleratorsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/applicationAccelerators/{applicationAcceleratorName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type ApplicationAcceleratorsDeleteInput =
@@ -929,6 +937,7 @@ export const ApplicationLiveViewsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/applicationLiveViews/{applicationLiveViewName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type ApplicationLiveViewsCreateOrUpdateInput =
@@ -974,6 +983,7 @@ export const ApplicationLiveViewsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/applicationLiveViews/{applicationLiveViewName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type ApplicationLiveViewsDeleteInput =
@@ -1218,6 +1228,7 @@ export const AppsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/apps/{appName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type AppsCreateOrUpdateInput = typeof AppsCreateOrUpdateInput.Type;
@@ -1261,6 +1272,7 @@ export const AppsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/apps/{appName}",
     apiVersion: "2023-12-01",
+    longRunning: {},
   }),
 );
 export type AppsDeleteInput = typeof AppsDeleteInput.Type;
@@ -1418,6 +1430,7 @@ export const AppsSetActiveDeploymentsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/apps/{appName}/setActiveDeployments",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type AppsSetActiveDeploymentsInput =
@@ -1568,6 +1581,7 @@ export const AppsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/apps/{appName}",
     apiVersion: "2023-12-01",
+    longRunning: {},
   }),
 );
 export type AppsUpdateInput = typeof AppsUpdateInput.Type;
@@ -1653,6 +1667,7 @@ export const BindingsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/apps/{appName}/bindings/{bindingName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type BindingsCreateOrUpdateInput =
@@ -1700,6 +1715,7 @@ export const BindingsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/apps/{appName}/bindings/{bindingName}",
     apiVersion: "2023-12-01",
+    longRunning: {},
   }),
 );
 export type BindingsDeleteInput = typeof BindingsDeleteInput.Type;
@@ -1838,6 +1854,7 @@ export const BindingsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/apps/{appName}/bindings/{bindingName}",
     apiVersion: "2023-12-01",
+    longRunning: {},
   }),
 );
 export type BindingsUpdateInput = typeof BindingsUpdateInput.Type;
@@ -1913,6 +1930,7 @@ export const BuildpackBindingCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/buildServices/{buildServiceName}/builders/{builderName}/buildpackBindings/{buildpackBindingName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type BuildpackBindingCreateOrUpdateInput =
@@ -1958,6 +1976,7 @@ export const BuildpackBindingDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/buildServices/{buildServiceName}/builders/{builderName}/buildpackBindings/{buildpackBindingName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type BuildpackBindingDeleteInput =
@@ -2273,6 +2292,7 @@ export const BuildServiceAgentPoolUpdatePutInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/buildServices/{buildServiceName}/agentPools/{agentPoolName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type BuildServiceAgentPoolUpdatePutInput =
@@ -2352,6 +2372,7 @@ export const BuildServiceBuilderCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/buildServices/{buildServiceName}/builders/{builderName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type BuildServiceBuilderCreateOrUpdateInput =
@@ -2397,6 +2418,7 @@ export const BuildServiceBuilderDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/buildServices/{buildServiceName}/builders/{builderName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type BuildServiceBuilderDeleteInput =
@@ -2585,6 +2607,7 @@ export const BuildServiceCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/buildServices/{buildServiceName}",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BuildServiceCreateOrUpdateInput =
@@ -2733,6 +2756,7 @@ export const BuildServiceDeleteBuildInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/buildServices/{buildServiceName}/builds/{buildName}",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BuildServiceDeleteBuildInput =
@@ -3379,6 +3403,7 @@ export const CertificatesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/certificates/{certificateName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type CertificatesCreateOrUpdateInput =
@@ -3425,6 +3450,7 @@ export const CertificatesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/certificates/{certificateName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type CertificatesDeleteInput = typeof CertificatesDeleteInput.Type;
@@ -3649,6 +3675,7 @@ export const ConfigServersUpdatePatchInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/configServers/default",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type ConfigServersUpdatePatchInput =
@@ -3749,6 +3776,7 @@ export const ConfigServersUpdatePutInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/configServers/default",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type ConfigServersUpdatePutInput =
@@ -3826,6 +3854,7 @@ export const ConfigServersValidateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/configServers/validate",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ConfigServersValidateInput = typeof ConfigServersValidateInput.Type;
@@ -3923,6 +3952,7 @@ export const ConfigurationServicesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/configurationServices/{configurationServiceName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type ConfigurationServicesCreateOrUpdateInput =
@@ -3968,6 +3998,7 @@ export const ConfigurationServicesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/configurationServices/{configurationServiceName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type ConfigurationServicesDeleteInput =
@@ -4131,6 +4162,7 @@ export const ConfigurationServicesValidateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/configurationServices/{configurationServiceName}/validate",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ConfigurationServicesValidateInput =
@@ -4231,6 +4263,7 @@ export const ConfigurationServicesValidateResourceInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/configurationServices/{configurationServiceName}/validateResource",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ConfigurationServicesValidateResourceInput =
@@ -4290,6 +4323,7 @@ export const ContainerRegistriesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/containerRegistries/{containerRegistryName}",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ContainerRegistriesCreateOrUpdateInput =
@@ -4335,6 +4369,7 @@ export const ContainerRegistriesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/containerRegistries/{containerRegistryName}",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ContainerRegistriesDeleteInput =
@@ -4486,6 +4521,7 @@ export const ContainerRegistriesValidateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/containerRegistries/{containerRegistryName}/validate",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ContainerRegistriesValidateInput =
@@ -4534,6 +4570,7 @@ export const CustomDomainsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/apps/{appName}/domains/{domainName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type CustomDomainsCreateOrUpdateInput =
@@ -4580,6 +4617,7 @@ export const CustomDomainsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/apps/{appName}/domains/{domainName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type CustomDomainsDeleteInput = typeof CustomDomainsDeleteInput.Type;
@@ -4725,6 +4763,7 @@ export const CustomDomainsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/apps/{appName}/domains/{domainName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type CustomDomainsUpdateInput = typeof CustomDomainsUpdateInput.Type;
@@ -4808,6 +4847,7 @@ export const CustomizedAcceleratorsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/applicationAccelerators/{applicationAcceleratorName}/customizedAccelerators/{customizedAcceleratorName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type CustomizedAcceleratorsCreateOrUpdateInput =
@@ -4853,6 +4893,7 @@ export const CustomizedAcceleratorsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/applicationAccelerators/{applicationAcceleratorName}/customizedAccelerators/{customizedAcceleratorName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type CustomizedAcceleratorsDeleteInput =
@@ -5019,6 +5060,7 @@ export const CustomizedAcceleratorsValidateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/applicationAccelerators/{applicationAcceleratorName}/customizedAccelerators/{customizedAcceleratorName}/validate",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type CustomizedAcceleratorsValidateInput =
@@ -5170,6 +5212,7 @@ export const DeploymentsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/apps/{appName}/deployments/{deploymentName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type DeploymentsCreateOrUpdateInput =
@@ -5217,6 +5260,7 @@ export const DeploymentsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/apps/{appName}/deployments/{deploymentName}",
     apiVersion: "2023-12-01",
+    longRunning: {},
   }),
 );
 export type DeploymentsDeleteInput = typeof DeploymentsDeleteInput.Type;
@@ -5240,6 +5284,7 @@ export const DeploymentsDisableRemoteDebuggingInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/apps/{appName}/deployments/{deploymentName}/disableRemoteDebugging",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type DeploymentsDisableRemoteDebuggingInput =
@@ -5272,6 +5317,7 @@ export const DeploymentsEnableRemoteDebuggingInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/apps/{appName}/deployments/{deploymentName}/enableRemoteDebugging",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type DeploymentsEnableRemoteDebuggingInput =
@@ -5306,6 +5352,7 @@ export const DeploymentsGenerateHeapDumpInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/apps/{appName}/deployments/{deploymentName}/generateHeapDump",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type DeploymentsGenerateHeapDumpInput =
@@ -5338,6 +5385,7 @@ export const DeploymentsGenerateThreadDumpInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/apps/{appName}/deployments/{deploymentName}/generateThreadDump",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type DeploymentsGenerateThreadDumpInput =
@@ -5597,6 +5645,7 @@ export const DeploymentsRestartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/apps/{appName}/deployments/{deploymentName}/restart",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type DeploymentsRestartInput = typeof DeploymentsRestartInput.Type;
@@ -5621,6 +5670,7 @@ export const DeploymentsStartInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/apps/{appName}/deployments/{deploymentName}/start",
     apiVersion: "2023-12-01",
+    longRunning: {},
   }),
 );
 export type DeploymentsStartInput = typeof DeploymentsStartInput.Type;
@@ -5648,6 +5698,7 @@ export const DeploymentsStartJFRInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/apps/{appName}/deployments/{deploymentName}/startJFR",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type DeploymentsStartJFRInput = typeof DeploymentsStartJFRInput.Type;
@@ -5673,6 +5724,7 @@ export const DeploymentsStopInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/apps/{appName}/deployments/{deploymentName}/stop",
     apiVersion: "2023-12-01",
+    longRunning: {},
   }),
 );
 export type DeploymentsStopInput = typeof DeploymentsStopInput.Type;
@@ -5818,6 +5870,7 @@ export const DeploymentsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/apps/{appName}/deployments/{deploymentName}",
     apiVersion: "2023-12-01",
+    longRunning: {},
   }),
 );
 export type DeploymentsUpdateInput = typeof DeploymentsUpdateInput.Type;
@@ -5927,6 +5980,7 @@ export const DevToolPortalsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/DevToolPortals/{devToolPortalName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type DevToolPortalsCreateOrUpdateInput =
@@ -5972,6 +6026,7 @@ export const DevToolPortalsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/DevToolPortals/{devToolPortalName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type DevToolPortalsDeleteInput = typeof DevToolPortalsDeleteInput.Type;
@@ -6106,6 +6161,7 @@ export const GatewayCustomDomainsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/gateways/{gatewayName}/domains/{domainName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type GatewayCustomDomainsCreateOrUpdateInput =
@@ -6151,6 +6207,7 @@ export const GatewayCustomDomainsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/gateways/{gatewayName}/domains/{domainName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type GatewayCustomDomainsDeleteInput =
@@ -6327,6 +6384,7 @@ export const GatewayRouteConfigsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/gateways/{gatewayName}/routeConfigs/{routeConfigName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type GatewayRouteConfigsCreateOrUpdateInput =
@@ -6372,6 +6430,7 @@ export const GatewayRouteConfigsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/gateways/{gatewayName}/routeConfigs/{routeConfigName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type GatewayRouteConfigsDeleteInput =
@@ -6619,6 +6678,7 @@ export const GatewaysCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/gateways/{gatewayName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type GatewaysCreateOrUpdateInput =
@@ -6666,6 +6726,7 @@ export const GatewaysDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/gateways/{gatewayName}",
     apiVersion: "2023-12-01",
+    longRunning: {},
   }),
 );
 export type GatewaysDeleteInput = typeof GatewaysDeleteInput.Type;
@@ -6819,6 +6880,7 @@ export const GatewaysRestartInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/gateways/{gatewayName}/restart",
     apiVersion: "2023-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type GatewaysRestartInput = typeof GatewaysRestartInput.Type;
@@ -6942,6 +7004,7 @@ export const MonitoringSettingsUpdatePatchInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/monitoringSettings/default",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type MonitoringSettingsUpdatePatchInput =
@@ -7009,6 +7072,7 @@ export const MonitoringSettingsUpdatePutInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/monitoringSettings/default",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type MonitoringSettingsUpdatePutInput =
@@ -7147,6 +7211,7 @@ export const PredefinedAcceleratorsDisableInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/applicationAccelerators/{applicationAcceleratorName}/predefinedAccelerators/{predefinedAcceleratorName}/disable",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type PredefinedAcceleratorsDisableInput =
@@ -7174,6 +7239,7 @@ export const PredefinedAcceleratorsEnableInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/applicationAccelerators/{applicationAcceleratorName}/predefinedAccelerators/{predefinedAcceleratorName}/enable",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type PredefinedAcceleratorsEnableInput =
@@ -7349,6 +7415,7 @@ export const ServiceRegistriesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/serviceRegistries/{serviceRegistryName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type ServiceRegistriesCreateOrUpdateInput =
@@ -7394,6 +7461,7 @@ export const ServiceRegistriesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/serviceRegistries/{serviceRegistryName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type ServiceRegistriesDeleteInput =
@@ -7645,6 +7713,7 @@ export const ServicesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type ServicesCreateOrUpdateInput =
@@ -7692,6 +7761,7 @@ export const ServicesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}",
     apiVersion: "2023-12-01",
+    longRunning: {},
   }),
 );
 export type ServicesDeleteInput = typeof ServicesDeleteInput.Type;
@@ -7717,6 +7787,7 @@ export const ServicesDisableApmGloballyInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/disableApmGlobally",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ServicesDisableApmGloballyInput =
@@ -7775,6 +7846,7 @@ export const ServicesEnableApmGloballyInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/enableApmGlobally",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ServicesEnableApmGloballyInput =
@@ -7837,6 +7909,7 @@ export const ServicesFlushVnetDnsSettingInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/flushVirtualNetworkDnsSettings",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServicesFlushVnetDnsSettingInput =
@@ -8201,6 +8274,7 @@ export const ServicesStartInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/start",
     apiVersion: "2023-12-01",
+    longRunning: {},
   }),
 );
 export type ServicesStartInput = typeof ServicesStartInput.Type;
@@ -8225,6 +8299,7 @@ export const ServicesStopInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/stop",
     apiVersion: "2023-12-01",
+    longRunning: {},
   }),
 );
 export type ServicesStopInput = typeof ServicesStopInput.Type;
@@ -8327,6 +8402,7 @@ export const ServicesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}",
     apiVersion: "2023-12-01",
+    longRunning: {},
   }),
 );
 export type ServicesUpdateInput = typeof ServicesUpdateInput.Type;
@@ -8458,6 +8534,7 @@ export const StoragesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/storages/{storageName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type StoragesCreateOrUpdateInput =
@@ -8505,6 +8582,7 @@ export const StoragesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppPlatform/Spring/{serviceName}/storages/{storageName}",
     apiVersion: "2023-12-01",
+    longRunning: {},
   }),
 );
 export type StoragesDeleteInput = typeof StoragesDeleteInput.Type;

--- a/packages/azure/src/services/automation.ts
+++ b/packages/azure/src/services/automation.ts
@@ -2378,6 +2378,7 @@ export const DscNodeConfigurationCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Automation/automationAccounts/{automationAccountName}/nodeConfigurations/{nodeConfigurationName}",
       apiVersion: "2024-10-23",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DscNodeConfigurationCreateOrUpdateInput =
@@ -5394,6 +5395,7 @@ export const PrivateEndpointConnectionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Automation/automationAccounts/{automationAccountName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2024-10-23",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsCreateOrUpdateInput =
@@ -5450,6 +5452,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Automation/automationAccounts/{automationAccountName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2024-10-23",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =
@@ -6510,6 +6513,7 @@ export const RunbookDraftReplaceContentInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Automation/automationAccounts/{automationAccountName}/runbooks/{runbookName}/draft/content",
       apiVersion: "2024-10-23",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type RunbookDraftReplaceContentInput =
@@ -6794,6 +6798,7 @@ export const RunbookPublishInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Automation/automationAccounts/{automationAccountName}/runbooks/{runbookName}/publish",
     apiVersion: "2024-10-23",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type RunbookPublishInput = typeof RunbookPublishInput.Type;

--- a/packages/azure/src/services/awsconnector.ts
+++ b/packages/azure/src/services/awsconnector.ts
@@ -82,6 +82,7 @@ export const AccessAnalyzerAnalyzersCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/accessAnalyzerAnalyzers/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AccessAnalyzerAnalyzersCreateOrReplaceInput =
@@ -136,6 +137,7 @@ export const AccessAnalyzerAnalyzersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/accessAnalyzerAnalyzers/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AccessAnalyzerAnalyzersDeleteInput =
@@ -360,6 +362,7 @@ export const AccessAnalyzerAnalyzersUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/accessAnalyzerAnalyzers/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AccessAnalyzerAnalyzersUpdateInput =
@@ -537,6 +540,7 @@ export const AcmCertificateSummariesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/acmCertificateSummaries/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AcmCertificateSummariesCreateOrReplaceInput =
@@ -591,6 +595,7 @@ export const AcmCertificateSummariesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/acmCertificateSummaries/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AcmCertificateSummariesDeleteInput =
@@ -815,6 +820,7 @@ export const AcmCertificateSummariesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/acmCertificateSummaries/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AcmCertificateSummariesUpdateInput =
@@ -935,6 +941,7 @@ export const ApiGatewayRestApisCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/apiGatewayRestApis/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ApiGatewayRestApisCreateOrReplaceInput =
@@ -989,6 +996,7 @@ export const ApiGatewayRestApisDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/apiGatewayRestApis/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ApiGatewayRestApisDeleteInput =
@@ -1213,6 +1221,7 @@ export const ApiGatewayRestApisUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/apiGatewayRestApis/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ApiGatewayRestApisUpdateInput =
@@ -1348,6 +1357,7 @@ export const ApiGatewayStagesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/apiGatewayStages/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ApiGatewayStagesCreateOrReplaceInput =
@@ -1402,6 +1412,7 @@ export const ApiGatewayStagesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/apiGatewayStages/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ApiGatewayStagesDeleteInput =
@@ -1623,6 +1634,7 @@ export const ApiGatewayStagesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/apiGatewayStages/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ApiGatewayStagesUpdateInput =
@@ -1865,6 +1877,7 @@ export const AppSyncGraphqlApisCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/appSyncGraphqlApis/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AppSyncGraphqlApisCreateOrReplaceInput =
@@ -1919,6 +1932,7 @@ export const AppSyncGraphqlApisDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/appSyncGraphqlApis/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AppSyncGraphqlApisDeleteInput =
@@ -2143,6 +2157,7 @@ export const AppSyncGraphqlApisUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/appSyncGraphqlApis/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AppSyncGraphqlApisUpdateInput =
@@ -2447,6 +2462,7 @@ export const AutoScalingAutoScalingGroupsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/autoScalingAutoScalingGroups/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AutoScalingAutoScalingGroupsCreateOrReplaceInput =
@@ -2501,6 +2517,7 @@ export const AutoScalingAutoScalingGroupsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/autoScalingAutoScalingGroups/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AutoScalingAutoScalingGroupsDeleteInput =
@@ -2724,6 +2741,7 @@ export const AutoScalingAutoScalingGroupsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/autoScalingAutoScalingGroups/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AutoScalingAutoScalingGroupsUpdateInput =
@@ -2881,6 +2899,7 @@ export const CloudFormationStacksCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/cloudFormationStacks/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CloudFormationStacksCreateOrReplaceInput =
@@ -2935,6 +2954,7 @@ export const CloudFormationStacksDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/cloudFormationStacks/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CloudFormationStacksDeleteInput =
@@ -3085,6 +3105,7 @@ export const CloudFormationStackSetsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/cloudFormationStackSets/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CloudFormationStackSetsCreateOrReplaceInput =
@@ -3139,6 +3160,7 @@ export const CloudFormationStackSetsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/cloudFormationStackSets/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CloudFormationStackSetsDeleteInput =
@@ -3363,6 +3385,7 @@ export const CloudFormationStackSetsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/cloudFormationStackSets/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CloudFormationStackSetsUpdateInput =
@@ -3605,6 +3628,7 @@ export const CloudFormationStacksUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/cloudFormationStacks/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CloudFormationStacksUpdateInput =
@@ -3974,6 +3998,7 @@ export const CloudFrontDistributionsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/cloudFrontDistributions/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CloudFrontDistributionsCreateOrReplaceInput =
@@ -4028,6 +4053,7 @@ export const CloudFrontDistributionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/cloudFrontDistributions/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CloudFrontDistributionsDeleteInput =
@@ -4252,6 +4278,7 @@ export const CloudFrontDistributionsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/cloudFrontDistributions/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CloudFrontDistributionsUpdateInput =
@@ -4410,6 +4437,7 @@ export const CloudTrailTrailsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/cloudTrailTrails/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CloudTrailTrailsCreateOrReplaceInput =
@@ -4464,6 +4492,7 @@ export const CloudTrailTrailsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/cloudTrailTrails/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CloudTrailTrailsDeleteInput =
@@ -4685,6 +4714,7 @@ export const CloudTrailTrailsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/cloudTrailTrails/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CloudTrailTrailsUpdateInput =
@@ -4839,6 +4869,7 @@ export const CloudWatchAlarmsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/cloudWatchAlarms/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CloudWatchAlarmsCreateOrReplaceInput =
@@ -4893,6 +4924,7 @@ export const CloudWatchAlarmsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/cloudWatchAlarms/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CloudWatchAlarmsDeleteInput =
@@ -5114,6 +5146,7 @@ export const CloudWatchAlarmsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/cloudWatchAlarms/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CloudWatchAlarmsUpdateInput =
@@ -5650,6 +5683,7 @@ export const CodeBuildProjectsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/codeBuildProjects/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CodeBuildProjectsCreateOrReplaceInput =
@@ -5704,6 +5738,7 @@ export const CodeBuildProjectsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/codeBuildProjects/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CodeBuildProjectsDeleteInput =
@@ -5927,6 +5962,7 @@ export const CodeBuildProjectsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/codeBuildProjects/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CodeBuildProjectsUpdateInput =
@@ -6037,6 +6073,7 @@ export const CodeBuildSourceCredentialsInfosCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/codeBuildSourceCredentialsInfos/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CodeBuildSourceCredentialsInfosCreateOrReplaceInput =
@@ -6091,6 +6128,7 @@ export const CodeBuildSourceCredentialsInfosDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/codeBuildSourceCredentialsInfos/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CodeBuildSourceCredentialsInfosDeleteInput =
@@ -6314,6 +6352,7 @@ export const CodeBuildSourceCredentialsInfosUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/codeBuildSourceCredentialsInfos/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CodeBuildSourceCredentialsInfosUpdateInput =
@@ -7687,6 +7726,7 @@ export const ConfigServiceConfigurationRecordersCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/configServiceConfigurationRecorders/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ConfigServiceConfigurationRecordersCreateOrReplaceInput =
@@ -7741,6 +7781,7 @@ export const ConfigServiceConfigurationRecordersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/configServiceConfigurationRecorders/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ConfigServiceConfigurationRecordersDeleteInput =
@@ -8005,6 +8046,7 @@ export const ConfigServiceConfigurationRecorderStatusesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/configServiceConfigurationRecorderStatuses/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ConfigServiceConfigurationRecorderStatusesCreateOrReplaceInput =
@@ -8060,6 +8102,7 @@ export const ConfigServiceConfigurationRecorderStatusesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/configServiceConfigurationRecorderStatuses/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ConfigServiceConfigurationRecorderStatusesDeleteInput =
@@ -8287,6 +8330,7 @@ export const ConfigServiceConfigurationRecorderStatusesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/configServiceConfigurationRecorderStatuses/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ConfigServiceConfigurationRecorderStatusesUpdateInput =
@@ -8342,6 +8386,7 @@ export const ConfigServiceConfigurationRecordersUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/configServiceConfigurationRecorders/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ConfigServiceConfigurationRecordersUpdateInput =
@@ -8446,6 +8491,7 @@ export const ConfigServiceDeliveryChannelsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/configServiceDeliveryChannels/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ConfigServiceDeliveryChannelsCreateOrReplaceInput =
@@ -8500,6 +8546,7 @@ export const ConfigServiceDeliveryChannelsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/configServiceDeliveryChannels/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ConfigServiceDeliveryChannelsDeleteInput =
@@ -8723,6 +8770,7 @@ export const ConfigServiceDeliveryChannelsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/configServiceDeliveryChannels/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ConfigServiceDeliveryChannelsUpdateInput =
@@ -8878,6 +8926,7 @@ export const DatabaseMigrationServiceReplicationInstancesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/databaseMigrationServiceReplicationInstances/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DatabaseMigrationServiceReplicationInstancesCreateOrReplaceInput =
@@ -8934,6 +8983,7 @@ export const DatabaseMigrationServiceReplicationInstancesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/databaseMigrationServiceReplicationInstances/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DatabaseMigrationServiceReplicationInstancesDeleteInput =
@@ -9161,6 +9211,7 @@ export const DatabaseMigrationServiceReplicationInstancesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/databaseMigrationServiceReplicationInstances/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DatabaseMigrationServiceReplicationInstancesUpdateInput =
@@ -9321,6 +9372,7 @@ export const DaxClustersCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/daxClusters/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DaxClustersCreateOrReplaceInput =
@@ -9377,6 +9429,7 @@ export const DaxClustersDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/daxClusters/{name}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type DaxClustersDeleteInput = typeof DaxClustersDeleteInput.Type;
@@ -9592,6 +9645,7 @@ export const DaxClustersUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/daxClusters/{name}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type DaxClustersUpdateInput = typeof DaxClustersUpdateInput.Type;
@@ -9691,6 +9745,7 @@ export const DynamoDbContinuousBackupsDescriptionsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/dynamoDBContinuousBackupsDescriptions/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DynamoDbContinuousBackupsDescriptionsCreateOrReplaceInput =
@@ -9745,6 +9800,7 @@ export const DynamoDbContinuousBackupsDescriptionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/dynamoDBContinuousBackupsDescriptions/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DynamoDbContinuousBackupsDescriptionsDeleteInput =
@@ -9969,6 +10025,7 @@ export const DynamoDbContinuousBackupsDescriptionsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/dynamoDBContinuousBackupsDescriptions/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DynamoDbContinuousBackupsDescriptionsUpdateInput =
@@ -10215,6 +10272,7 @@ export const DynamoDbTablesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/dynamoDBTables/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DynamoDbTablesCreateOrReplaceInput =
@@ -10269,6 +10327,7 @@ export const DynamoDbTablesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/dynamoDBTables/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DynamoDbTablesDeleteInput = typeof DynamoDbTablesDeleteInput.Type;
@@ -10489,6 +10548,7 @@ export const DynamoDbTablesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/dynamoDBTables/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DynamoDbTablesUpdateInput = typeof DynamoDbTablesUpdateInput.Type;
@@ -10578,6 +10638,7 @@ export const Ec2AccountAttributesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2AccountAttributes/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type Ec2AccountAttributesCreateOrReplaceInput =
@@ -10632,6 +10693,7 @@ export const Ec2AccountAttributesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2AccountAttributes/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type Ec2AccountAttributesDeleteInput =
@@ -10857,6 +10919,7 @@ export const Ec2AccountAttributesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2AccountAttributes/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type Ec2AccountAttributesUpdateInput =
@@ -10965,6 +11028,7 @@ export const Ec2AddressesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2Addresses/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type Ec2AddressesCreateOrReplaceInput =
@@ -11020,6 +11084,7 @@ export const Ec2AddressesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2Addresses/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type Ec2AddressesDeleteInput = typeof Ec2AddressesDeleteInput.Type;
@@ -11234,6 +11299,7 @@ export const Ec2AddressesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2Addresses/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type Ec2AddressesUpdateInput = typeof Ec2AddressesUpdateInput.Type;
@@ -11357,6 +11423,7 @@ export const Ec2FlowLogsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2FlowLogs/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type Ec2FlowLogsCreateOrReplaceInput =
@@ -11413,6 +11480,7 @@ export const Ec2FlowLogsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2FlowLogs/{name}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type Ec2FlowLogsDeleteInput = typeof Ec2FlowLogsDeleteInput.Type;
@@ -11628,6 +11696,7 @@ export const Ec2FlowLogsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2FlowLogs/{name}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type Ec2FlowLogsUpdateInput = typeof Ec2FlowLogsUpdateInput.Type;
@@ -11865,6 +11934,7 @@ export const Ec2ImagesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2Images/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type Ec2ImagesCreateOrReplaceInput =
@@ -11919,6 +11989,7 @@ export const Ec2ImagesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2Images/{name}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type Ec2ImagesDeleteInput = typeof Ec2ImagesDeleteInput.Type;
@@ -12133,6 +12204,7 @@ export const Ec2ImagesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2Images/{name}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type Ec2ImagesUpdateInput = typeof Ec2ImagesUpdateInput.Type;
@@ -13483,6 +13555,7 @@ export const Ec2InstancesCreateOrReplaceInput =
       method: "PUT",
       path: "/{resourceUri}/providers/Microsoft.AwsConnector/ec2Instances/default",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type Ec2InstancesCreateOrReplaceInput =
@@ -13531,6 +13604,7 @@ export const Ec2InstancesDeleteInput =
       method: "DELETE",
       path: "/{resourceUri}/providers/Microsoft.AwsConnector/ec2Instances/default",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type Ec2InstancesDeleteInput = typeof Ec2InstancesDeleteInput.Type;
@@ -13662,6 +13736,7 @@ export const Ec2InstancesStartInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "POST",
     path: "/{resourceUri}/providers/Microsoft.AwsConnector/ec2Instances/default/start",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type Ec2InstancesStartInput = typeof Ec2InstancesStartInput.Type;
@@ -13726,6 +13801,7 @@ export const Ec2InstancesStopInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/{resourceUri}/providers/Microsoft.AwsConnector/ec2Instances/default/stop",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type Ec2InstancesStopInput = typeof Ec2InstancesStopInput.Type;
@@ -13953,6 +14029,7 @@ export const Ec2InstanceStatusesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2InstanceStatuses/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type Ec2InstanceStatusesCreateOrReplaceInput =
@@ -14007,6 +14084,7 @@ export const Ec2InstanceStatusesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2InstanceStatuses/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type Ec2InstanceStatusesDeleteInput =
@@ -14232,6 +14310,7 @@ export const Ec2InstanceStatusesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2InstanceStatuses/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type Ec2InstanceStatusesUpdateInput =
@@ -14369,6 +14448,7 @@ export const Ec2IpamsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2Ipams/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type Ec2IpamsCreateOrReplaceInput =
@@ -14423,6 +14503,7 @@ export const Ec2IpamsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2Ipams/{name}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type Ec2IpamsDeleteInput = typeof Ec2IpamsDeleteInput.Type;
@@ -14638,6 +14719,7 @@ export const Ec2IpamsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2Ipams/{name}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type Ec2IpamsUpdateInput = typeof Ec2IpamsUpdateInput.Type;
@@ -14730,6 +14812,7 @@ export const Ec2KeyPairsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2KeyPairs/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type Ec2KeyPairsCreateOrReplaceInput =
@@ -14786,6 +14869,7 @@ export const Ec2KeyPairsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2KeyPairs/{name}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type Ec2KeyPairsDeleteInput = typeof Ec2KeyPairsDeleteInput.Type;
@@ -15001,6 +15085,7 @@ export const Ec2KeyPairsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2KeyPairs/{name}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type Ec2KeyPairsUpdateInput = typeof Ec2KeyPairsUpdateInput.Type;
@@ -15090,6 +15175,7 @@ export const Ec2NetworkAclsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2NetworkAcls/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type Ec2NetworkAclsCreateOrReplaceInput =
@@ -15144,6 +15230,7 @@ export const Ec2NetworkAclsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2NetworkAcls/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type Ec2NetworkAclsDeleteInput = typeof Ec2NetworkAclsDeleteInput.Type;
@@ -15364,6 +15451,7 @@ export const Ec2NetworkAclsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2NetworkAcls/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type Ec2NetworkAclsUpdateInput = typeof Ec2NetworkAclsUpdateInput.Type;
@@ -15507,6 +15595,7 @@ export const Ec2NetworkInterfacesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2NetworkInterfaces/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type Ec2NetworkInterfacesCreateOrReplaceInput =
@@ -15561,6 +15650,7 @@ export const Ec2NetworkInterfacesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2NetworkInterfaces/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type Ec2NetworkInterfacesDeleteInput =
@@ -15786,6 +15876,7 @@ export const Ec2NetworkInterfacesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2NetworkInterfaces/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type Ec2NetworkInterfacesUpdateInput =
@@ -15879,6 +15970,7 @@ export const Ec2RouteTablesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2RouteTables/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type Ec2RouteTablesCreateOrReplaceInput =
@@ -15933,6 +16025,7 @@ export const Ec2RouteTablesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2RouteTables/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type Ec2RouteTablesDeleteInput = typeof Ec2RouteTablesDeleteInput.Type;
@@ -16153,6 +16246,7 @@ export const Ec2RouteTablesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2RouteTables/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type Ec2RouteTablesUpdateInput = typeof Ec2RouteTablesUpdateInput.Type;
@@ -16339,6 +16433,7 @@ export const Ec2SecurityGroupsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2SecurityGroups/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type Ec2SecurityGroupsCreateOrReplaceInput =
@@ -16393,6 +16488,7 @@ export const Ec2SecurityGroupsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2SecurityGroups/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type Ec2SecurityGroupsDeleteInput =
@@ -16616,6 +16712,7 @@ export const Ec2SecurityGroupsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2SecurityGroups/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type Ec2SecurityGroupsUpdateInput =
@@ -16748,6 +16845,7 @@ export const Ec2SnapshotsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2Snapshots/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type Ec2SnapshotsCreateOrReplaceInput =
@@ -16803,6 +16901,7 @@ export const Ec2SnapshotsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2Snapshots/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type Ec2SnapshotsDeleteInput = typeof Ec2SnapshotsDeleteInput.Type;
@@ -17017,6 +17116,7 @@ export const Ec2SnapshotsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2Snapshots/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type Ec2SnapshotsUpdateInput = typeof Ec2SnapshotsUpdateInput.Type;
@@ -17131,6 +17231,7 @@ export const Ec2SubnetsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2Subnets/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type Ec2SubnetsCreateOrReplaceInput =
@@ -17185,6 +17286,7 @@ export const Ec2SubnetsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2Subnets/{name}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type Ec2SubnetsDeleteInput = typeof Ec2SubnetsDeleteInput.Type;
@@ -17398,6 +17500,7 @@ export const Ec2SubnetsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2Subnets/{name}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type Ec2SubnetsUpdateInput = typeof Ec2SubnetsUpdateInput.Type;
@@ -17498,6 +17601,7 @@ export const Ec2VolumesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2Volumes/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type Ec2VolumesCreateOrReplaceInput =
@@ -17552,6 +17656,7 @@ export const Ec2VolumesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2Volumes/{name}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type Ec2VolumesDeleteInput = typeof Ec2VolumesDeleteInput.Type;
@@ -17765,6 +17870,7 @@ export const Ec2VolumesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2Volumes/{name}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type Ec2VolumesUpdateInput = typeof Ec2VolumesUpdateInput.Type;
@@ -17861,6 +17967,7 @@ export const Ec2VpcEndpointsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2VPCEndpoints/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type Ec2VpcEndpointsCreateOrReplaceInput =
@@ -17915,6 +18022,7 @@ export const Ec2VpcEndpointsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2VPCEndpoints/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type Ec2VpcEndpointsDeleteInput = typeof Ec2VpcEndpointsDeleteInput.Type;
@@ -18135,6 +18243,7 @@ export const Ec2VpcEndpointsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2VPCEndpoints/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type Ec2VpcEndpointsUpdateInput = typeof Ec2VpcEndpointsUpdateInput.Type;
@@ -18231,6 +18340,7 @@ export const Ec2VpcPeeringConnectionsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2VPCPeeringConnections/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type Ec2VpcPeeringConnectionsCreateOrReplaceInput =
@@ -18285,6 +18395,7 @@ export const Ec2VpcPeeringConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2VPCPeeringConnections/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type Ec2VpcPeeringConnectionsDeleteInput =
@@ -18509,6 +18620,7 @@ export const Ec2VpcPeeringConnectionsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2VPCPeeringConnections/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type Ec2VpcPeeringConnectionsUpdateInput =
@@ -18610,6 +18722,7 @@ export const Ec2VpcsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2Vpcs/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type Ec2VpcsCreateOrReplaceInput =
@@ -18664,6 +18777,7 @@ export const Ec2VpcsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2Vpcs/{name}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type Ec2VpcsDeleteInput = typeof Ec2VpcsDeleteInput.Type;
@@ -18879,6 +18993,7 @@ export const Ec2VpcsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ec2Vpcs/{name}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type Ec2VpcsUpdateInput = typeof Ec2VpcsUpdateInput.Type;
@@ -18996,6 +19111,7 @@ export const EcrImageDetailsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ecrImageDetails/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type EcrImageDetailsCreateOrReplaceInput =
@@ -19050,6 +19166,7 @@ export const EcrImageDetailsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ecrImageDetails/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type EcrImageDetailsDeleteInput = typeof EcrImageDetailsDeleteInput.Type;
@@ -19270,6 +19387,7 @@ export const EcrImageDetailsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ecrImageDetails/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type EcrImageDetailsUpdateInput = typeof EcrImageDetailsUpdateInput.Type;
@@ -19389,6 +19507,7 @@ export const EcrRepositoriesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ecrRepositories/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type EcrRepositoriesCreateOrReplaceInput =
@@ -19443,6 +19562,7 @@ export const EcrRepositoriesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ecrRepositories/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type EcrRepositoriesDeleteInput = typeof EcrRepositoriesDeleteInput.Type;
@@ -19663,6 +19783,7 @@ export const EcrRepositoriesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ecrRepositories/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type EcrRepositoriesUpdateInput = typeof EcrRepositoriesUpdateInput.Type;
@@ -19799,6 +19920,7 @@ export const EcsClustersCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ecsClusters/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type EcsClustersCreateOrReplaceInput =
@@ -19855,6 +19977,7 @@ export const EcsClustersDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ecsClusters/{name}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type EcsClustersDeleteInput = typeof EcsClustersDeleteInput.Type;
@@ -20070,6 +20193,7 @@ export const EcsClustersUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ecsClusters/{name}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type EcsClustersUpdateInput = typeof EcsClustersUpdateInput.Type;
@@ -20363,6 +20487,7 @@ export const EcsServicesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ecsServices/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type EcsServicesCreateOrReplaceInput =
@@ -20419,6 +20544,7 @@ export const EcsServicesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ecsServices/{name}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type EcsServicesDeleteInput = typeof EcsServicesDeleteInput.Type;
@@ -20634,6 +20760,7 @@ export const EcsServicesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ecsServices/{name}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type EcsServicesUpdateInput = typeof EcsServicesUpdateInput.Type;
@@ -21026,6 +21153,7 @@ export const EcsTaskDefinitionsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ecsTaskDefinitions/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type EcsTaskDefinitionsCreateOrReplaceInput =
@@ -21080,6 +21208,7 @@ export const EcsTaskDefinitionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ecsTaskDefinitions/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type EcsTaskDefinitionsDeleteInput =
@@ -21304,6 +21433,7 @@ export const EcsTaskDefinitionsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ecsTaskDefinitions/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type EcsTaskDefinitionsUpdateInput =
@@ -21444,6 +21574,7 @@ export const EfsFileSystemsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/efsFileSystems/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type EfsFileSystemsCreateOrReplaceInput =
@@ -21498,6 +21629,7 @@ export const EfsFileSystemsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/efsFileSystems/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type EfsFileSystemsDeleteInput = typeof EfsFileSystemsDeleteInput.Type;
@@ -21718,6 +21850,7 @@ export const EfsFileSystemsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/efsFileSystems/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type EfsFileSystemsUpdateInput = typeof EfsFileSystemsUpdateInput.Type;
@@ -21804,6 +21937,7 @@ export const EfsMountTargetsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/efsMountTargets/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type EfsMountTargetsCreateOrReplaceInput =
@@ -21858,6 +21992,7 @@ export const EfsMountTargetsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/efsMountTargets/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type EfsMountTargetsDeleteInput = typeof EfsMountTargetsDeleteInput.Type;
@@ -22078,6 +22213,7 @@ export const EfsMountTargetsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/efsMountTargets/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type EfsMountTargetsUpdateInput = typeof EfsMountTargetsUpdateInput.Type;
@@ -22326,6 +22462,7 @@ export const EksClustersCreateOrReplaceInput =
       method: "PUT",
       path: "/{resourceUri}/providers/Microsoft.AwsConnector/eksClusters/default",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type EksClustersCreateOrReplaceInput =
@@ -22375,6 +22512,7 @@ export const EksClustersDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/{resourceUri}/providers/Microsoft.AwsConnector/eksClusters/default",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type EksClustersDeleteInput = typeof EksClustersDeleteInput.Type;
@@ -22579,6 +22717,7 @@ export const EksNodegroupsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/eksNodegroups/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type EksNodegroupsCreateOrReplaceInput =
@@ -22633,6 +22772,7 @@ export const EksNodegroupsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/eksNodegroups/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type EksNodegroupsDeleteInput = typeof EksNodegroupsDeleteInput.Type;
@@ -22850,6 +22990,7 @@ export const EksNodegroupsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/eksNodegroups/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type EksNodegroupsUpdateInput = typeof EksNodegroupsUpdateInput.Type;
@@ -22954,6 +23095,7 @@ export const ElasticBeanstalkApplicationsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/elasticBeanstalkApplications/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ElasticBeanstalkApplicationsCreateOrReplaceInput =
@@ -23008,6 +23150,7 @@ export const ElasticBeanstalkApplicationsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/elasticBeanstalkApplications/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ElasticBeanstalkApplicationsDeleteInput =
@@ -23231,6 +23374,7 @@ export const ElasticBeanstalkApplicationsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/elasticBeanstalkApplications/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ElasticBeanstalkApplicationsUpdateInput =
@@ -23335,6 +23479,7 @@ export const ElasticBeanstalkConfigurationTemplatesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/elasticBeanstalkConfigurationTemplates/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ElasticBeanstalkConfigurationTemplatesCreateOrReplaceInput =
@@ -23389,6 +23534,7 @@ export const ElasticBeanstalkConfigurationTemplatesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/elasticBeanstalkConfigurationTemplates/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ElasticBeanstalkConfigurationTemplatesDeleteInput =
@@ -23614,6 +23760,7 @@ export const ElasticBeanstalkConfigurationTemplatesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/elasticBeanstalkConfigurationTemplates/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ElasticBeanstalkConfigurationTemplatesUpdateInput =
@@ -23731,6 +23878,7 @@ export const ElasticBeanstalkEnvironmentsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/elasticBeanstalkEnvironments/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ElasticBeanstalkEnvironmentsCreateOrReplaceInput =
@@ -23785,6 +23933,7 @@ export const ElasticBeanstalkEnvironmentsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/elasticBeanstalkEnvironments/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ElasticBeanstalkEnvironmentsDeleteInput =
@@ -24008,6 +24157,7 @@ export const ElasticBeanstalkEnvironmentsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/elasticBeanstalkEnvironments/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ElasticBeanstalkEnvironmentsUpdateInput =
@@ -24186,6 +24336,7 @@ export const ElasticLoadBalancingV2ListenersCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/elasticLoadBalancingV2Listeners/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ElasticLoadBalancingV2ListenersCreateOrReplaceInput =
@@ -24240,6 +24391,7 @@ export const ElasticLoadBalancingV2ListenersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/elasticLoadBalancingV2Listeners/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ElasticLoadBalancingV2ListenersDeleteInput =
@@ -24463,6 +24615,7 @@ export const ElasticLoadBalancingV2ListenersUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/elasticLoadBalancingV2Listeners/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ElasticLoadBalancingV2ListenersUpdateInput =
@@ -24584,6 +24737,7 @@ export const ElasticLoadBalancingV2LoadBalancersCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/elasticLoadBalancingV2LoadBalancers/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ElasticLoadBalancingV2LoadBalancersCreateOrReplaceInput =
@@ -24638,6 +24792,7 @@ export const ElasticLoadBalancingV2LoadBalancersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/elasticLoadBalancingV2LoadBalancers/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ElasticLoadBalancingV2LoadBalancersDeleteInput =
@@ -24861,6 +25016,7 @@ export const ElasticLoadBalancingV2LoadBalancersUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/elasticLoadBalancingV2LoadBalancers/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ElasticLoadBalancingV2LoadBalancersUpdateInput =
@@ -24993,6 +25149,7 @@ export const ElasticLoadBalancingV2TargetGroupsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/elasticLoadBalancingV2TargetGroups/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ElasticLoadBalancingV2TargetGroupsCreateOrReplaceInput =
@@ -25047,6 +25204,7 @@ export const ElasticLoadBalancingV2TargetGroupsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/elasticLoadBalancingV2TargetGroups/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ElasticLoadBalancingV2TargetGroupsDeleteInput =
@@ -25270,6 +25428,7 @@ export const ElasticLoadBalancingV2TargetGroupsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/elasticLoadBalancingV2TargetGroups/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ElasticLoadBalancingV2TargetGroupsUpdateInput =
@@ -25416,6 +25575,7 @@ export const ElasticLoadBalancingv2TargetHealthDescriptionsCreateOrReplaceInput 
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/elasticLoadBalancingV2TargetHealthDescriptions/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ElasticLoadBalancingv2TargetHealthDescriptionsCreateOrReplaceInput =
@@ -25472,6 +25632,7 @@ export const ElasticLoadBalancingv2TargetHealthDescriptionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/elasticLoadBalancingV2TargetHealthDescriptions/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ElasticLoadBalancingv2TargetHealthDescriptionsDeleteInput =
@@ -25699,6 +25860,7 @@ export const ElasticLoadBalancingv2TargetHealthDescriptionsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/elasticLoadBalancingV2TargetHealthDescriptions/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ElasticLoadBalancingv2TargetHealthDescriptionsUpdateInput =
@@ -25972,6 +26134,7 @@ export const EmrClustersCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/emrClusters/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type EmrClustersCreateOrReplaceInput =
@@ -26028,6 +26191,7 @@ export const EmrClustersDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/emrClusters/{name}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type EmrClustersDeleteInput = typeof EmrClustersDeleteInput.Type;
@@ -26243,6 +26407,7 @@ export const EmrClustersUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/emrClusters/{name}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type EmrClustersUpdateInput = typeof EmrClustersUpdateInput.Type;
@@ -26378,6 +26543,7 @@ export const GuardDutyDetectorsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/guardDutyDetectors/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type GuardDutyDetectorsCreateOrReplaceInput =
@@ -26432,6 +26598,7 @@ export const GuardDutyDetectorsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/guardDutyDetectors/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type GuardDutyDetectorsDeleteInput =
@@ -26656,6 +26823,7 @@ export const GuardDutyDetectorsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/guardDutyDetectors/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type GuardDutyDetectorsUpdateInput =
@@ -26742,6 +26910,7 @@ export const IamAccessKeyLastUsedsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/iamAccessKeyLastUseds/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type IamAccessKeyLastUsedsCreateOrReplaceInput =
@@ -26796,6 +26965,7 @@ export const IamAccessKeyLastUsedsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/iamAccessKeyLastUseds/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type IamAccessKeyLastUsedsDeleteInput =
@@ -27021,6 +27191,7 @@ export const IamAccessKeyLastUsedsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/iamAccessKeyLastUseds/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type IamAccessKeyLastUsedsUpdateInput =
@@ -27112,6 +27283,7 @@ export const IamAccessKeyMetadataInfoCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/iamAccessKeyMetadata/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type IamAccessKeyMetadataInfoCreateOrReplaceInput =
@@ -27166,6 +27338,7 @@ export const IamAccessKeyMetadataInfoDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/iamAccessKeyMetadata/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type IamAccessKeyMetadataInfoDeleteInput =
@@ -27390,6 +27563,7 @@ export const IamAccessKeyMetadataInfoUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/iamAccessKeyMetadata/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type IamAccessKeyMetadataInfoUpdateInput =
@@ -27486,6 +27660,7 @@ export const IamGroupsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/iamGroups/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type IamGroupsCreateOrReplaceInput =
@@ -27540,6 +27715,7 @@ export const IamGroupsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/iamGroups/{name}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type IamGroupsDeleteInput = typeof IamGroupsDeleteInput.Type;
@@ -27754,6 +27930,7 @@ export const IamGroupsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/iamGroups/{name}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type IamGroupsUpdateInput = typeof IamGroupsUpdateInput.Type;
@@ -27836,6 +28013,7 @@ export const IamInstanceProfilesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/iamInstanceProfiles/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type IamInstanceProfilesCreateOrUpdateInput =
@@ -27890,6 +28068,7 @@ export const IamInstanceProfilesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/iamInstanceProfiles/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type IamInstanceProfilesDeleteInput =
@@ -28115,6 +28294,7 @@ export const IamInstanceProfilesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/iamInstanceProfiles/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type IamInstanceProfilesUpdateInput =
@@ -28201,6 +28381,7 @@ export const IamMfaDevicesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/iamMFADevices/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type IamMfaDevicesCreateOrReplaceInput =
@@ -28255,6 +28436,7 @@ export const IamMfaDevicesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/iamMFADevices/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type IamMfaDevicesDeleteInput = typeof IamMfaDevicesDeleteInput.Type;
@@ -28472,6 +28654,7 @@ export const IamMfaDevicesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/iamMFADevices/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type IamMfaDevicesUpdateInput = typeof IamMfaDevicesUpdateInput.Type;
@@ -28561,6 +28744,7 @@ export const IamPasswordPoliciesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/iamPasswordPolicies/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type IamPasswordPoliciesCreateOrReplaceInput =
@@ -28615,6 +28799,7 @@ export const IamPasswordPoliciesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/iamPasswordPolicies/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type IamPasswordPoliciesDeleteInput =
@@ -28840,6 +29025,7 @@ export const IamPasswordPoliciesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/iamPasswordPolicies/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type IamPasswordPoliciesUpdateInput =
@@ -28927,6 +29113,7 @@ export const IamPolicyVersionsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/iamPolicyVersions/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type IamPolicyVersionsCreateOrReplaceInput =
@@ -28981,6 +29168,7 @@ export const IamPolicyVersionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/iamPolicyVersions/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type IamPolicyVersionsDeleteInput =
@@ -29204,6 +29392,7 @@ export const IamPolicyVersionsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/iamPolicyVersions/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type IamPolicyVersionsUpdateInput =
@@ -29316,6 +29505,7 @@ export const IamRolesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/iamRoles/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type IamRolesCreateOrReplaceInput =
@@ -29370,6 +29560,7 @@ export const IamRolesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/iamRoles/{name}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type IamRolesDeleteInput = typeof IamRolesDeleteInput.Type;
@@ -29585,6 +29776,7 @@ export const IamRolesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/iamRoles/{name}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type IamRolesUpdateInput = typeof IamRolesUpdateInput.Type;
@@ -29677,6 +29869,7 @@ export const IamServerCertificatesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/iamServerCertificates/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type IamServerCertificatesCreateOrReplaceInput =
@@ -29731,6 +29924,7 @@ export const IamServerCertificatesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/iamServerCertificates/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type IamServerCertificatesDeleteInput =
@@ -29956,6 +30150,7 @@ export const IamServerCertificatesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/iamServerCertificates/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type IamServerCertificatesUpdateInput =
@@ -30051,6 +30246,7 @@ export const IamVirtualMfaDevicesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/iamVirtualMFADevices/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type IamVirtualMfaDevicesCreateOrReplaceInput =
@@ -30105,6 +30301,7 @@ export const IamVirtualMfaDevicesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/iamVirtualMFADevices/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type IamVirtualMfaDevicesDeleteInput =
@@ -30330,6 +30527,7 @@ export const IamVirtualMfaDevicesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/iamVirtualMFADevices/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type IamVirtualMfaDevicesUpdateInput =
@@ -30415,6 +30613,7 @@ export const KmsAliasesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/kmsAliases/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type KmsAliasesCreateOrReplaceInput =
@@ -30469,6 +30668,7 @@ export const KmsAliasesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/kmsAliases/{name}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type KmsAliasesDeleteInput = typeof KmsAliasesDeleteInput.Type;
@@ -30682,6 +30882,7 @@ export const KmsAliasesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/kmsAliases/{name}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type KmsAliasesUpdateInput = typeof KmsAliasesUpdateInput.Type;
@@ -30807,6 +31008,7 @@ export const KmsKeysCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/kmsKeys/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type KmsKeysCreateOrReplaceInput =
@@ -30861,6 +31063,7 @@ export const KmsKeysDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/kmsKeys/{name}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type KmsKeysDeleteInput = typeof KmsKeysDeleteInput.Type;
@@ -31076,6 +31279,7 @@ export const KmsKeysUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/kmsKeys/{name}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type KmsKeysUpdateInput = typeof KmsKeysUpdateInput.Type;
@@ -31158,6 +31362,7 @@ export const LambdaFunctionCodeLocationsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/lambdaFunctionCodeLocations/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type LambdaFunctionCodeLocationsCreateOrReplaceInput =
@@ -31212,6 +31417,7 @@ export const LambdaFunctionCodeLocationsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/lambdaFunctionCodeLocations/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LambdaFunctionCodeLocationsDeleteInput =
@@ -31435,6 +31641,7 @@ export const LambdaFunctionCodeLocationsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/lambdaFunctionCodeLocations/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LambdaFunctionCodeLocationsUpdateInput =
@@ -31640,6 +31847,7 @@ export const LambdaFunctionsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/lambdaFunctions/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type LambdaFunctionsCreateOrReplaceInput =
@@ -31694,6 +31902,7 @@ export const LambdaFunctionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/lambdaFunctions/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LambdaFunctionsDeleteInput = typeof LambdaFunctionsDeleteInput.Type;
@@ -31914,6 +32123,7 @@ export const LambdaFunctionsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/lambdaFunctions/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LambdaFunctionsUpdateInput = typeof LambdaFunctionsUpdateInput.Type;
@@ -32022,6 +32232,7 @@ export const LightsailBucketsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/lightsailBuckets/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type LightsailBucketsCreateOrReplaceInput =
@@ -32076,6 +32287,7 @@ export const LightsailBucketsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/lightsailBuckets/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LightsailBucketsDeleteInput =
@@ -32297,6 +32509,7 @@ export const LightsailBucketsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/lightsailBuckets/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LightsailBucketsUpdateInput =
@@ -32483,6 +32696,7 @@ export const LightsailInstancesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/lightsailInstances/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type LightsailInstancesCreateOrReplaceInput =
@@ -32537,6 +32751,7 @@ export const LightsailInstancesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/lightsailInstances/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LightsailInstancesDeleteInput =
@@ -32761,6 +32976,7 @@ export const LightsailInstancesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/lightsailInstances/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LightsailInstancesUpdateInput =
@@ -32860,6 +33076,7 @@ export const LogsLogGroupsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/logsLogGroups/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type LogsLogGroupsCreateOrReplaceInput =
@@ -32914,6 +33131,7 @@ export const LogsLogGroupsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/logsLogGroups/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LogsLogGroupsDeleteInput = typeof LogsLogGroupsDeleteInput.Type;
@@ -33131,6 +33349,7 @@ export const LogsLogGroupsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/logsLogGroups/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LogsLogGroupsUpdateInput = typeof LogsLogGroupsUpdateInput.Type;
@@ -33212,6 +33431,7 @@ export const LogsLogStreamsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/logsLogStreams/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type LogsLogStreamsCreateOrReplaceInput =
@@ -33266,6 +33486,7 @@ export const LogsLogStreamsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/logsLogStreams/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LogsLogStreamsDeleteInput = typeof LogsLogStreamsDeleteInput.Type;
@@ -33486,6 +33707,7 @@ export const LogsLogStreamsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/logsLogStreams/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LogsLogStreamsUpdateInput = typeof LogsLogStreamsUpdateInput.Type;
@@ -33619,6 +33841,7 @@ export const LogsMetricFiltersCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/logsMetricFilters/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type LogsMetricFiltersCreateOrReplaceInput =
@@ -33673,6 +33896,7 @@ export const LogsMetricFiltersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/logsMetricFilters/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LogsMetricFiltersDeleteInput =
@@ -33896,6 +34120,7 @@ export const LogsMetricFiltersUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/logsMetricFilters/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LogsMetricFiltersUpdateInput =
@@ -33987,6 +34212,7 @@ export const LogsSubscriptionFiltersCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/logsSubscriptionFilters/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type LogsSubscriptionFiltersCreateOrReplaceInput =
@@ -34041,6 +34267,7 @@ export const LogsSubscriptionFiltersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/logsSubscriptionFilters/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LogsSubscriptionFiltersDeleteInput =
@@ -34265,6 +34492,7 @@ export const LogsSubscriptionFiltersUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/logsSubscriptionFilters/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LogsSubscriptionFiltersUpdateInput =
@@ -34547,6 +34775,7 @@ export const Macie2JobSummariesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/macie2JobSummaries/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type Macie2JobSummariesCreateOrReplaceInput =
@@ -34601,6 +34830,7 @@ export const Macie2JobSummariesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/macie2JobSummaries/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type Macie2JobSummariesDeleteInput =
@@ -34825,6 +35055,7 @@ export const Macie2JobSummariesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/macie2JobSummaries/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type Macie2JobSummariesUpdateInput =
@@ -34943,6 +35174,7 @@ export const MacieAllowListsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/macieAllowLists/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type MacieAllowListsCreateOrReplaceInput =
@@ -34997,6 +35229,7 @@ export const MacieAllowListsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/macieAllowLists/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type MacieAllowListsDeleteInput = typeof MacieAllowListsDeleteInput.Type;
@@ -35217,6 +35450,7 @@ export const MacieAllowListsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/macieAllowLists/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type MacieAllowListsUpdateInput = typeof MacieAllowListsUpdateInput.Type;
@@ -35394,6 +35628,7 @@ export const NetworkFirewallFirewallPoliciesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/networkFirewallFirewallPolicies/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NetworkFirewallFirewallPoliciesCreateOrReplaceInput =
@@ -35448,6 +35683,7 @@ export const NetworkFirewallFirewallPoliciesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/networkFirewallFirewallPolicies/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkFirewallFirewallPoliciesDeleteInput =
@@ -35671,6 +35907,7 @@ export const NetworkFirewallFirewallPoliciesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/networkFirewallFirewallPolicies/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkFirewallFirewallPoliciesUpdateInput =
@@ -35779,6 +36016,7 @@ export const NetworkFirewallFirewallsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/networkFirewallFirewalls/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NetworkFirewallFirewallsCreateOrReplaceInput =
@@ -35833,6 +36071,7 @@ export const NetworkFirewallFirewallsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/networkFirewallFirewalls/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkFirewallFirewallsDeleteInput =
@@ -36057,6 +36296,7 @@ export const NetworkFirewallFirewallsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/networkFirewallFirewalls/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkFirewallFirewallsUpdateInput =
@@ -36377,6 +36617,7 @@ export const NetworkFirewallRuleGroupsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/networkFirewallRuleGroups/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NetworkFirewallRuleGroupsCreateOrReplaceInput =
@@ -36431,6 +36672,7 @@ export const NetworkFirewallRuleGroupsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/networkFirewallRuleGroups/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkFirewallRuleGroupsDeleteInput =
@@ -36654,6 +36896,7 @@ export const NetworkFirewallRuleGroupsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/networkFirewallRuleGroups/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkFirewallRuleGroupsUpdateInput =
@@ -37238,6 +37481,7 @@ export const OpenSearchDomainStatusesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/openSearchDomainStatuses/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type OpenSearchDomainStatusesCreateOrReplaceInput =
@@ -37292,6 +37536,7 @@ export const OpenSearchDomainStatusesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/openSearchDomainStatuses/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type OpenSearchDomainStatusesDeleteInput =
@@ -37516,6 +37761,7 @@ export const OpenSearchDomainStatusesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/openSearchDomainStatuses/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type OpenSearchDomainStatusesUpdateInput =
@@ -37667,6 +37913,7 @@ export const OrganizationsAccountsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/organizationsAccounts/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type OrganizationsAccountsCreateOrReplaceInput =
@@ -37721,6 +37968,7 @@ export const OrganizationsAccountsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/organizationsAccounts/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type OrganizationsAccountsDeleteInput =
@@ -37946,6 +38194,7 @@ export const OrganizationsAccountsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/organizationsAccounts/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type OrganizationsAccountsUpdateInput =
@@ -38038,6 +38287,7 @@ export const OrganizationsOrganizationsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/organizationsOrganizations/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type OrganizationsOrganizationsCreateOrReplaceInput =
@@ -38092,6 +38342,7 @@ export const OrganizationsOrganizationsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/organizationsOrganizations/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type OrganizationsOrganizationsDeleteInput =
@@ -38315,6 +38566,7 @@ export const OrganizationsOrganizationsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/organizationsOrganizations/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type OrganizationsOrganizationsUpdateInput =
@@ -38500,6 +38752,7 @@ export const RdsDbClustersCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/rdsDBClusters/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type RdsDbClustersCreateOrReplaceInput =
@@ -38554,6 +38807,7 @@ export const RdsDbClustersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/rdsDBClusters/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RdsDbClustersDeleteInput = typeof RdsDbClustersDeleteInput.Type;
@@ -38771,6 +39025,7 @@ export const RdsDbClustersUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/rdsDBClusters/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RdsDbClustersUpdateInput = typeof RdsDbClustersUpdateInput.Type;
@@ -38971,6 +39226,7 @@ export const RdsDbInstancesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/rdsDBInstances/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type RdsDbInstancesCreateOrReplaceInput =
@@ -39025,6 +39281,7 @@ export const RdsDbInstancesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/rdsDBInstances/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RdsDbInstancesDeleteInput = typeof RdsDbInstancesDeleteInput.Type;
@@ -39245,6 +39502,7 @@ export const RdsDbInstancesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/rdsDBInstances/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RdsDbInstancesUpdateInput = typeof RdsDbInstancesUpdateInput.Type;
@@ -39335,6 +39593,7 @@ export const RdsDbSnapshotAttributesResultsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/rdsDBSnapshotAttributesResults/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type RdsDbSnapshotAttributesResultsCreateOrReplaceInput =
@@ -39389,6 +39648,7 @@ export const RdsDbSnapshotAttributesResultsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/rdsDBSnapshotAttributesResults/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RdsDbSnapshotAttributesResultsDeleteInput =
@@ -39612,6 +39872,7 @@ export const RdsDbSnapshotAttributesResultsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/rdsDBSnapshotAttributesResults/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RdsDbSnapshotAttributesResultsUpdateInput =
@@ -39744,6 +40005,7 @@ export const RdsDbSnapshotsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/rdsDBSnapshots/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type RdsDbSnapshotsCreateOrReplaceInput =
@@ -39798,6 +40060,7 @@ export const RdsDbSnapshotsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/rdsDBSnapshots/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RdsDbSnapshotsDeleteInput = typeof RdsDbSnapshotsDeleteInput.Type;
@@ -40018,6 +40281,7 @@ export const RdsDbSnapshotsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/rdsDBSnapshots/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RdsDbSnapshotsUpdateInput = typeof RdsDbSnapshotsUpdateInput.Type;
@@ -40113,6 +40377,7 @@ export const RdsEventSubscriptionsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/rdsEventSubscriptions/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type RdsEventSubscriptionsCreateOrReplaceInput =
@@ -40167,6 +40432,7 @@ export const RdsEventSubscriptionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/rdsEventSubscriptions/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RdsEventSubscriptionsDeleteInput =
@@ -40392,6 +40658,7 @@ export const RdsEventSubscriptionsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/rdsEventSubscriptions/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RdsEventSubscriptionsUpdateInput =
@@ -40497,6 +40764,7 @@ export const RdsExportTasksCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/rdsExportTasks/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type RdsExportTasksCreateOrReplaceInput =
@@ -40551,6 +40819,7 @@ export const RdsExportTasksDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/rdsExportTasks/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RdsExportTasksDeleteInput = typeof RdsExportTasksDeleteInput.Type;
@@ -40771,6 +41040,7 @@ export const RdsExportTasksUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/rdsExportTasks/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RdsExportTasksUpdateInput = typeof RdsExportTasksUpdateInput.Type;
@@ -40871,6 +41141,7 @@ export const RedshiftClusterParameterGroupsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/redshiftClusterParameterGroups/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type RedshiftClusterParameterGroupsCreateOrReplaceInput =
@@ -40925,6 +41196,7 @@ export const RedshiftClusterParameterGroupsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/redshiftClusterParameterGroups/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RedshiftClusterParameterGroupsDeleteInput =
@@ -41148,6 +41420,7 @@ export const RedshiftClusterParameterGroupsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/redshiftClusterParameterGroups/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RedshiftClusterParameterGroupsUpdateInput =
@@ -41302,6 +41575,7 @@ export const RedshiftClustersCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/redshiftClusters/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type RedshiftClustersCreateOrReplaceInput =
@@ -41356,6 +41630,7 @@ export const RedshiftClustersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/redshiftClusters/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RedshiftClustersDeleteInput =
@@ -41577,6 +41852,7 @@ export const RedshiftClustersUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/redshiftClusters/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RedshiftClustersUpdateInput =
@@ -41664,6 +41940,7 @@ export const Route53DomainsDomainSummariesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/route53DomainsDomainSummaries/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type Route53DomainsDomainSummariesCreateOrReplaceInput =
@@ -41718,6 +41995,7 @@ export const Route53DomainsDomainSummariesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/route53DomainsDomainSummaries/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type Route53DomainsDomainSummariesDeleteInput =
@@ -41941,6 +42219,7 @@ export const Route53DomainsDomainSummariesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/route53DomainsDomainSummaries/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type Route53DomainsDomainSummariesUpdateInput =
@@ -42052,6 +42331,7 @@ export const Route53HostedZonesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/route53HostedZones/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type Route53HostedZonesCreateOrReplaceInput =
@@ -42106,6 +42386,7 @@ export const Route53HostedZonesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/route53HostedZones/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type Route53HostedZonesDeleteInput =
@@ -42330,6 +42611,7 @@ export const Route53HostedZonesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/route53HostedZones/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type Route53HostedZonesUpdateInput =
@@ -42527,6 +42809,7 @@ export const Route53ResourceRecordSetsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/route53ResourceRecordSets/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type Route53ResourceRecordSetsCreateOrReplaceInput =
@@ -42581,6 +42864,7 @@ export const Route53ResourceRecordSetsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/route53ResourceRecordSets/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type Route53ResourceRecordSetsDeleteInput =
@@ -42804,6 +43088,7 @@ export const Route53ResourceRecordSetsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/route53ResourceRecordSets/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type Route53ResourceRecordSetsUpdateInput =
@@ -42930,6 +43215,7 @@ export const S3AccessControlPoliciesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/s3AccessControlPolicies/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type S3AccessControlPoliciesCreateOrReplaceInput =
@@ -42984,6 +43270,7 @@ export const S3AccessControlPoliciesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/s3AccessControlPolicies/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type S3AccessControlPoliciesDeleteInput =
@@ -43208,6 +43495,7 @@ export const S3AccessControlPoliciesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/s3AccessControlPolicies/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type S3AccessControlPoliciesUpdateInput =
@@ -43312,6 +43600,7 @@ export const S3AccessPointsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/s3AccessPoints/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type S3AccessPointsCreateOrReplaceInput =
@@ -43366,6 +43655,7 @@ export const S3AccessPointsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/s3AccessPoints/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type S3AccessPointsDeleteInput = typeof S3AccessPointsDeleteInput.Type;
@@ -43586,6 +43876,7 @@ export const S3AccessPointsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/s3AccessPoints/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type S3AccessPointsUpdateInput = typeof S3AccessPointsUpdateInput.Type;
@@ -43668,6 +43959,7 @@ export const S3BucketPoliciesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/s3BucketPolicies/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type S3BucketPoliciesCreateOrReplaceInput =
@@ -43722,6 +44014,7 @@ export const S3BucketPoliciesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/s3BucketPolicies/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type S3BucketPoliciesDeleteInput =
@@ -43943,6 +44236,7 @@ export const S3BucketPoliciesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/s3BucketPolicies/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type S3BucketPoliciesUpdateInput =
@@ -44669,6 +44963,7 @@ export const S3BucketsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/s3Buckets/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type S3BucketsCreateOrReplaceInput =
@@ -44723,6 +45018,7 @@ export const S3BucketsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/s3Buckets/{name}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type S3BucketsDeleteInput = typeof S3BucketsDeleteInput.Type;
@@ -44937,6 +45233,7 @@ export const S3BucketsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/s3Buckets/{name}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type S3BucketsUpdateInput = typeof S3BucketsUpdateInput.Type;
@@ -45025,6 +45322,7 @@ export const S3ControlMultiRegionAccessPointPolicyDocumentsCreateOrReplaceInput 
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/s3ControlMultiRegionAccessPointPolicyDocuments/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type S3ControlMultiRegionAccessPointPolicyDocumentsCreateOrReplaceInput =
@@ -45081,6 +45379,7 @@ export const S3ControlMultiRegionAccessPointPolicyDocumentsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/s3ControlMultiRegionAccessPointPolicyDocuments/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type S3ControlMultiRegionAccessPointPolicyDocumentsDeleteInput =
@@ -45308,6 +45607,7 @@ export const S3ControlMultiRegionAccessPointPolicyDocumentsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/s3ControlMultiRegionAccessPointPolicyDocuments/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type S3ControlMultiRegionAccessPointPolicyDocumentsUpdateInput =
@@ -45484,6 +45784,7 @@ export const SageMakerAppsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/sageMakerApps/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SageMakerAppsCreateOrReplaceInput =
@@ -45538,6 +45839,7 @@ export const SageMakerAppsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/sageMakerApps/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SageMakerAppsDeleteInput = typeof SageMakerAppsDeleteInput.Type;
@@ -45755,6 +46057,7 @@ export const SageMakerAppsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/sageMakerApps/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SageMakerAppsUpdateInput = typeof SageMakerAppsUpdateInput.Type;
@@ -46024,6 +46327,7 @@ export const SageMakerNotebookInstanceSummariesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/sageMakerNotebookInstanceSummaries/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SageMakerNotebookInstanceSummariesCreateOrReplaceInput =
@@ -46078,6 +46382,7 @@ export const SageMakerNotebookInstanceSummariesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/sageMakerNotebookInstanceSummaries/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SageMakerNotebookInstanceSummariesDeleteInput =
@@ -46301,6 +46606,7 @@ export const SageMakerNotebookInstanceSummariesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/sageMakerNotebookInstanceSummaries/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SageMakerNotebookInstanceSummariesUpdateInput =
@@ -46387,6 +46693,7 @@ export const SecretsManagerResourcePoliciesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/secretsManagerResourcePolicies/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SecretsManagerResourcePoliciesCreateOrReplaceInput =
@@ -46441,6 +46748,7 @@ export const SecretsManagerResourcePoliciesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/secretsManagerResourcePolicies/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SecretsManagerResourcePoliciesDeleteInput =
@@ -46664,6 +46972,7 @@ export const SecretsManagerResourcePoliciesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/secretsManagerResourcePolicies/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SecretsManagerResourcePoliciesUpdateInput =
@@ -46781,6 +47090,7 @@ export const SecretsManagerSecretsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/secretsManagerSecrets/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SecretsManagerSecretsCreateOrReplaceInput =
@@ -46835,6 +47145,7 @@ export const SecretsManagerSecretsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/secretsManagerSecrets/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SecretsManagerSecretsDeleteInput =
@@ -47060,6 +47371,7 @@ export const SecretsManagerSecretsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/secretsManagerSecrets/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SecretsManagerSecretsUpdateInput =
@@ -47148,6 +47460,7 @@ export const SnsSubscriptionsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/snsSubscriptions/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SnsSubscriptionsCreateOrReplaceInput =
@@ -47202,6 +47515,7 @@ export const SnsSubscriptionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/snsSubscriptions/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SnsSubscriptionsDeleteInput =
@@ -47423,6 +47737,7 @@ export const SnsSubscriptionsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/snsSubscriptions/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SnsSubscriptionsUpdateInput =
@@ -47550,6 +47865,7 @@ export const SnsTopicsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/snsTopics/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SnsTopicsCreateOrReplaceInput =
@@ -47604,6 +47920,7 @@ export const SnsTopicsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/snsTopics/{name}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type SnsTopicsDeleteInput = typeof SnsTopicsDeleteInput.Type;
@@ -47818,6 +48135,7 @@ export const SnsTopicsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/snsTopics/{name}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type SnsTopicsUpdateInput = typeof SnsTopicsUpdateInput.Type;
@@ -47925,6 +48243,7 @@ export const SqsQueuesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/sqsQueues/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SqsQueuesCreateOrReplaceInput =
@@ -47979,6 +48298,7 @@ export const SqsQueuesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/sqsQueues/{name}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type SqsQueuesDeleteInput = typeof SqsQueuesDeleteInput.Type;
@@ -48193,6 +48513,7 @@ export const SqsQueuesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/sqsQueues/{name}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type SqsQueuesUpdateInput = typeof SqsQueuesUpdateInput.Type;
@@ -48329,6 +48650,7 @@ export const SsmInstanceInformationsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ssmInstanceInformations/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SsmInstanceInformationsCreateOrReplaceInput =
@@ -48383,6 +48705,7 @@ export const SsmInstanceInformationsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ssmInstanceInformations/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SsmInstanceInformationsDeleteInput =
@@ -48607,6 +48930,7 @@ export const SsmInstanceInformationsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ssmInstanceInformations/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SsmInstanceInformationsUpdateInput =
@@ -48702,6 +49026,7 @@ export const SsmParametersCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ssmParameters/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SsmParametersCreateOrReplaceInput =
@@ -48756,6 +49081,7 @@ export const SsmParametersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ssmParameters/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SsmParametersDeleteInput = typeof SsmParametersDeleteInput.Type;
@@ -48973,6 +49299,7 @@ export const SsmParametersUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ssmParameters/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SsmParametersUpdateInput = typeof SsmParametersUpdateInput.Type;
@@ -49113,6 +49440,7 @@ export const SsmResourceComplianceSummaryItemsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ssmResourceComplianceSummaryItems/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SsmResourceComplianceSummaryItemsCreateOrReplaceInput =
@@ -49167,6 +49495,7 @@ export const SsmResourceComplianceSummaryItemsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ssmResourceComplianceSummaryItems/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SsmResourceComplianceSummaryItemsDeleteInput =
@@ -49390,6 +49719,7 @@ export const SsmResourceComplianceSummaryItemsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/ssmResourceComplianceSummaryItems/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SsmResourceComplianceSummaryItemsUpdateInput =
@@ -49533,6 +49863,7 @@ export const Wafv2LoggingConfigurationsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/wafv2LoggingConfigurations/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type Wafv2LoggingConfigurationsCreateOrReplaceInput =
@@ -49587,6 +49918,7 @@ export const Wafv2LoggingConfigurationsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/wafv2LoggingConfigurations/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type Wafv2LoggingConfigurationsDeleteInput =
@@ -49810,6 +50142,7 @@ export const Wafv2LoggingConfigurationsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/wafv2LoggingConfigurations/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type Wafv2LoggingConfigurationsUpdateInput =
@@ -49894,6 +50227,7 @@ export const WafWebAclSummariesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/wafWebACLSummaries/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type WafWebAclSummariesCreateOrReplaceInput =
@@ -49948,6 +50282,7 @@ export const WafWebAclSummariesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/wafWebACLSummaries/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WafWebAclSummariesDeleteInput =
@@ -50172,6 +50507,7 @@ export const WafWebAclSummariesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AwsConnector/wafWebACLSummaries/{name}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WafWebAclSummariesUpdateInput =

--- a/packages/azure/src/services/azure-kusto.ts
+++ b/packages/azure/src/services/azure-kusto.ts
@@ -111,6 +111,7 @@ export const AttachedDatabaseConfigurationsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Kusto/clusters/{clusterName}/attachedDatabaseConfigurations/{attachedDatabaseConfigurationName}",
       apiVersion: "2025-02-14",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AttachedDatabaseConfigurationsCreateOrUpdateInput =
@@ -167,6 +168,7 @@ export const AttachedDatabaseConfigurationsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Kusto/clusters/{clusterName}/attachedDatabaseConfigurations/{attachedDatabaseConfigurationName}",
       apiVersion: "2025-02-14",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AttachedDatabaseConfigurationsDeleteInput =
@@ -401,6 +403,7 @@ export const ClusterPrincipalAssignmentsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Kusto/clusters/{clusterName}/principalAssignments/{principalAssignmentName}",
       apiVersion: "2025-02-14",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ClusterPrincipalAssignmentsCreateOrUpdateInput =
@@ -457,6 +460,7 @@ export const ClusterPrincipalAssignmentsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Kusto/clusters/{clusterName}/principalAssignments/{principalAssignmentName}",
       apiVersion: "2025-02-14",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ClusterPrincipalAssignmentsDeleteInput =
@@ -644,6 +648,7 @@ export const ClustersAddCalloutPoliciesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Kusto/clusters/{clusterName}/addCalloutPolicies",
       apiVersion: "2025-02-14",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ClustersAddCalloutPoliciesInput =
@@ -703,6 +708,7 @@ export const ClustersAddLanguageExtensionsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Kusto/clusters/{clusterName}/addLanguageExtensions",
       apiVersion: "2025-02-14",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ClustersAddLanguageExtensionsInput =
@@ -1060,6 +1066,7 @@ export const ClustersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Kusto/clusters/{clusterName}",
       apiVersion: "2025-02-14",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ClustersCreateOrUpdateInput =
@@ -1116,6 +1123,7 @@ export const ClustersDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Kusto/clusters/{clusterName}",
     apiVersion: "2025-02-14",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ClustersDeleteInput = typeof ClustersDeleteInput.Type;
@@ -1170,6 +1178,7 @@ export const ClustersDetachFollowerDatabasesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Kusto/clusters/{clusterName}/detachFollowerDatabases",
       apiVersion: "2025-02-14",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ClustersDetachFollowerDatabasesInput =
@@ -1206,6 +1215,7 @@ export const ClustersDiagnoseVirtualNetworkInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Kusto/clusters/{clusterName}/diagnoseVirtualNetwork",
       apiVersion: "2025-02-14",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ClustersDiagnoseVirtualNetworkInput =
@@ -1951,6 +1961,7 @@ export const ClustersMigrateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Kusto/clusters/{clusterName}/migrate",
     apiVersion: "2025-02-14",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ClustersMigrateInput = typeof ClustersMigrateInput.Type;
@@ -1984,6 +1995,7 @@ export const ClustersRemoveCalloutPolicyInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Kusto/clusters/{clusterName}/removeCalloutPolicy",
       apiVersion: "2025-02-14",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ClustersRemoveCalloutPolicyInput =
@@ -2043,6 +2055,7 @@ export const ClustersRemoveLanguageExtensionsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Kusto/clusters/{clusterName}/removeLanguageExtensions",
       apiVersion: "2025-02-14",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ClustersRemoveLanguageExtensionsInput =
@@ -2078,6 +2091,7 @@ export const ClustersStartInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Kusto/clusters/{clusterName}/start",
     apiVersion: "2025-02-14",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ClustersStartInput = typeof ClustersStartInput.Type;
@@ -2109,6 +2123,7 @@ export const ClustersStopInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Kusto/clusters/{clusterName}/stop",
     apiVersion: "2025-02-14",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ClustersStopInput = typeof ClustersStopInput.Type;
@@ -2436,6 +2451,7 @@ export const ClustersUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Kusto/clusters/{clusterName}",
     apiVersion: "2025-02-14",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ClustersUpdateInput = typeof ClustersUpdateInput.Type;
@@ -2623,6 +2639,7 @@ export const DatabasePrincipalAssignmentsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Kusto/clusters/{clusterName}/databases/{databaseName}/principalAssignments/{principalAssignmentName}",
       apiVersion: "2025-02-14",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DatabasePrincipalAssignmentsCreateOrUpdateInput =
@@ -2681,6 +2698,7 @@ export const DatabasePrincipalAssignmentsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Kusto/clusters/{clusterName}/databases/{databaseName}/principalAssignments/{principalAssignmentName}",
       apiVersion: "2025-02-14",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DatabasePrincipalAssignmentsDeleteInput =
@@ -2981,6 +2999,7 @@ export const DatabasesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Kusto/clusters/{clusterName}/databases/{databaseName}",
       apiVersion: "2025-02-14",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DatabasesCreateOrUpdateInput =
@@ -3038,6 +3057,7 @@ export const DatabasesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Kusto/clusters/{clusterName}/databases/{databaseName}",
     apiVersion: "2025-02-14",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type DatabasesDeleteInput = typeof DatabasesDeleteInput.Type;
@@ -3341,6 +3361,7 @@ export const DatabasesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Kusto/clusters/{clusterName}/databases/{databaseName}",
     apiVersion: "2025-02-14",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type DatabasesUpdateInput = typeof DatabasesUpdateInput.Type;
@@ -3451,6 +3472,7 @@ export const DataConnectionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Kusto/clusters/{clusterName}/databases/{databaseName}/dataConnections/{dataConnectionName}",
       apiVersion: "2025-02-14",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DataConnectionsCreateOrUpdateInput =
@@ -3540,6 +3562,7 @@ export const DataConnectionsDataConnectionValidationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Kusto/clusters/{clusterName}/databases/{databaseName}/dataConnectionValidation",
       apiVersion: "2025-02-14",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DataConnectionsDataConnectionValidationInput =
@@ -3587,6 +3610,7 @@ export const DataConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Kusto/clusters/{clusterName}/databases/{databaseName}/dataConnections/{dataConnectionName}",
       apiVersion: "2025-02-14",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DataConnectionsDeleteInput = typeof DataConnectionsDeleteInput.Type;
@@ -3764,6 +3788,7 @@ export const DataConnectionsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Kusto/clusters/{clusterName}/databases/{databaseName}/dataConnections/{dataConnectionName}",
       apiVersion: "2025-02-14",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DataConnectionsUpdateInput = typeof DataConnectionsUpdateInput.Type;
@@ -3883,6 +3908,7 @@ export const ManagedPrivateEndpointsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Kusto/clusters/{clusterName}/managedPrivateEndpoints/{managedPrivateEndpointName}",
       apiVersion: "2025-02-14",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedPrivateEndpointsCreateOrUpdateInput =
@@ -3939,6 +3965,7 @@ export const ManagedPrivateEndpointsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Kusto/clusters/{clusterName}/managedPrivateEndpoints/{managedPrivateEndpointName}",
       apiVersion: "2025-02-14",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedPrivateEndpointsDeleteInput =
@@ -4125,6 +4152,7 @@ export const ManagedPrivateEndpointsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Kusto/clusters/{clusterName}/managedPrivateEndpoints/{managedPrivateEndpointName}",
       apiVersion: "2025-02-14",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedPrivateEndpointsUpdateInput =
@@ -4309,6 +4337,7 @@ export const PrivateEndpointConnectionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Kusto/clusters/{clusterName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-02-14",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsCreateOrUpdateInput =
@@ -4365,6 +4394,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Kusto/clusters/{clusterName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-02-14",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =
@@ -4721,6 +4751,7 @@ export const SandboxCustomImagesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Kusto/clusters/{clusterName}/sandboxCustomImages/{sandboxCustomImageName}",
       apiVersion: "2025-02-14",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SandboxCustomImagesCreateOrUpdateInput =
@@ -4777,6 +4808,7 @@ export const SandboxCustomImagesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Kusto/clusters/{clusterName}/sandboxCustomImages/{sandboxCustomImageName}",
       apiVersion: "2025-02-14",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SandboxCustomImagesDeleteInput =
@@ -4961,6 +4993,7 @@ export const SandboxCustomImagesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Kusto/clusters/{clusterName}/sandboxCustomImages/{sandboxCustomImageName}",
       apiVersion: "2025-02-14",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SandboxCustomImagesUpdateInput =
@@ -5092,6 +5125,7 @@ export const ScriptsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Kusto/clusters/{clusterName}/databases/{databaseName}/scripts/{scriptName}",
       apiVersion: "2025-02-14",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ScriptsCreateOrUpdateInput = typeof ScriptsCreateOrUpdateInput.Type;
@@ -5149,6 +5183,7 @@ export const ScriptsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Kusto/clusters/{clusterName}/databases/{databaseName}/scripts/{scriptName}",
     apiVersion: "2025-02-14",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ScriptsDeleteInput = typeof ScriptsDeleteInput.Type;
@@ -5338,6 +5373,7 @@ export const ScriptsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Kusto/clusters/{clusterName}/databases/{databaseName}/scripts/{scriptName}",
     apiVersion: "2025-02-14",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ScriptsUpdateInput = typeof ScriptsUpdateInput.Type;

--- a/packages/azure/src/services/azureactivedirectory.ts
+++ b/packages/azure/src/services/azureactivedirectory.ts
@@ -47,6 +47,7 @@ export const PrivateEndpointConnectionsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.aadiam/privateLinkForAzureAd/{policyName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2020-03-01",
+      longRunning: {},
     }),
   );
 export type PrivateEndpointConnectionsCreateInput =
@@ -78,6 +79,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.aadiam/privateLinkForAzureAd/{policyName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2020-03-01",
+      longRunning: {},
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =
@@ -185,6 +187,7 @@ export const PrivateLinkForAzureAdCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/microsoft.aadiam/privateLinkForAzureAd/{policyName}",
       apiVersion: "2020-03-01",
+      longRunning: {},
     }),
   );
 export type PrivateLinkForAzureAdCreateInput =

--- a/packages/azure/src/services/azurearcdata.ts
+++ b/packages/azure/src/services/azurearcdata.ts
@@ -65,6 +65,7 @@ export const ActiveDirectoryConnectorsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureArcData/dataControllers/{dataControllerName}/activeDirectoryConnectors/{activeDirectoryConnectorName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ActiveDirectoryConnectorsCreateInput =
@@ -111,6 +112,7 @@ export const ActiveDirectoryConnectorsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureArcData/dataControllers/{dataControllerName}/activeDirectoryConnectors/{activeDirectoryConnectorName}",
       apiVersion: "2026-01-01",
+      longRunning: {},
     }),
   );
 export type ActiveDirectoryConnectorsDeleteInput =
@@ -245,6 +247,7 @@ export const DataControllersDeleteDataControllerInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureArcData/dataControllers/{dataControllerName}",
       apiVersion: "2026-01-01",
+      longRunning: {},
     }),
   );
 export type DataControllersDeleteDataControllerInput =
@@ -509,6 +512,7 @@ export const DataControllersPatchDataControllerInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureArcData/dataControllers/{dataControllerName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DataControllersPatchDataControllerInput =
@@ -628,6 +632,7 @@ export const DataControllersPutDataControllerInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureArcData/dataControllers/{dataControllerName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DataControllersPutDataControllerInput =
@@ -697,6 +702,7 @@ export const FailoverGroupsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureArcData/sqlManagedInstances/{sqlManagedInstanceName}/failoverGroups/{failoverGroupName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type FailoverGroupsCreateInput = typeof FailoverGroupsCreateInput.Type;
@@ -742,6 +748,7 @@ export const FailoverGroupsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureArcData/sqlManagedInstances/{sqlManagedInstanceName}/failoverGroups/{failoverGroupName}",
       apiVersion: "2026-01-01",
+      longRunning: {},
     }),
   );
 export type FailoverGroupsDeleteInput = typeof FailoverGroupsDeleteInput.Type;
@@ -945,6 +952,7 @@ export const PostgresInstancesCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureArcData/postgresInstances/{postgresInstanceName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PostgresInstancesCreateInput =
@@ -994,6 +1002,7 @@ export const PostgresInstancesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureArcData/postgresInstances/{postgresInstanceName}",
       apiVersion: "2026-01-01",
+      longRunning: {},
     }),
   );
 export type PostgresInstancesDeleteInput =
@@ -1370,6 +1379,7 @@ export const SqlManagedInstancesCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureArcData/sqlManagedInstances/{sqlManagedInstanceName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SqlManagedInstancesCreateInput =
@@ -1419,6 +1429,7 @@ export const SqlManagedInstancesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureArcData/sqlManagedInstances/{sqlManagedInstanceName}",
       apiVersion: "2026-01-01",
+      longRunning: {},
     }),
   );
 export type SqlManagedInstancesDeleteInput =
@@ -2010,6 +2021,7 @@ export const SqlServerAvailabilityGroupsCreateAvailabilityGroupInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureArcData/sqlServerInstances/{sqlServerInstanceName}/createAvailabilityGroup",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SqlServerAvailabilityGroupsCreateAvailabilityGroupInput =
@@ -2097,6 +2109,7 @@ export const SqlServerAvailabilityGroupsCreateDistributedAvailabilityGroupInput 
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureArcData/sqlServerInstances/{sqlServerInstanceName}/createDistributedAvailabilityGroup",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SqlServerAvailabilityGroupsCreateDistributedAvailabilityGroupInput =
@@ -2278,6 +2291,7 @@ export const SqlServerAvailabilityGroupsCreateManagedInstanceLinkInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureArcData/sqlServerInstances/{sqlServerInstanceName}/createManagedInstanceLink",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SqlServerAvailabilityGroupsCreateManagedInstanceLinkInput =
@@ -2329,6 +2343,7 @@ export const SqlServerAvailabilityGroupsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureArcData/sqlServerInstances/{sqlServerInstanceName}/availabilityGroups/{availabilityGroupName}",
       apiVersion: "2026-01-01",
+      longRunning: {},
     }),
   );
 export type SqlServerAvailabilityGroupsDeleteInput =
@@ -2362,6 +2377,7 @@ export const SqlServerAvailabilityGroupsDeleteMiLinkInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureArcData/sqlServerInstances/{sqlServerInstanceName}/availabilityGroups/{availabilityGroupName}/deleteMiLink",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SqlServerAvailabilityGroupsDeleteMiLinkInput =
@@ -2498,6 +2514,7 @@ export const SqlServerAvailabilityGroupsFailoverMiLinkInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureArcData/sqlServerInstances/{sqlServerInstanceName}/availabilityGroups/{availabilityGroupName}/failoverMiLink",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SqlServerAvailabilityGroupsFailoverMiLinkInput =
@@ -2944,6 +2961,7 @@ export const SqlServerAvailabilityGroupsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureArcData/sqlServerInstances/{sqlServerInstanceName}/availabilityGroups/{availabilityGroupName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SqlServerAvailabilityGroupsUpdateInput =
@@ -3336,6 +3354,7 @@ export const SqlServerDatabasesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureArcData/sqlServerInstances/{sqlServerInstanceName}/databases/{databaseName}",
       apiVersion: "2026-01-01",
+      longRunning: {},
     }),
   );
 export type SqlServerDatabasesDeleteInput =
@@ -3783,6 +3802,7 @@ export const SqlServerDatabasesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureArcData/sqlServerInstances/{sqlServerInstanceName}/databases/{databaseName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SqlServerDatabasesUpdateInput =
@@ -4742,6 +4762,7 @@ export const SqlServerInstancesCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureArcData/sqlServerInstances/{sqlServerInstanceName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SqlServerInstancesCreateInput =
@@ -4789,6 +4810,7 @@ export const SqlServerInstancesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureArcData/sqlServerInstances/{sqlServerInstanceName}",
       apiVersion: "2026-01-01",
+      longRunning: {},
     }),
   );
 export type SqlServerInstancesDeleteInput =
@@ -4935,6 +4957,7 @@ export const SqlServerInstancesGetBestPracticesAssessmentInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureArcData/sqlServerInstances/{sqlServerInstanceName}/getBestPracticesAssessment",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SqlServerInstancesGetBestPracticesAssessmentInput =
@@ -5099,6 +5122,7 @@ export const SqlServerInstancesGetTelemetryInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureArcData/sqlServerInstances/{sqlServerInstanceName}/getTelemetry",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SqlServerInstancesGetTelemetryInput =
@@ -5489,6 +5513,7 @@ export const SqlServerInstancesRunManagedInstanceLinkAssessmentInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureArcData/sqlServerInstances/{sqlServerInstanceName}/runManagedInstanceLinkAssessment",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SqlServerInstancesRunManagedInstanceLinkAssessmentInput =
@@ -6190,6 +6215,7 @@ export const SqlServerInstancesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureArcData/sqlServerInstances/{sqlServerInstanceName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SqlServerInstancesUpdateInput =

--- a/packages/azure/src/services/azuredatatransfer.ts
+++ b/packages/azure/src/services/azuredatatransfer.ts
@@ -198,6 +198,7 @@ export const ConnectionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureDataTransfer/connections/{connectionName}",
       apiVersion: "2025-05-21",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ConnectionsCreateOrUpdateInput =
@@ -254,6 +255,7 @@ export const ConnectionsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureDataTransfer/connections/{connectionName}",
     apiVersion: "2025-05-21",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ConnectionsDeleteInput = typeof ConnectionsDeleteInput.Type;
@@ -336,6 +338,7 @@ export const ConnectionsLinkInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureDataTransfer/connections/{connectionName}/link",
     apiVersion: "2025-05-21",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ConnectionsLinkInput = typeof ConnectionsLinkInput.Type;
@@ -541,6 +544,7 @@ export const ConnectionsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureDataTransfer/connections/{connectionName}",
     apiVersion: "2025-05-21",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ConnectionsUpdateInput = typeof ConnectionsUpdateInput.Type;
@@ -724,6 +728,7 @@ export const FlowsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureDataTransfer/connections/{connectionName}/flows/{flowName}",
       apiVersion: "2025-05-21",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type FlowsCreateOrUpdateInput = typeof FlowsCreateOrUpdateInput.Type;
@@ -776,6 +781,7 @@ export const FlowsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureDataTransfer/connections/{connectionName}/flows/{flowName}",
     apiVersion: "2025-05-21",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type FlowsDeleteInput = typeof FlowsDeleteInput.Type;
@@ -809,6 +815,7 @@ export const FlowsDisableInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureDataTransfer/connections/{connectionName}/flows/{flowName}/disable",
     apiVersion: "2025-05-21",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type FlowsDisableInput = typeof FlowsDisableInput.Type;
@@ -860,6 +867,7 @@ export const FlowsEnableInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureDataTransfer/connections/{connectionName}/flows/{flowName}/enable",
     apiVersion: "2025-05-21",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type FlowsEnableInput = typeof FlowsEnableInput.Type;
@@ -912,6 +920,7 @@ export const FlowsGeneratePassphraseInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureDataTransfer/connections/{connectionName}/flows/{flowName}/generatePassphrase",
       apiVersion: "2025-05-21",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type FlowsGeneratePassphraseInput =
@@ -1182,6 +1191,7 @@ export const FlowsLinkInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureDataTransfer/connections/{connectionName}/flows/{flowName}/link",
     apiVersion: "2025-05-21",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type FlowsLinkInput = typeof FlowsLinkInput.Type;
@@ -1304,6 +1314,7 @@ export const FlowsSetDestinationEndpointPortsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureDataTransfer/connections/{connectionName}/flows/{flowName}/setDestinationEndpointPorts",
       apiVersion: "2025-05-21",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type FlowsSetDestinationEndpointPortsInput =
@@ -1361,6 +1372,7 @@ export const FlowsSetDestinationEndpointsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureDataTransfer/connections/{connectionName}/flows/{flowName}/setDestinationEndpoints",
       apiVersion: "2025-05-21",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type FlowsSetDestinationEndpointsInput =
@@ -1418,6 +1430,7 @@ export const FlowsSetPassphraseInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureDataTransfer/connections/{connectionName}/flows/{flowName}/setPassphrase",
       apiVersion: "2025-05-21",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type FlowsSetPassphraseInput = typeof FlowsSetPassphraseInput.Type;
@@ -1472,6 +1485,7 @@ export const FlowsSetSourceAddressesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureDataTransfer/connections/{connectionName}/flows/{flowName}/setSourceAddresses",
       apiVersion: "2025-05-21",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type FlowsSetSourceAddressesInput =
@@ -1550,6 +1564,7 @@ export const FlowsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureDataTransfer/connections/{connectionName}/flows/{flowName}",
     apiVersion: "2025-05-21",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type FlowsUpdateInput = typeof FlowsUpdateInput.Type;
@@ -2087,6 +2102,7 @@ export const PipelinesApproveConnectionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureDataTransfer/pipelines/{pipelineName}/approveConnection",
       apiVersion: "2025-05-21",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PipelinesApproveConnectionInput =
@@ -2279,6 +2295,7 @@ export const PipelinesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureDataTransfer/pipelines/{pipelineName}",
       apiVersion: "2025-05-21",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PipelinesCreateOrUpdateInput =
@@ -2333,6 +2350,7 @@ export const PipelinesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureDataTransfer/pipelines/{pipelineName}",
     apiVersion: "2025-05-21",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type PipelinesDeleteInput = typeof PipelinesDeleteInput.Type;
@@ -2369,6 +2387,7 @@ export const PipelinesExecuteActionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureDataTransfer/pipelines/{pipelineName}/executeAction",
       apiVersion: "2025-05-21",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PipelinesExecuteActionInput =
@@ -2608,6 +2627,7 @@ export const PipelinesRejectConnectionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureDataTransfer/pipelines/{pipelineName}/rejectConnection",
       apiVersion: "2025-05-21",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PipelinesRejectConnectionInput =
@@ -2708,6 +2728,7 @@ export const PipelinesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureDataTransfer/pipelines/{pipelineName}",
     apiVersion: "2025-05-21",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type PipelinesUpdateInput = typeof PipelinesUpdateInput.Type;

--- a/packages/azure/src/services/azurefleet.ts
+++ b/packages/azure/src/services/azurefleet.ts
@@ -1605,6 +1605,7 @@ export const FleetsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureFleet/fleets/{fleetName}",
       apiVersion: "2024-11-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type FleetsCreateOrUpdateInput = typeof FleetsCreateOrUpdateInput.Type;
@@ -1657,6 +1658,7 @@ export const FleetsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureFleet/fleets/{fleetName}",
     apiVersion: "2024-11-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type FleetsDeleteInput = typeof FleetsDeleteInput.Type;
@@ -3492,6 +3494,7 @@ export const FleetsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureFleet/fleets/{fleetName}",
     apiVersion: "2024-11-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type FleetsUpdateInput = typeof FleetsUpdateInput.Type;

--- a/packages/azure/src/services/azurelargeinstance.ts
+++ b/packages/azure/src/services/azurelargeinstance.ts
@@ -209,6 +209,7 @@ export const AzureLargeInstanceRestartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureLargeInstance/azureLargeInstances/{azureLargeInstanceName}/restart",
       apiVersion: "2024-04-10",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AzureLargeInstanceRestartInput =
@@ -300,6 +301,7 @@ export const AzureLargeInstanceShutdownInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureLargeInstance/azureLargeInstances/{azureLargeInstanceName}/shutdown",
       apiVersion: "2024-04-10",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AzureLargeInstanceShutdownInput =
@@ -391,6 +393,7 @@ export const AzureLargeInstanceStartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureLargeInstance/azureLargeInstances/{azureLargeInstanceName}/start",
       apiVersion: "2024-04-10",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AzureLargeInstanceStartInput =

--- a/packages/azure/src/services/azurestackhci.ts
+++ b/packages/azure/src/services/azurestackhci.ts
@@ -236,6 +236,7 @@ export const ArcSettingsCreateIdentityInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/clusters/{clusterName}/arcSettings/{arcSettingName}/createArcIdentity",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ArcSettingsCreateIdentityInput =
@@ -285,6 +286,7 @@ export const ArcSettingsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/clusters/{clusterName}/arcSettings/{arcSettingName}",
     apiVersion: "2026-02-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type ArcSettingsDeleteInput = typeof ArcSettingsDeleteInput.Type;
@@ -414,6 +416,7 @@ export const ArcSettingsInitializeDisableProcessInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/clusters/{clusterName}/arcSettings/{arcSettingName}/initializeDisableProcess",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ArcSettingsInitializeDisableProcessInput =
@@ -527,6 +530,7 @@ export const ArcSettingsReconcileInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/clusters/{clusterName}/arcSettings/{arcSettingName}/reconcile",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ArcSettingsReconcileInput = typeof ArcSettingsReconcileInput.Type;
@@ -664,6 +668,7 @@ export const ClustersConfigureRemoteSupportInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/clusters/{clusterName}/configureRemoteSupport",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ClustersConfigureRemoteSupportInput =
@@ -1032,6 +1037,7 @@ export const ClustersCreateIdentityInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/clusters/{clusterName}/createClusterIdentity",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ClustersCreateIdentityInput =
@@ -1077,6 +1083,7 @@ export const ClustersDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/clusters/{clusterName}",
     apiVersion: "2026-02-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ClustersDeleteInput = typeof ClustersDeleteInput.Type;
@@ -1116,6 +1123,7 @@ export const ClustersExtendSoftwareAssuranceBenefitInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/clusters/{clusterName}/extendSoftwareAssuranceBenefit",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ClustersExtendSoftwareAssuranceBenefitInput =
@@ -1359,6 +1367,7 @@ export const ClustersTriggerLogCollectionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/clusters/{clusterName}/triggerLogCollection",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ClustersTriggerLogCollectionInput =
@@ -1509,6 +1518,7 @@ export const ClustersUpdateSecretsLocationsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/clusters/{clusterName}/updateSecretsLocations",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ClustersUpdateSecretsLocationsInput =
@@ -1568,6 +1578,7 @@ export const ClustersUploadCertificateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/clusters/{clusterName}/uploadCertificate",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ClustersUploadCertificateInput =
@@ -1939,6 +1950,7 @@ export const DeploymentSettingsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/clusters/{clusterName}/deploymentSettings/{deploymentSettingsName}",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DeploymentSettingsCreateOrUpdateInput =
@@ -1995,6 +2007,7 @@ export const DeploymentSettingsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/clusters/{clusterName}/deploymentSettings/{deploymentSettingsName}",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeploymentSettingsDeleteInput =
@@ -2159,6 +2172,7 @@ export const EdgeDeviceJobsCreateOrUpdateInput =
       method: "PUT",
       path: "/{resourceUri}/providers/Microsoft.AzureStackHCI/edgeDevices/{edgeDeviceName}/jobs/{jobsName}",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type EdgeDeviceJobsCreateOrUpdateInput =
@@ -2213,6 +2227,7 @@ export const EdgeDeviceJobsDeleteInput =
       method: "DELETE",
       path: "/{resourceUri}/providers/Microsoft.AzureStackHCI/edgeDevices/{edgeDeviceName}/jobs/{jobsName}",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type EdgeDeviceJobsDeleteInput = typeof EdgeDeviceJobsDeleteInput.Type;
@@ -2367,6 +2382,7 @@ export const EdgeDevicesCreateOrUpdateInput =
       method: "PUT",
       path: "/{resourceUri}/providers/Microsoft.AzureStackHCI/edgeDevices/{edgeDeviceName}",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type EdgeDevicesCreateOrUpdateInput =
@@ -2421,6 +2437,7 @@ export const EdgeDevicesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/{resourceUri}/providers/Microsoft.AzureStackHCI/edgeDevices/{edgeDeviceName}",
     apiVersion: "2026-02-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type EdgeDevicesDeleteInput = typeof EdgeDevicesDeleteInput.Type;
@@ -2550,6 +2567,7 @@ export const EdgeDevicesValidateInput =
       method: "POST",
       path: "/{resourceUri}/providers/Microsoft.AzureStackHCI/edgeDevices/{edgeDeviceName}/validate",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type EdgeDevicesValidateInput = typeof EdgeDevicesValidateInput.Type;
@@ -2694,6 +2712,7 @@ export const ExtensionsCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/clusters/{clusterName}/arcSettings/{arcSettingName}/extensions/{extensionName}",
     apiVersion: "2026-02-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type ExtensionsCreateInput = typeof ExtensionsCreateInput.Type;
@@ -2749,6 +2768,7 @@ export const ExtensionsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/clusters/{clusterName}/arcSettings/{arcSettingName}/extensions/{extensionName}",
     apiVersion: "2026-02-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type ExtensionsDeleteInput = typeof ExtensionsDeleteInput.Type;
@@ -2921,6 +2941,7 @@ export const ExtensionsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/clusters/{clusterName}/arcSettings/{arcSettingName}/extensions/{extensionName}",
     apiVersion: "2026-02-01",
+    longRunning: { finalStateVia: "original-uri" },
   }),
 );
 export type ExtensionsUpdateInput = typeof ExtensionsUpdateInput.Type;
@@ -2979,6 +3000,7 @@ export const ExtensionsUpgradeInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/clusters/{clusterName}/arcSettings/{arcSettingName}/extensions/{extensionName}/upgrade",
     apiVersion: "2026-02-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type ExtensionsUpgradeInput = typeof ExtensionsUpgradeInput.Type;
@@ -3084,6 +3106,7 @@ export const GalleryImagesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/galleryImages/{galleryImageName}",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type GalleryImagesCreateOrUpdateInput =
@@ -3137,6 +3160,7 @@ export const GalleryImagesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/galleryImages/{galleryImageName}",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type GalleryImagesDeleteInput = typeof GalleryImagesDeleteInput.Type;
@@ -3351,6 +3375,7 @@ export const GalleryImagesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/galleryImages/{galleryImageName}",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type GalleryImagesUpdateInput = typeof GalleryImagesUpdateInput.Type;
@@ -3424,6 +3449,7 @@ export const GuestAgentCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/{resourceUri}/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default/guestAgents/default",
     apiVersion: "2024-01-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type GuestAgentCreateInput = typeof GuestAgentCreateInput.Type;
@@ -3472,6 +3498,7 @@ export const GuestAgentDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/{resourceUri}/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default/guestAgents/default",
     apiVersion: "2024-01-01",
+    longRunning: {},
   }),
 );
 export type GuestAgentDeleteInput = typeof GuestAgentDeleteInput.Type;
@@ -3826,6 +3853,7 @@ export const LogicalNetworksCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/logicalNetworks/{logicalNetworkName}",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type LogicalNetworksCreateOrUpdateInput =
@@ -3878,6 +3906,7 @@ export const LogicalNetworksDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/logicalNetworks/{logicalNetworkName}",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type LogicalNetworksDeleteInput = typeof LogicalNetworksDeleteInput.Type;
@@ -4095,6 +4124,7 @@ export const LogicalNetworksUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/logicalNetworks/{logicalNetworkName}",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type LogicalNetworksUpdateInput = typeof LogicalNetworksUpdateInput.Type;
@@ -4218,6 +4248,7 @@ export const MarketplaceGalleryImagesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/marketplaceGalleryImages/{marketplaceGalleryImageName}",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type MarketplaceGalleryImagesCreateOrUpdateInput =
@@ -4270,6 +4301,7 @@ export const MarketplaceGalleryImagesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/marketplaceGalleryImages/{marketplaceGalleryImageName}",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type MarketplaceGalleryImagesDeleteInput =
@@ -4494,6 +4526,7 @@ export const MarketplaceGalleryImagesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/marketplaceGalleryImages/{marketplaceGalleryImageName}",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type MarketplaceGalleryImagesUpdateInput =
@@ -4607,6 +4640,7 @@ export const NetworkInterfacesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/networkInterfaces/{networkInterfaceName}",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NetworkInterfacesCreateOrUpdateInput =
@@ -4659,6 +4693,7 @@ export const NetworkInterfacesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/networkInterfaces/{networkInterfaceName}",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NetworkInterfacesDeleteInput =
@@ -4883,6 +4918,7 @@ export const NetworkInterfacesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/networkInterfaces/{networkInterfaceName}",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NetworkInterfacesUpdateInput =
@@ -5233,6 +5269,7 @@ export const SecuritySettingsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/clusters/{clusterName}/securitySettings/{securitySettingsName}",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SecuritySettingsCreateOrUpdateInput =
@@ -5289,6 +5326,7 @@ export const SecuritySettingsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/clusters/{clusterName}/securitySettings/{securitySettingsName}",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SecuritySettingsDeleteInput =
@@ -5604,6 +5642,7 @@ export const StorageContainersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/storageContainers/{storageContainerName}",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type StorageContainersCreateOrUpdateInput =
@@ -5656,6 +5695,7 @@ export const StorageContainersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/storageContainers/{storageContainerName}",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type StorageContainersDeleteInput =
@@ -5880,6 +5920,7 @@ export const StorageContainersUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/storageContainers/{storageContainerName}",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type StorageContainersUpdateInput =
@@ -5935,6 +5976,7 @@ export const UpdateRunsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/clusters/{clusterName}/updates/{updateName}/updateRuns/{updateRunName}",
     apiVersion: "2026-02-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type UpdateRunsDeleteInput = typeof UpdateRunsDeleteInput.Type;
@@ -6177,6 +6219,7 @@ export const UpdatesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/clusters/{clusterName}/updates/{updateName}",
     apiVersion: "2026-02-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type UpdatesDeleteInput = typeof UpdatesDeleteInput.Type;
@@ -6315,6 +6358,7 @@ export const UpdatesPostInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/clusters/{clusterName}/updates/{updateName}/apply",
     apiVersion: "2026-02-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type UpdatesPostInput = typeof UpdatesPostInput.Type;
@@ -6549,6 +6593,7 @@ export const UpdateSummariesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/clusters/{clusterName}/updateSummaries/default",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type UpdateSummariesDeleteInput = typeof UpdateSummariesDeleteInput.Type;
@@ -7034,6 +7079,7 @@ export const VirtualHardDisksCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/virtualHardDisks/{virtualHardDiskName}",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualHardDisksCreateOrUpdateInput =
@@ -7086,6 +7132,7 @@ export const VirtualHardDisksDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/virtualHardDisks/{virtualHardDiskName}",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualHardDisksDeleteInput =
@@ -7307,6 +7354,7 @@ export const VirtualHardDisksUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/virtualHardDisks/{virtualHardDiskName}",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualHardDisksUpdateInput =
@@ -7620,6 +7668,7 @@ export const VirtualMachineInstancesCreateOrUpdateInput =
       method: "PUT",
       path: "/{resourceUri}/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualMachineInstancesCreateOrUpdateInput =
@@ -7667,6 +7716,7 @@ export const VirtualMachineInstancesDeleteInput =
       method: "DELETE",
       path: "/{resourceUri}/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualMachineInstancesDeleteInput =
@@ -7809,6 +7859,7 @@ export const VirtualMachineInstancesRestartInput =
       method: "POST",
       path: "/{resourceUri}/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default/restart",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineInstancesRestartInput =
@@ -7856,6 +7907,7 @@ export const VirtualMachineInstancesStartInput =
       method: "POST",
       path: "/{resourceUri}/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default/start",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineInstancesStartInput =
@@ -7903,6 +7955,7 @@ export const VirtualMachineInstancesStopInput =
       method: "POST",
       path: "/{resourceUri}/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default/stop",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineInstancesStopInput =
@@ -8035,6 +8088,7 @@ export const VirtualMachineInstancesUpdateInput =
       method: "PATCH",
       path: "/{resourceUri}/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualMachineInstancesUpdateInput =

--- a/packages/azure/src/services/batch.ts
+++ b/packages/azure/src/services/batch.ts
@@ -687,6 +687,7 @@ export const BatchAccountCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Batch/batchAccounts/{accountName}",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BatchAccountCreateInput = typeof BatchAccountCreateInput.Type;
@@ -738,6 +739,7 @@ export const BatchAccountDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Batch/batchAccounts/{accountName}",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BatchAccountDeleteInput = typeof BatchAccountDeleteInput.Type;
@@ -1648,6 +1650,7 @@ export const NetworkSecurityPerimeterReconcileConfigurationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Batch/batchAccounts/{accountName}/networkSecurityPerimeterConfigurations/{networkSecurityPerimeterConfigurationName}/reconcile",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkSecurityPerimeterReconcileConfigurationInput =
@@ -2374,6 +2377,7 @@ export const PoolDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Batch/batchAccounts/{accountName}/pools/{poolName}",
     apiVersion: "2025-06-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type PoolDeleteInput = typeof PoolDeleteInput.Type;
@@ -3299,6 +3303,7 @@ export const PrivateEndpointConnectionDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Batch/batchAccounts/{accountName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PrivateEndpointConnectionDeleteInput =
@@ -3498,6 +3503,7 @@ export const PrivateEndpointConnectionUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Batch/batchAccounts/{accountName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PrivateEndpointConnectionUpdateInput =

--- a/packages/azure/src/services/billing.ts
+++ b/packages/azure/src/services/billing.ts
@@ -233,6 +233,7 @@ export const AssociatedTenantsCreateOrUpdateInput =
       method: "PUT",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/associatedTenants/{associatedTenantName}",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AssociatedTenantsCreateOrUpdateInput =
@@ -285,6 +286,7 @@ export const AssociatedTenantsDeleteInput =
       method: "DELETE",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/associatedTenants/{associatedTenantName}",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AssociatedTenantsDeleteInput =
@@ -551,6 +553,7 @@ export const BillingAccountsAddPaymentTermsInput =
       method: "POST",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/addPaymentTerms",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BillingAccountsAddPaymentTermsInput =
@@ -601,6 +604,7 @@ export const BillingAccountsCancelPaymentTermsInput =
       method: "POST",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/cancelPaymentTerms",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BillingAccountsCancelPaymentTermsInput =
@@ -1089,6 +1093,7 @@ export const BillingAccountsUpdateInput =
       method: "PATCH",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BillingAccountsUpdateInput = typeof BillingAccountsUpdateInput.Type;
@@ -1937,6 +1942,7 @@ export const BillingProfilesCreateOrUpdateInput =
       method: "PUT",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/billingProfiles/{billingProfileName}",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BillingProfilesCreateOrUpdateInput =
@@ -1989,6 +1995,7 @@ export const BillingProfilesDeleteInput =
       method: "DELETE",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/billingProfiles/{billingProfileName}",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BillingProfilesDeleteInput = typeof BillingProfilesDeleteInput.Type;
@@ -2661,6 +2668,7 @@ export const BillingRequestsCreateOrUpdateInput =
       method: "PUT",
       path: "/providers/Microsoft.Billing/billingRequests/{billingRequestName}",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BillingRequestsCreateOrUpdateInput =
@@ -3206,6 +3214,7 @@ export const BillingRoleAssignmentsCreateByBillingAccountInput =
       method: "POST",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/createBillingRoleAssignment",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BillingRoleAssignmentsCreateByBillingAccountInput =
@@ -3311,6 +3320,7 @@ export const BillingRoleAssignmentsCreateByBillingProfileInput =
       method: "POST",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/billingProfiles/{billingProfileName}/createBillingRoleAssignment",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BillingRoleAssignmentsCreateByBillingProfileInput =
@@ -3418,6 +3428,7 @@ export const BillingRoleAssignmentsCreateByCustomerInput =
       method: "POST",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/billingProfiles/{billingProfileName}/customers/{customerName}/createBillingRoleAssignment",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BillingRoleAssignmentsCreateByCustomerInput =
@@ -3526,6 +3537,7 @@ export const BillingRoleAssignmentsCreateByInvoiceSectionInput =
       method: "POST",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/billingProfiles/{billingProfileName}/invoiceSections/{invoiceSectionName}/createBillingRoleAssignment",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BillingRoleAssignmentsCreateByInvoiceSectionInput =
@@ -3638,6 +3650,7 @@ export const BillingRoleAssignmentsCreateOrUpdateByBillingAccountInput =
       method: "PUT",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/billingRoleAssignments/{billingRoleAssignmentName}",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BillingRoleAssignmentsCreateOrUpdateByBillingAccountInput =
@@ -3750,6 +3763,7 @@ export const BillingRoleAssignmentsCreateOrUpdateByDepartmentInput =
       method: "PUT",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/departments/{departmentName}/billingRoleAssignments/{billingRoleAssignmentName}",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BillingRoleAssignmentsCreateOrUpdateByDepartmentInput =
@@ -3863,6 +3877,7 @@ export const BillingRoleAssignmentsCreateOrUpdateByEnrollmentAccountInput =
       method: "PUT",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/enrollmentAccounts/{enrollmentAccountName}/billingRoleAssignments/{billingRoleAssignmentName}",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BillingRoleAssignmentsCreateOrUpdateByEnrollmentAccountInput =
@@ -4889,6 +4904,7 @@ export const BillingRoleAssignmentsResolveByBillingAccountInput =
       method: "POST",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/resolveBillingRoleAssignments",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BillingRoleAssignmentsResolveByBillingAccountInput =
@@ -4959,6 +4975,7 @@ export const BillingRoleAssignmentsResolveByBillingProfileInput =
       method: "POST",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/billingProfiles/{billingProfileName}/resolveBillingRoleAssignments",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BillingRoleAssignmentsResolveByBillingProfileInput =
@@ -5031,6 +5048,7 @@ export const BillingRoleAssignmentsResolveByCustomerInput =
       method: "POST",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/billingProfiles/{billingProfileName}/customers/{customerName}/resolveBillingRoleAssignments",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BillingRoleAssignmentsResolveByCustomerInput =
@@ -5104,6 +5122,7 @@ export const BillingRoleAssignmentsResolveByInvoiceSectionInput =
       method: "POST",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/billingProfiles/{billingProfileName}/invoiceSections/{invoiceSectionName}/resolveBillingRoleAssignments",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BillingRoleAssignmentsResolveByInvoiceSectionInput =
@@ -6061,6 +6080,7 @@ export const BillingSubscriptionsAliasesCreateOrUpdateInput =
       method: "PUT",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/billingSubscriptionAliases/{aliasName}",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BillingSubscriptionsAliasesCreateOrUpdateInput =
@@ -6246,6 +6266,7 @@ export const BillingSubscriptionsCancelInput =
       method: "POST",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/billingSubscriptions/{billingSubscriptionName}/cancel",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BillingSubscriptionsCancelInput =
@@ -6281,6 +6302,7 @@ export const BillingSubscriptionsDeleteInput =
       method: "DELETE",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/billingSubscriptions/{billingSubscriptionName}",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BillingSubscriptionsDeleteInput =
@@ -6947,6 +6969,7 @@ export const BillingSubscriptionsMergeInput =
       method: "POST",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/billingSubscriptions/{billingSubscriptionName}/merge",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BillingSubscriptionsMergeInput =
@@ -7002,6 +7025,7 @@ export const BillingSubscriptionsMoveInput =
       method: "POST",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/billingSubscriptions/{billingSubscriptionName}/move",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BillingSubscriptionsMoveInput =
@@ -7060,6 +7084,7 @@ export const BillingSubscriptionsSplitInput =
       method: "POST",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/billingSubscriptions/{billingSubscriptionName}/split",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BillingSubscriptionsSplitInput =
@@ -7270,6 +7295,7 @@ export const BillingSubscriptionsUpdateInput =
       method: "PATCH",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/billingSubscriptions/{billingSubscriptionName}",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BillingSubscriptionsUpdateInput =
@@ -8043,6 +8069,7 @@ export const InvoicesAmendInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/invoices/{invoiceName}/amend",
     apiVersion: "2024-04-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type InvoicesAmendInput = typeof InvoicesAmendInput.Type;
@@ -8074,6 +8101,7 @@ export const InvoicesDownloadByBillingAccountInput =
       method: "POST",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/invoices/{invoiceName}/download",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type InvoicesDownloadByBillingAccountInput =
@@ -8113,6 +8141,7 @@ export const InvoicesDownloadByBillingSubscriptionInput =
       method: "POST",
       path: "/providers/Microsoft.Billing/billingAccounts/default/billingSubscriptions/{subscriptionId}/invoices/{invoiceName}/download",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type InvoicesDownloadByBillingSubscriptionInput =
@@ -8150,6 +8179,7 @@ export const InvoicesDownloadDocumentsByBillingAccountInput =
       method: "POST",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/downloadDocuments",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type InvoicesDownloadDocumentsByBillingAccountInput =
@@ -8185,6 +8215,7 @@ export const InvoicesDownloadDocumentsByBillingSubscriptionInput =
       method: "POST",
       path: "/providers/Microsoft.Billing/billingAccounts/default/billingSubscriptions/{subscriptionId}/downloadDocuments",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type InvoicesDownloadDocumentsByBillingSubscriptionInput =
@@ -8221,6 +8252,7 @@ export const InvoicesDownloadSummaryByBillingAccountInput =
       method: "POST",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/invoices/{invoiceName}/downloadSummary",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type InvoicesDownloadSummaryByBillingAccountInput =
@@ -8303,6 +8335,7 @@ export const InvoiceSectionsCreateOrUpdateInput =
       method: "PUT",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/billingProfiles/{billingProfileName}/invoiceSections/{invoiceSectionName}",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type InvoiceSectionsCreateOrUpdateInput =
@@ -8357,6 +8390,7 @@ export const InvoiceSectionsDeleteInput =
       method: "DELETE",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/billingProfiles/{billingProfileName}/invoiceSections/{invoiceSectionName}",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type InvoiceSectionsDeleteInput = typeof InvoiceSectionsDeleteInput.Type;
@@ -9714,6 +9748,7 @@ export const PoliciesCreateOrUpdateByBillingAccountInput =
       method: "PUT",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/policies/default",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PoliciesCreateOrUpdateByBillingAccountInput =
@@ -9841,6 +9876,7 @@ export const PoliciesCreateOrUpdateByBillingProfileInput =
       method: "PUT",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/billingProfiles/{billingProfileName}/policies/default",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PoliciesCreateOrUpdateByBillingProfileInput =
@@ -9931,6 +9967,7 @@ export const PoliciesCreateOrUpdateByCustomerInput =
       method: "PUT",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/billingProfiles/{billingProfileName}/customers/{customerName}/policies/default",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PoliciesCreateOrUpdateByCustomerInput =
@@ -10021,6 +10058,7 @@ export const PoliciesCreateOrUpdateByCustomerAtBillingAccountInput =
       method: "PUT",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/customers/{customerName}/policies/default",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PoliciesCreateOrUpdateByCustomerAtBillingAccountInput =
@@ -10700,6 +10738,7 @@ export const ProductsMoveInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/products/{productName}/move",
     apiVersion: "2024-04-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ProductsMoveInput = typeof ProductsMoveInput.Type;
@@ -11739,6 +11778,7 @@ export const ReservationsUpdateByBillingAccountInput =
       method: "PATCH",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/reservationOrders/{reservationOrderId}/reservations/{reservationId}",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ReservationsUpdateByBillingAccountInput =
@@ -12184,6 +12224,7 @@ export const SavingsPlansUpdateByBillingAccountInput =
       method: "PATCH",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/savingsPlanOrders/{savingsPlanOrderId}/savingsPlans/{savingsPlanId}",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SavingsPlansUpdateByBillingAccountInput =
@@ -12735,6 +12776,7 @@ export const TransactionsTransactionsDownloadByInvoiceInput =
       method: "POST",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/invoices/{invoiceName}/transactionsDownload",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type TransactionsTransactionsDownloadByInvoiceInput =

--- a/packages/azure/src/services/billingbenefits.ts
+++ b/packages/azure/src/services/billingbenefits.ts
@@ -63,6 +63,7 @@ export const ReservationOrderAliasCreateInput =
       method: "PUT",
       path: "/providers/Microsoft.BillingBenefits/reservationOrderAliases/{reservationOrderAliasName}",
       apiVersion: "2022-11-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ReservationOrderAliasCreateInput =
@@ -349,6 +350,7 @@ export const SavingsPlanOrderAliasCreateInput =
       method: "PUT",
       path: "/providers/Microsoft.BillingBenefits/savingsPlanOrderAliases/{savingsPlanOrderAliasName}",
       apiVersion: "2022-11-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SavingsPlanOrderAliasCreateInput =

--- a/packages/azure/src/services/botservice.ts
+++ b/packages/azure/src/services/botservice.ts
@@ -1221,6 +1221,7 @@ export const OperationResultsGetInput =
       method: "GET",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.BotService/operationresults/{operationResultId}",
       apiVersion: "2022-09-15",
+      longRunning: {},
     }),
   );
 export type OperationResultsGetInput = typeof OperationResultsGetInput.Type;

--- a/packages/azure/src/services/cdn.ts
+++ b/packages/azure/src/services/cdn.ts
@@ -119,6 +119,7 @@ export const AFDCustomDomainsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/customDomains/{customDomainName}",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AFDCustomDomainsCreateInput =
@@ -176,6 +177,7 @@ export const AFDCustomDomainsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/customDomains/{customDomainName}",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AFDCustomDomainsDeleteInput =
@@ -337,6 +339,7 @@ export const AFDCustomDomainsRefreshValidationTokenInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/customDomains/{customDomainName}/refreshValidationToken",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AFDCustomDomainsRefreshValidationTokenInput =
@@ -439,6 +442,7 @@ export const AFDCustomDomainsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/customDomains/{customDomainName}",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AFDCustomDomainsUpdateInput =
@@ -525,6 +529,7 @@ export const AFDEndpointsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/afdEndpoints/{endpointName}",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AFDEndpointsCreateInput = typeof AFDEndpointsCreateInput.Type;
@@ -578,6 +583,7 @@ export const AFDEndpointsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/afdEndpoints/{endpointName}",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AFDEndpointsDeleteInput = typeof AFDEndpointsDeleteInput.Type;
@@ -787,6 +793,7 @@ export const AFDEndpointsPurgeContentInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/afdEndpoints/{endpointName}/purge",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AFDEndpointsPurgeContentInput =
@@ -833,6 +840,7 @@ export const AFDEndpointsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/afdEndpoints/{endpointName}",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AFDEndpointsUpdateInput = typeof AFDEndpointsUpdateInput.Type;
@@ -987,6 +995,7 @@ export const AFDOriginGroupsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/originGroups/{originGroupName}",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AFDOriginGroupsCreateInput = typeof AFDOriginGroupsCreateInput.Type;
@@ -1043,6 +1052,7 @@ export const AFDOriginGroupsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/originGroups/{originGroupName}",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AFDOriginGroupsDeleteInput = typeof AFDOriginGroupsDeleteInput.Type;
@@ -1301,6 +1311,7 @@ export const AFDOriginGroupsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/originGroups/{originGroupName}",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AFDOriginGroupsUpdateInput = typeof AFDOriginGroupsUpdateInput.Type;
@@ -1408,6 +1419,7 @@ export const AFDOriginsCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/originGroups/{originGroupName}/origins/{originName}",
     apiVersion: "2025-06-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type AFDOriginsCreateInput = typeof AFDOriginsCreateInput.Type;
@@ -1463,6 +1475,7 @@ export const AFDOriginsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/originGroups/{originGroupName}/origins/{originName}",
     apiVersion: "2025-06-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type AFDOriginsDeleteInput = typeof AFDOriginsDeleteInput.Type;
@@ -1662,6 +1675,7 @@ export const AFDOriginsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/originGroups/{originGroupName}/origins/{originName}",
     apiVersion: "2025-06-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type AFDOriginsUpdateInput = typeof AFDOriginsUpdateInput.Type;
@@ -1869,6 +1883,7 @@ export const AFDProfilesUpgradeInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/upgrade",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AFDProfilesUpgradeInput = typeof AFDProfilesUpgradeInput.Type;
@@ -2116,6 +2131,7 @@ export const CustomDomainsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/endpoints/{endpointName}/customDomains/{customDomainName}",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CustomDomainsCreateInput = typeof CustomDomainsCreateInput.Type;
@@ -2171,6 +2187,7 @@ export const CustomDomainsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/endpoints/{endpointName}/customDomains/{customDomainName}",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CustomDomainsDeleteInput = typeof CustomDomainsDeleteInput.Type;
@@ -2208,6 +2225,7 @@ export const CustomDomainsDisableCustomHttpsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/endpoints/{endpointName}/customDomains/{customDomainName}/disableCustomHttps",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CustomDomainsDisableCustomHttpsInput =
@@ -2271,6 +2289,7 @@ export const CustomDomainsEnableCustomHttpsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/endpoints/{endpointName}/customDomains/{customDomainName}/enableCustomHttps",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CustomDomainsEnableCustomHttpsInput =
@@ -2620,6 +2639,7 @@ export const EndpointsCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/endpoints/{endpointName}",
     apiVersion: "2025-06-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type EndpointsCreateInput = typeof EndpointsCreateInput.Type;
@@ -2671,6 +2691,7 @@ export const EndpointsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/endpoints/{endpointName}",
     apiVersion: "2025-06-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type EndpointsDeleteInput = typeof EndpointsDeleteInput.Type;
@@ -2876,6 +2897,7 @@ export const EndpointsLoadContentInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/endpoints/{endpointName}/load",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type EndpointsLoadContentInput = typeof EndpointsLoadContentInput.Type;
@@ -2914,6 +2936,7 @@ export const EndpointsPurgeContentInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/endpoints/{endpointName}/purge",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type EndpointsPurgeContentInput = typeof EndpointsPurgeContentInput.Type;
@@ -2951,6 +2974,7 @@ export const EndpointsStartInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/endpoints/{endpointName}/start",
     apiVersion: "2025-06-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type EndpointsStartInput = typeof EndpointsStartInput.Type;
@@ -3002,6 +3026,7 @@ export const EndpointsStopInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/endpoints/{endpointName}/stop",
     apiVersion: "2025-06-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type EndpointsStopInput = typeof EndpointsStopInput.Type;
@@ -3169,6 +3194,7 @@ export const EndpointsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/endpoints/{endpointName}",
     apiVersion: "2025-06-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type EndpointsUpdateInput = typeof EndpointsUpdateInput.Type;
@@ -3866,6 +3892,7 @@ export const OriginGroupsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/endpoints/{endpointName}/originGroups/{originGroupName}",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type OriginGroupsCreateInput = typeof OriginGroupsCreateInput.Type;
@@ -3921,6 +3948,7 @@ export const OriginGroupsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/endpoints/{endpointName}/originGroups/{originGroupName}",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type OriginGroupsDeleteInput = typeof OriginGroupsDeleteInput.Type;
@@ -4126,6 +4154,7 @@ export const OriginGroupsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/endpoints/{endpointName}/originGroups/{originGroupName}",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type OriginGroupsUpdateInput = typeof OriginGroupsUpdateInput.Type;
@@ -4195,6 +4224,7 @@ export const OriginsCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/endpoints/{endpointName}/origins/{originName}",
     apiVersion: "2025-06-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type OriginsCreateInput = typeof OriginsCreateInput.Type;
@@ -4248,6 +4278,7 @@ export const OriginsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/endpoints/{endpointName}/origins/{originName}",
     apiVersion: "2025-06-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type OriginsDeleteInput = typeof OriginsDeleteInput.Type;
@@ -4422,6 +4453,7 @@ export const OriginsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/endpoints/{endpointName}/origins/{originName}",
     apiVersion: "2025-06-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type OriginsUpdateInput = typeof OriginsUpdateInput.Type;
@@ -4704,6 +4736,7 @@ export const PoliciesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/cdnWebApplicationFirewallPolicies/{policyName}",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PoliciesCreateOrUpdateInput =
@@ -4891,6 +4924,7 @@ export const PoliciesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/cdnWebApplicationFirewallPolicies/{policyName}",
     apiVersion: "2025-06-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type PoliciesUpdateInput = typeof PoliciesUpdateInput.Type;
@@ -4943,6 +4977,7 @@ export const ProfilesCanMigrateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/canMigrate",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ProfilesCanMigrateInput = typeof ProfilesCanMigrateInput.Type;
@@ -4999,6 +5034,7 @@ export const ProfilesCdnCanMigrateToAfdInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/cdnCanMigrateToAfd",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ProfilesCdnCanMigrateToAfdInput =
@@ -5087,6 +5123,7 @@ export const ProfilesCdnMigrateToAfdInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/cdnMigrateToAfd",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ProfilesCdnMigrateToAfdInput =
@@ -5230,6 +5267,7 @@ export const ProfilesCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}",
     apiVersion: "2025-06-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ProfilesCreateInput = typeof ProfilesCreateInput.Type;
@@ -5279,6 +5317,7 @@ export const ProfilesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}",
     apiVersion: "2025-06-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ProfilesDeleteInput = typeof ProfilesDeleteInput.Type;
@@ -5649,6 +5688,7 @@ export const ProfilesMigrateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/migrate",
     apiVersion: "2025-06-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ProfilesMigrateInput = typeof ProfilesMigrateInput.Type;
@@ -5692,6 +5732,7 @@ export const ProfilesMigrationAbortInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/migrationAbort",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ProfilesMigrationAbortInput =
@@ -5729,6 +5770,7 @@ export const ProfilesMigrationCommitInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/migrationCommit",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ProfilesMigrationCommitInput =
@@ -5813,6 +5855,7 @@ export const ProfilesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}",
     apiVersion: "2025-06-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ProfilesUpdateInput = typeof ProfilesUpdateInput.Type;
@@ -5975,6 +6018,7 @@ export const RoutesCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/afdEndpoints/{endpointName}/routes/{routeName}",
     apiVersion: "2025-06-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type RoutesCreateInput = typeof RoutesCreateInput.Type;
@@ -6028,6 +6072,7 @@ export const RoutesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/afdEndpoints/{endpointName}/routes/{routeName}",
     apiVersion: "2025-06-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type RoutesDeleteInput = typeof RoutesDeleteInput.Type;
@@ -6245,6 +6290,7 @@ export const RoutesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/afdEndpoints/{endpointName}/routes/{routeName}",
     apiVersion: "2025-06-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type RoutesUpdateInput = typeof RoutesUpdateInput.Type;
@@ -6363,6 +6409,7 @@ export const RulesCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/ruleSets/{ruleSetName}/rules/{ruleName}",
     apiVersion: "2025-06-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type RulesCreateInput = typeof RulesCreateInput.Type;
@@ -6416,6 +6463,7 @@ export const RulesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/ruleSets/{ruleSetName}/rules/{ruleName}",
     apiVersion: "2025-06-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type RulesDeleteInput = typeof RulesDeleteInput.Type;
@@ -6501,6 +6549,7 @@ export const RuleSetsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/ruleSets/{ruleSetName}",
     apiVersion: "2025-06-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type RuleSetsDeleteInput = typeof RuleSetsDeleteInput.Type;
@@ -6882,6 +6931,7 @@ export const RulesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/ruleSets/{ruleSetName}/rules/{ruleName}",
     apiVersion: "2025-06-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type RulesUpdateInput = typeof RulesUpdateInput.Type;
@@ -6950,6 +7000,7 @@ export const SecretsCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/secrets/{secretName}",
     apiVersion: "2025-06-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type SecretsCreateInput = typeof SecretsCreateInput.Type;
@@ -7001,6 +7052,7 @@ export const SecretsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/secrets/{secretName}",
     apiVersion: "2025-06-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type SecretsDeleteInput = typeof SecretsDeleteInput.Type;
@@ -7170,6 +7222,7 @@ export const SecurityPoliciesCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/securityPolicies/{securityPolicyName}",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SecurityPoliciesCreateInput =
@@ -7227,6 +7280,7 @@ export const SecurityPoliciesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/securityPolicies/{securityPolicyName}",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SecurityPoliciesDeleteInput =
@@ -7397,6 +7451,7 @@ export const SecurityPoliciesPatchInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/securityPolicies/{securityPolicyName}",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SecurityPoliciesPatchInput = typeof SecurityPoliciesPatchInput.Type;

--- a/packages/azure/src/services/certificateregistration.ts
+++ b/packages/azure/src/services/certificateregistration.ts
@@ -144,6 +144,7 @@ export const AppServiceCertificateOrdersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CertificateRegistration/certificateOrders/{certificateOrderName}",
       apiVersion: "2024-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AppServiceCertificateOrdersCreateOrUpdateInput =
@@ -225,6 +226,7 @@ export const AppServiceCertificateOrdersCreateOrUpdateCertificateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CertificateRegistration/certificateOrders/{certificateOrderName}/certificates/{name}",
       apiVersion: "2024-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AppServiceCertificateOrdersCreateOrUpdateCertificateInput =

--- a/packages/azure/src/services/chaos.ts
+++ b/packages/azure/src/services/chaos.ts
@@ -384,6 +384,7 @@ export const ExperimentsCancelInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Chaos/experiments/{experimentName}/cancel",
     apiVersion: "2025-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ExperimentsCancelInput = typeof ExperimentsCancelInput.Type;
@@ -478,6 +479,7 @@ export const ExperimentsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Chaos/experiments/{experimentName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ExperimentsCreateOrUpdateInput =
@@ -534,6 +536,7 @@ export const ExperimentsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Chaos/experiments/{experimentName}",
     apiVersion: "2025-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ExperimentsDeleteInput = typeof ExperimentsDeleteInput.Type;
@@ -967,6 +970,7 @@ export const ExperimentsStartInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Chaos/experiments/{experimentName}/start",
     apiVersion: "2025-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ExperimentsStartInput = typeof ExperimentsStartInput.Type;
@@ -1022,6 +1026,7 @@ export const ExperimentsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Chaos/experiments/{experimentName}",
     apiVersion: "2025-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ExperimentsUpdateInput = typeof ExperimentsUpdateInput.Type;

--- a/packages/azure/src/services/codesigning.ts
+++ b/packages/azure/src/services/codesigning.ts
@@ -77,6 +77,7 @@ export const CertificateProfilesCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CodeSigning/codeSigningAccounts/{accountName}/certificateProfiles/{profileName}",
       apiVersion: "2025-10-13",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CertificateProfilesCreateInput =
@@ -134,6 +135,7 @@ export const CertificateProfilesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CodeSigning/codeSigningAccounts/{accountName}/certificateProfiles/{profileName}",
       apiVersion: "2025-10-13",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CertificateProfilesDeleteInput =
@@ -403,6 +405,7 @@ export const CodeSigningAccountsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CodeSigning/codeSigningAccounts/{accountName}",
       apiVersion: "2025-10-13",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CodeSigningAccountsCreateInput =
@@ -458,6 +461,7 @@ export const CodeSigningAccountsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CodeSigning/codeSigningAccounts/{accountName}",
       apiVersion: "2025-10-13",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CodeSigningAccountsDeleteInput =
@@ -692,6 +696,7 @@ export const CodeSigningAccountsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CodeSigning/codeSigningAccounts/{accountName}",
       apiVersion: "2025-10-13",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CodeSigningAccountsUpdateInput =

--- a/packages/azure/src/services/cognitiveservices.ts
+++ b/packages/azure/src/services/cognitiveservices.ts
@@ -26,6 +26,7 @@ export const AccountCapabilityHostsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/capabilityHosts/{capabilityHostName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type AccountCapabilityHostsCreateOrUpdateInput =
@@ -82,6 +83,7 @@ export const AccountCapabilityHostsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/capabilityHosts/{capabilityHostName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AccountCapabilityHostsDeleteInput =
@@ -1186,6 +1188,7 @@ export const AccountsCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}",
     apiVersion: "2026-03-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type AccountsCreateInput = typeof AccountsCreateInput.Type;
@@ -1235,6 +1238,7 @@ export const AccountsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}",
     apiVersion: "2026-03-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type AccountsDeleteInput = typeof AccountsDeleteInput.Type;
@@ -2026,6 +2030,7 @@ export const AccountsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}",
     apiVersion: "2026-03-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type AccountsUpdateInput = typeof AccountsUpdateInput.Type;
@@ -2084,6 +2089,7 @@ export const AgentApplicationsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}/applications/{name}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AgentApplicationsCreateOrUpdateInput =
@@ -2142,6 +2148,7 @@ export const AgentApplicationsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}/applications/{name}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AgentApplicationsDeleteInput =
@@ -2494,6 +2501,7 @@ export const AgentDeploymentsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}/applications/{appName}/agentDeployments/{deploymentName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AgentDeploymentsCreateOrUpdateInput =
@@ -2554,6 +2562,7 @@ export const AgentDeploymentsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}/applications/{appName}/agentDeployments/{deploymentName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AgentDeploymentsDeleteInput =
@@ -3205,6 +3214,7 @@ export const CommitmentPlansCreateOrUpdateAssociationInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/commitmentPlans/{commitmentPlanName}/accountAssociations/{commitmentPlanAssociationName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CommitmentPlansCreateOrUpdateAssociationInput =
@@ -3367,6 +3377,7 @@ export const CommitmentPlansCreateOrUpdatePlanInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/commitmentPlans/{commitmentPlanName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CommitmentPlansCreateOrUpdatePlanInput =
@@ -3422,6 +3433,7 @@ export const CommitmentPlansDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/commitmentPlans/{commitmentPlanName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CommitmentPlansDeleteInput = typeof CommitmentPlansDeleteInput.Type;
@@ -3460,6 +3472,7 @@ export const CommitmentPlansDeleteAssociationInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/commitmentPlans/{commitmentPlanName}/accountAssociations/{commitmentPlanAssociationName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CommitmentPlansDeleteAssociationInput =
@@ -3497,6 +3510,7 @@ export const CommitmentPlansDeletePlanInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/commitmentPlans/{commitmentPlanName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CommitmentPlansDeletePlanInput =
@@ -3991,6 +4005,7 @@ export const CommitmentPlansUpdatePlanInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/commitmentPlans/{commitmentPlanName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CommitmentPlansUpdatePlanInput =
@@ -4484,6 +4499,7 @@ export const DeletedAccountsPurgeInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/locations/{location}/resourceGroups/{resourceGroupName}/deletedAccounts/{accountName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeletedAccountsPurgeInput = typeof DeletedAccountsPurgeInput.Type;
@@ -4713,6 +4729,7 @@ export const DeploymentsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/deployments/{deploymentName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DeploymentsCreateOrUpdateInput =
@@ -4771,6 +4788,7 @@ export const DeploymentsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/deployments/{deploymentName}",
     apiVersion: "2026-03-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type DeploymentsDeleteInput = typeof DeploymentsDeleteInput.Type;
@@ -5122,6 +5140,7 @@ export const DeploymentsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/deployments/{deploymentName}",
     apiVersion: "2026-03-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type DeploymentsUpdateInput = typeof DeploymentsUpdateInput.Type;
@@ -5251,6 +5270,7 @@ export const EncryptionScopesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/encryptionScopes/{encryptionScopeName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type EncryptionScopesDeleteInput =
@@ -5488,6 +5508,7 @@ export const ManagedNetworkProvisionsProvisionManagedNetworkInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/managedNetworks/{managedNetworkName}/provision",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedNetworkProvisionsProvisionManagedNetworkInput =
@@ -5742,6 +5763,7 @@ export const ManagedNetworkSettingsPatchInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/managedNetworks/{managedNetworkName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedNetworkSettingsPatchInput =
@@ -5884,6 +5906,7 @@ export const ManagedNetworkSettingsPutInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/managedNetworks/{managedNetworkName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedNetworkSettingsPutInput =
@@ -6213,6 +6236,7 @@ export const NetworkSecurityPerimeterConfigurationsReconcileInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/networkSecurityPerimeterConfigurations/{nspConfigurationName}/reconcile",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkSecurityPerimeterConfigurationsReconcileInput =
@@ -6340,6 +6364,7 @@ export const OutboundRuleCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/managedNetworks/{managedNetworkName}/outboundRules/{ruleName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type OutboundRuleCreateOrUpdateInput =
@@ -6399,6 +6424,7 @@ export const OutboundRuleDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/managedNetworks/{managedNetworkName}/outboundRules/{ruleName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type OutboundRuleDeleteInput = typeof OutboundRuleDeleteInput.Type;
@@ -6638,6 +6664,7 @@ export const OutboundRulesPostInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/managedNetworks/{managedNetworkName}/batchOutboundRules",
     apiVersion: "2026-03-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type OutboundRulesPostInput = typeof OutboundRulesPostInput.Type;
@@ -6730,6 +6757,7 @@ export const PrivateEndpointConnectionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsCreateOrUpdateInput =
@@ -6786,6 +6814,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =
@@ -7046,6 +7075,7 @@ export const ProjectCapabilityHostsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}/capabilityHosts/{capabilityHostName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type ProjectCapabilityHostsCreateOrUpdateInput =
@@ -7104,6 +7134,7 @@ export const ProjectCapabilityHostsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}/capabilityHosts/{capabilityHostName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ProjectCapabilityHostsDeleteInput =
@@ -7981,6 +8012,7 @@ export const ProjectsCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}",
     apiVersion: "2026-03-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ProjectsCreateInput = typeof ProjectsCreateInput.Type;
@@ -8032,6 +8064,7 @@ export const ProjectsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}",
     apiVersion: "2026-03-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ProjectsDeleteInput = typeof ProjectsDeleteInput.Type;
@@ -8245,6 +8278,7 @@ export const ProjectsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}",
     apiVersion: "2026-03-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ProjectsUpdateInput = typeof ProjectsUpdateInput.Type;
@@ -8725,6 +8759,7 @@ export const RaiBlocklistItemsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/raiBlocklists/{raiBlocklistName}/raiBlocklistItems/{raiBlocklistItemName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RaiBlocklistItemsDeleteInput =
@@ -8959,6 +8994,7 @@ export const RaiBlocklistsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/raiBlocklists/{raiBlocklistName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RaiBlocklistsDeleteInput = typeof RaiBlocklistsDeleteInput.Type;
@@ -9303,6 +9339,7 @@ export const RaiExternalSafetyProviderDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/raiExternalSafetyProviders/{safetyProviderName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RaiExternalSafetyProviderDeleteInput =
@@ -9581,6 +9618,7 @@ export const RaiPoliciesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/raiPolicies/{raiPolicyName}",
     apiVersion: "2026-03-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type RaiPoliciesDeleteInput = typeof RaiPoliciesDeleteInput.Type;
@@ -9811,6 +9849,7 @@ export const RaiToolLabelsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/raiToolLabels/{raiToolConnectionName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RaiToolLabelsDeleteInput = typeof RaiToolLabelsDeleteInput.Type;
@@ -10038,6 +10077,7 @@ export const RaiTopicsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/raitopics/{raiTopicName}",
     apiVersion: "2026-03-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type RaiTopicsDeleteInput = typeof RaiTopicsDeleteInput.Type;
@@ -10361,6 +10401,7 @@ export const SubscriptionRaiPolicyDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/raiPolicy/{raiPolicyName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SubscriptionRaiPolicyDeleteInput =

--- a/packages/azure/src/services/communication.ts
+++ b/packages/azure/src/services/communication.ts
@@ -110,6 +110,7 @@ export const CommunicationServicesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Communication/communicationServices/{communicationServiceName}",
       apiVersion: "2026-03-18",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CommunicationServicesCreateOrUpdateInput =
@@ -166,6 +167,7 @@ export const CommunicationServicesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Communication/communicationServices/{communicationServiceName}",
       apiVersion: "2026-03-18",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CommunicationServicesDeleteInput =
@@ -623,6 +625,7 @@ export const DomainsCancelVerificationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Communication/emailServices/{emailServiceName}/domains/{domainName}/cancelVerification",
       apiVersion: "2026-03-18",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DomainsCancelVerificationInput =
@@ -817,6 +820,7 @@ export const DomainsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Communication/emailServices/{emailServiceName}/domains/{domainName}",
       apiVersion: "2026-03-18",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DomainsCreateOrUpdateInput = typeof DomainsCreateOrUpdateInput.Type;
@@ -874,6 +878,7 @@ export const DomainsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Communication/emailServices/{emailServiceName}/domains/{domainName}",
     apiVersion: "2026-03-18",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type DomainsDeleteInput = typeof DomainsDeleteInput.Type;
@@ -970,6 +975,7 @@ export const DomainsInitiateVerificationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Communication/emailServices/{emailServiceName}/domains/{domainName}/initiateVerification",
       apiVersion: "2026-03-18",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DomainsInitiateVerificationInput =
@@ -1089,6 +1095,7 @@ export const DomainsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Communication/emailServices/{emailServiceName}/domains/{domainName}",
     apiVersion: "2026-03-18",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type DomainsUpdateInput = typeof DomainsUpdateInput.Type;
@@ -1162,6 +1169,7 @@ export const EmailServicesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Communication/emailServices/{emailServiceName}",
       apiVersion: "2026-03-18",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type EmailServicesCreateOrUpdateInput =
@@ -1219,6 +1227,7 @@ export const EmailServicesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Communication/emailServices/{emailServiceName}",
       apiVersion: "2026-03-18",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type EmailServicesDeleteInput = typeof EmailServicesDeleteInput.Type;
@@ -1478,6 +1487,7 @@ export const EmailServicesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Communication/emailServices/{emailServiceName}",
       apiVersion: "2026-03-18",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type EmailServicesUpdateInput = typeof EmailServicesUpdateInput.Type;

--- a/packages/azure/src/services/communitytraining.ts
+++ b/packages/azure/src/services/communitytraining.ts
@@ -65,6 +65,7 @@ export const CommunityTrainingsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Community/communityTrainings/{communityTrainingName}",
       apiVersion: "2023-11-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CommunityTrainingsCreateInput =
@@ -120,6 +121,7 @@ export const CommunityTrainingsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Community/communityTrainings/{communityTrainingName}",
       apiVersion: "2023-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CommunityTrainingsDeleteInput =
@@ -372,6 +374,7 @@ export const CommunityTrainingsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Community/communityTrainings/{communityTrainingName}",
       apiVersion: "2023-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CommunityTrainingsUpdateInput =

--- a/packages/azure/src/services/compute.ts
+++ b/packages/azure/src/services/compute.ts
@@ -57,6 +57,7 @@ export const AvailabilitySetsConvertToVirtualMachineScaleSetInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/availabilitySets/{availabilitySetName}/convertToVirtualMachineScaleSet",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AvailabilitySetsConvertToVirtualMachineScaleSetInput =
@@ -1293,6 +1294,7 @@ export const CapacityReservationsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/capacityReservationGroups/{capacityReservationGroupName}/capacityReservations/{capacityReservationName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CapacityReservationsCreateOrUpdateInput =
@@ -1349,6 +1351,7 @@ export const CapacityReservationsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/capacityReservationGroups/{capacityReservationGroupName}/capacityReservations/{capacityReservationName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CapacityReservationsDeleteInput =
@@ -1582,6 +1585,7 @@ export const CapacityReservationsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/capacityReservationGroups/{capacityReservationGroupName}/capacityReservations/{capacityReservationName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CapacityReservationsUpdateInput =
@@ -1754,6 +1758,7 @@ export const ContainerServicesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/containerServices/{containerServiceName}",
       apiVersion: "2017-01-31",
+      longRunning: {},
     }),
   );
 export type ContainerServicesCreateOrUpdateInput =
@@ -1795,6 +1800,7 @@ export const ContainerServicesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/containerServices/{containerServiceName}",
       apiVersion: "2017-01-31",
+      longRunning: {},
     }),
   );
 export type ContainerServicesDeleteInput =
@@ -2472,6 +2478,7 @@ export const DedicatedHostsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}/hosts/{hostName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DedicatedHostsCreateOrUpdateInput =
@@ -2528,6 +2535,7 @@ export const DedicatedHostsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}/hosts/{hostName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DedicatedHostsDeleteInput = typeof DedicatedHostsDeleteInput.Type;
@@ -2733,6 +2741,7 @@ export const DedicatedHostsRedeployInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}/hosts/{hostName}/redeploy",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DedicatedHostsRedeployInput =
@@ -2772,6 +2781,7 @@ export const DedicatedHostsRestartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}/hosts/{hostName}/restart",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DedicatedHostsRestartInput = typeof DedicatedHostsRestartInput.Type;
@@ -2872,6 +2882,7 @@ export const DedicatedHostsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}/hosts/{hostName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DedicatedHostsUpdateInput = typeof DedicatedHostsUpdateInput.Type;
@@ -3022,6 +3033,7 @@ export const ImagesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/images/{imageName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ImagesCreateOrUpdateInput = typeof ImagesCreateOrUpdateInput.Type;
@@ -3074,6 +3086,7 @@ export const ImagesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/images/{imageName}",
     apiVersion: "2025-04-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ImagesDeleteInput = typeof ImagesDeleteInput.Type;
@@ -3363,6 +3376,7 @@ export const ImagesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/images/{imageName}",
     apiVersion: "2025-04-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ImagesUpdateInput = typeof ImagesUpdateInput.Type;
@@ -3426,6 +3440,7 @@ export const LogAnalyticsExportRequestRateByIntervalInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/logAnalytics/apiAccess/getRequestRateByInterval",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type LogAnalyticsExportRequestRateByIntervalInput =
@@ -3474,6 +3489,7 @@ export const LogAnalyticsExportThrottledRequestsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/logAnalytics/apiAccess/getThrottledRequests",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type LogAnalyticsExportThrottledRequestsInput =
@@ -4046,6 +4062,7 @@ export const RestorePointCollectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/restorePointCollections/{restorePointCollectionName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RestorePointCollectionsDeleteInput =
@@ -4930,6 +4947,7 @@ export const RestorePointsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/restorePointCollections/{restorePointCollectionName}/restorePoints/{restorePointName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RestorePointsCreateInput = typeof RestorePointsCreateInput.Type;
@@ -4983,6 +5001,7 @@ export const RestorePointsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/restorePointCollections/{restorePointCollectionName}/restorePoints/{restorePointName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RestorePointsDeleteInput = typeof RestorePointsDeleteInput.Type;
@@ -5835,6 +5854,7 @@ export const VirtualMachineExtensionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/extensions/{vmExtensionName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineExtensionsCreateOrUpdateInput =
@@ -5891,6 +5911,7 @@ export const VirtualMachineExtensionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/extensions/{vmExtensionName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineExtensionsDeleteInput =
@@ -6082,6 +6103,7 @@ export const VirtualMachineExtensionsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/extensions/{vmExtensionName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineExtensionsUpdateInput =
@@ -6714,6 +6736,7 @@ export const VirtualMachineRunCommandsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/runCommands/{runCommandName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineRunCommandsCreateOrUpdateInput =
@@ -6770,6 +6793,7 @@ export const VirtualMachineRunCommandsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/runCommands/{runCommandName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineRunCommandsDeleteInput =
@@ -7116,6 +7140,7 @@ export const VirtualMachineRunCommandsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/runCommands/{runCommandName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineRunCommandsUpdateInput =
@@ -7171,6 +7196,7 @@ export const VirtualMachinesAssessPatchesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/assessPatches",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesAssessPatchesInput =
@@ -7295,6 +7321,7 @@ export const VirtualMachinesAttachDetachDataDisksInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/attachDetachDataDisks",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesAttachDetachDataDisksInput =
@@ -7474,6 +7501,7 @@ export const VirtualMachineScaleSetExtensionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/extensions/{vmssExtensionName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetExtensionsCreateOrUpdateInput =
@@ -7514,6 +7542,7 @@ export const VirtualMachineScaleSetExtensionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/extensions/{vmssExtensionName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetExtensionsDeleteInput =
@@ -7663,6 +7692,7 @@ export const VirtualMachineScaleSetExtensionsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/extensions/{vmssExtensionName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetExtensionsUpdateInput =
@@ -7702,6 +7732,7 @@ export const VirtualMachineScaleSetRollingUpgradesCancelInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/rollingUpgrades/cancel",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetRollingUpgradesCancelInput =
@@ -7792,6 +7823,7 @@ export const VirtualMachineScaleSetRollingUpgradesStartExtensionUpgradeInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/extensionRollingUpgrade",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetRollingUpgradesStartExtensionUpgradeInput =
@@ -7830,6 +7862,7 @@ export const VirtualMachineScaleSetRollingUpgradesStartOSUpgradeInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/osRollingUpgrade",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetRollingUpgradesStartOSUpgradeInput =
@@ -7867,6 +7900,7 @@ export const VirtualMachineScaleSetsApproveRollingUpgradeInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/approveRollingUpgrade",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetsApproveRollingUpgradeInput =
@@ -8829,6 +8863,7 @@ export const VirtualMachineScaleSetsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetsCreateOrUpdateInput =
@@ -8887,6 +8922,7 @@ export const VirtualMachineScaleSetsDeallocateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/deallocate",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetsDeallocateInput =
@@ -8925,6 +8961,7 @@ export const VirtualMachineScaleSetsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetsDeleteInput =
@@ -8964,6 +9001,7 @@ export const VirtualMachineScaleSetsDeleteInstancesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/delete",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetsDeleteInstancesInput =
@@ -9585,6 +9623,7 @@ export const VirtualMachineScaleSetsPerformMaintenanceInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/performMaintenance",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetsPerformMaintenanceInput =
@@ -9623,6 +9662,7 @@ export const VirtualMachineScaleSetsPowerOffInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/poweroff",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetsPowerOffInput =
@@ -9660,6 +9700,7 @@ export const VirtualMachineScaleSetsReapplyInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/reapply",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetsReapplyInput =
@@ -9697,6 +9738,7 @@ export const VirtualMachineScaleSetsRedeployInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/redeploy",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetsRedeployInput =
@@ -9735,6 +9777,7 @@ export const VirtualMachineScaleSetsReimageInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/reimage",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetsReimageInput =
@@ -9772,6 +9815,7 @@ export const VirtualMachineScaleSetsReimageAllInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/reimageall",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetsReimageAllInput =
@@ -9809,6 +9853,7 @@ export const VirtualMachineScaleSetsRestartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/restart",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetsRestartInput =
@@ -9851,6 +9896,7 @@ export const VirtualMachineScaleSetsScaleOutInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/scaleOut",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetsScaleOutInput =
@@ -9892,6 +9938,7 @@ export const VirtualMachineScaleSetsSetOrchestrationServiceStateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/setOrchestrationServiceState",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetsSetOrchestrationServiceStateInput =
@@ -9929,6 +9976,7 @@ export const VirtualMachineScaleSetsStartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/start",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetsStartInput =
@@ -10710,6 +10758,7 @@ export const VirtualMachineScaleSetsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetsUpdateInput =
@@ -10767,6 +10816,7 @@ export const VirtualMachineScaleSetsUpdateInstancesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/manualupgrade",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetsUpdateInstancesInput =
@@ -10865,6 +10915,7 @@ export const VirtualMachineScaleSetVMExtensionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualMachines/{instanceId}/extensions/{vmExtensionName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetVMExtensionsCreateOrUpdateInput =
@@ -10907,6 +10958,7 @@ export const VirtualMachineScaleSetVMExtensionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualMachines/{instanceId}/extensions/{vmExtensionName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetVMExtensionsDeleteInput =
@@ -11063,6 +11115,7 @@ export const VirtualMachineScaleSetVMExtensionsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualMachines/{instanceId}/extensions/{vmExtensionName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetVMExtensionsUpdateInput =
@@ -11198,6 +11251,7 @@ export const VirtualMachineScaleSetVMRunCommandsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualMachines/{instanceId}/runCommands/{runCommandName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetVMRunCommandsCreateOrUpdateInput =
@@ -11256,6 +11310,7 @@ export const VirtualMachineScaleSetVMRunCommandsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualMachines/{instanceId}/runCommands/{runCommandName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetVMRunCommandsDeleteInput =
@@ -11521,6 +11576,7 @@ export const VirtualMachineScaleSetVMRunCommandsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualMachines/{instanceId}/runCommands/{runCommandName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetVMRunCommandsUpdateInput =
@@ -11578,6 +11634,7 @@ export const VirtualMachineScaleSetVMsApproveRollingUpgradeInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualMachines/{instanceId}/approveRollingUpgrade",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetVMsApproveRollingUpgradeInput =
@@ -11642,6 +11699,7 @@ export const VirtualMachineScaleSetVMsAttachDetachDataDisksInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualMachines/{instanceId}/attachDetachDataDisks",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetVMsAttachDetachDataDisksInput =
@@ -11796,6 +11854,7 @@ export const VirtualMachineScaleSetVMsDeallocateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualMachines/{instanceId}/deallocate",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetVMsDeallocateInput =
@@ -11835,6 +11894,7 @@ export const VirtualMachineScaleSetVMsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualMachines/{instanceId}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetVMsDeleteInput =
@@ -12233,6 +12293,7 @@ export const VirtualMachineScaleSetVMsPerformMaintenanceInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualMachines/{instanceId}/performMaintenance",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetVMsPerformMaintenanceInput =
@@ -12272,6 +12333,7 @@ export const VirtualMachineScaleSetVMsPowerOffInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualMachines/{instanceId}/powerOff",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetVMsPowerOffInput =
@@ -12311,6 +12373,7 @@ export const VirtualMachineScaleSetVMsRedeployInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualMachines/{instanceId}/redeploy",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetVMsRedeployInput =
@@ -12358,6 +12421,7 @@ export const VirtualMachineScaleSetVMsReimageInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualMachines/{instanceId}/reimage",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetVMsReimageInput =
@@ -12396,6 +12460,7 @@ export const VirtualMachineScaleSetVMsReimageAllInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualMachines/{instanceId}/reimageall",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetVMsReimageAllInput =
@@ -12434,6 +12499,7 @@ export const VirtualMachineScaleSetVMsRestartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualMachines/{instanceId}/restart",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetVMsRestartInput =
@@ -12525,6 +12591,7 @@ export const VirtualMachineScaleSetVMsRunCommandInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualMachines/{instanceId}/runCommand",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetVMsRunCommandInput =
@@ -12613,6 +12680,7 @@ export const VirtualMachineScaleSetVMsStartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualMachines/{instanceId}/start",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetVMsStartInput =
@@ -13781,6 +13849,7 @@ export const VirtualMachineScaleSetVMsUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualMachines/{instanceId}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineScaleSetVMsUpdateInput =
@@ -13841,6 +13910,7 @@ export const VirtualMachinesCaptureInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/capture",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesCaptureInput =
@@ -13880,6 +13950,7 @@ export const VirtualMachinesConvertToManagedDisksInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/convertToManagedDisks",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesConvertToManagedDisksInput =
@@ -15093,6 +15164,7 @@ export const VirtualMachinesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesCreateOrUpdateInput =
@@ -15150,6 +15222,7 @@ export const VirtualMachinesDeallocateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/deallocate",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesDeallocateInput =
@@ -15189,6 +15262,7 @@ export const VirtualMachinesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesDeleteInput = typeof VirtualMachinesDeleteInput.Type;
@@ -15354,6 +15428,7 @@ export const VirtualMachinesInstallPatchesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/installPatches",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesInstallPatchesInput =
@@ -16095,6 +16170,7 @@ export const VirtualMachinesMigrateToVMScaleSetInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/migrateToVirtualMachineScaleSet",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesMigrateToVMScaleSetInput =
@@ -16131,6 +16207,7 @@ export const VirtualMachinesPerformMaintenanceInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/performMaintenance",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesPerformMaintenanceInput =
@@ -16168,6 +16245,7 @@ export const VirtualMachinesPowerOffInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/powerOff",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesPowerOffInput =
@@ -16206,6 +16284,7 @@ export const VirtualMachinesReapplyInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/reapply",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesReapplyInput =
@@ -16243,6 +16322,7 @@ export const VirtualMachinesRedeployInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/redeploy",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesRedeployInput =
@@ -16288,6 +16368,7 @@ export const VirtualMachinesReimageInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/reimage",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesReimageInput =
@@ -16325,6 +16406,7 @@ export const VirtualMachinesRestartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/restart",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesRestartInput =
@@ -16413,6 +16495,7 @@ export const VirtualMachinesRunCommandInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/runCommand",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesRunCommandInput =
@@ -16498,6 +16581,7 @@ export const VirtualMachinesStartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/start",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesStartInput = typeof VirtualMachinesStartInput.Type;
@@ -17661,6 +17745,7 @@ export const VirtualMachinesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesUpdateInput = typeof VirtualMachinesUpdateInput.Type;

--- a/packages/azure/src/services/computelimit.ts
+++ b/packages/azure/src/services/computelimit.ts
@@ -18,6 +18,7 @@ export const FeaturesDisableInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/providers/Microsoft.ComputeLimit/locations/{location}/features/{featureName}/disable",
     apiVersion: "2026-04-30",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type FeaturesDisableInput = typeof FeaturesDisableInput.Type;
@@ -103,6 +104,7 @@ export const FeaturesEnableInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/providers/Microsoft.ComputeLimit/locations/{location}/features/{featureName}/enable",
     apiVersion: "2026-04-30",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type FeaturesEnableInput = typeof FeaturesEnableInput.Type;

--- a/packages/azure/src/services/confidentialledger.ts
+++ b/packages/azure/src/services/confidentialledger.ts
@@ -113,6 +113,7 @@ export const LedgerCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ConfidentialLedger/ledgers/{ledgerName}",
     apiVersion: "2022-05-13",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type LedgerCreateInput = typeof LedgerCreateInput.Type;
@@ -159,6 +160,7 @@ export const LedgerDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ConfidentialLedger/ledgers/{ledgerName}",
     apiVersion: "2022-05-13",
+    longRunning: {},
   }),
 );
 export type LedgerDeleteInput = typeof LedgerDeleteInput.Type;
@@ -191,6 +193,7 @@ export const LedgerFilesExportInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ConfidentialLedger/ledgers/{ledgerName}/filesExport",
     apiVersion: "2026-02-23",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type LedgerFilesExportInput = typeof LedgerFilesExportInput.Type;
@@ -472,6 +475,7 @@ export const LedgerUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ConfidentialLedger/ledgers/{ledgerName}",
     apiVersion: "2022-05-13",
+    longRunning: {},
   }),
 );
 export type LedgerUpdateInput = typeof LedgerUpdateInput.Type;

--- a/packages/azure/src/services/confluent.ts
+++ b/packages/azure/src/services/confluent.ts
@@ -790,6 +790,7 @@ export const ClusterDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Confluent/organizations/{organizationName}/environments/{environmentId}/clusters/{clusterId}",
     apiVersion: "2024-07-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ClusterDeleteInput = typeof ClusterDeleteInput.Type;
@@ -924,6 +925,7 @@ export const ConnectorDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Confluent/organizations/{organizationName}/environments/{environmentId}/clusters/{clusterId}/connectors/{connectorName}",
     apiVersion: "2024-07-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ConnectorDeleteInput = typeof ConnectorDeleteInput.Type;
@@ -1156,6 +1158,7 @@ export const EnvironmentDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Confluent/organizations/{organizationName}/environments/{environmentId}",
     apiVersion: "2024-07-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type EnvironmentDeleteInput = typeof EnvironmentDeleteInput.Type;
@@ -1415,6 +1418,7 @@ export const OrganizationCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Confluent/organizations/{organizationName}",
       apiVersion: "2024-07-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type OrganizationCreateInput = typeof OrganizationCreateInput.Type;
@@ -1549,6 +1553,7 @@ export const OrganizationDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Confluent/organizations/{organizationName}",
       apiVersion: "2024-07-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type OrganizationDeleteInput = typeof OrganizationDeleteInput.Type;
@@ -2575,6 +2580,7 @@ export const TopicsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Confluent/organizations/{organizationName}/environments/{environmentId}/clusters/{clusterId}/topics/{topicName}",
     apiVersion: "2024-07-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type TopicsDeleteInput = typeof TopicsDeleteInput.Type;

--- a/packages/azure/src/services/connectedvmware.ts
+++ b/packages/azure/src/services/connectedvmware.ts
@@ -81,6 +81,7 @@ export const ClustersCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ConnectedVMwarevSphere/clusters/{clusterName}",
     apiVersion: "2023-12-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type ClustersCreateInput = typeof ClustersCreateInput.Type;
@@ -175,6 +176,7 @@ export const ClustersDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ConnectedVMwarevSphere/clusters/{clusterName}",
     apiVersion: "2023-12-01",
+    longRunning: {},
   }),
 );
 export type ClustersDeleteInput = typeof ClustersDeleteInput.Type;
@@ -657,6 +659,7 @@ export const DatastoresCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ConnectedVMwarevSphere/datastores/{datastoreName}",
     apiVersion: "2023-12-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type DatastoresCreateInput = typeof DatastoresCreateInput.Type;
@@ -749,6 +752,7 @@ export const DatastoresDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ConnectedVMwarevSphere/datastores/{datastoreName}",
     apiVersion: "2023-12-01",
+    longRunning: {},
   }),
 );
 export type DatastoresDeleteInput = typeof DatastoresDeleteInput.Type;
@@ -1220,6 +1224,7 @@ export const HostsCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ConnectedVMwarevSphere/hosts/{hostName}",
     apiVersion: "2023-12-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type HostsCreateInput = typeof HostsCreateInput.Type;
@@ -1314,6 +1319,7 @@ export const HostsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ConnectedVMwarevSphere/hosts/{hostName}",
     apiVersion: "2023-12-01",
+    longRunning: {},
   }),
 );
 export type HostsDeleteInput = typeof HostsDeleteInput.Type;
@@ -2078,6 +2084,7 @@ export const ResourcePoolsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ConnectedVMwarevSphere/resourcePools/{resourcePoolName}",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ResourcePoolsCreateInput = typeof ResourcePoolsCreateInput.Type;
@@ -2180,6 +2187,7 @@ export const ResourcePoolsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ConnectedVMwarevSphere/resourcePools/{resourcePoolName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type ResourcePoolsDeleteInput = typeof ResourcePoolsDeleteInput.Type;
@@ -2706,6 +2714,7 @@ export const VCentersCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ConnectedVMwarevSphere/vcenters/{vcenterName}",
     apiVersion: "2023-12-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type VCentersCreateInput = typeof VCentersCreateInput.Type;
@@ -2801,6 +2810,7 @@ export const VCentersDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ConnectedVMwarevSphere/vcenters/{vcenterName}",
     apiVersion: "2023-12-01",
+    longRunning: {},
   }),
 );
 export type VCentersDeleteInput = typeof VCentersDeleteInput.Type;
@@ -3452,6 +3462,7 @@ export const VirtualMachineInstancesCreateOrUpdateInput =
       method: "PUT",
       path: "/{resourceUri}/providers/Microsoft.ConnectedVMwarevSphere/virtualMachineInstances/default",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualMachineInstancesCreateOrUpdateInput =
@@ -3502,6 +3513,7 @@ export const VirtualMachineInstancesDeleteInput =
       method: "DELETE",
       path: "/{resourceUri}/providers/Microsoft.ConnectedVMwarevSphere/virtualMachineInstances/default",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualMachineInstancesDeleteInput =
@@ -3645,6 +3657,7 @@ export const VirtualMachineInstancesRestartInput =
       method: "POST",
       path: "/{resourceUri}/providers/Microsoft.ConnectedVMwarevSphere/virtualMachineInstances/default/restart",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineInstancesRestartInput =
@@ -3674,6 +3687,7 @@ export const VirtualMachineInstancesStartInput =
       method: "POST",
       path: "/{resourceUri}/providers/Microsoft.ConnectedVMwarevSphere/virtualMachineInstances/default/start",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineInstancesStartInput =
@@ -3705,6 +3719,7 @@ export const VirtualMachineInstancesStopInput =
       method: "POST",
       path: "/{resourceUri}/providers/Microsoft.ConnectedVMwarevSphere/virtualMachineInstances/default/stop",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineInstancesStopInput =
@@ -3810,6 +3825,7 @@ export const VirtualMachineInstancesUpdateInput =
       method: "PATCH",
       path: "/{resourceUri}/providers/Microsoft.ConnectedVMwarevSphere/virtualMachineInstances/default",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualMachineInstancesUpdateInput =
@@ -4014,6 +4030,7 @@ export const VirtualMachineTemplatesCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ConnectedVMwarevSphere/virtualMachineTemplates/{virtualMachineTemplateName}",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualMachineTemplatesCreateInput =
@@ -4204,6 +4221,7 @@ export const VirtualMachineTemplatesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ConnectedVMwarevSphere/virtualMachineTemplates/{virtualMachineTemplateName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type VirtualMachineTemplatesDeleteInput =
@@ -5081,6 +5099,7 @@ export const VirtualNetworksCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ConnectedVMwarevSphere/virtualNetworks/{virtualNetworkName}",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualNetworksCreateInput = typeof VirtualNetworksCreateInput.Type;
@@ -5174,6 +5193,7 @@ export const VirtualNetworksDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ConnectedVMwarevSphere/virtualNetworks/{virtualNetworkName}",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type VirtualNetworksDeleteInput = typeof VirtualNetworksDeleteInput.Type;
@@ -5637,6 +5657,7 @@ export const VMInstanceGuestAgentsCreateInput =
       method: "PUT",
       path: "/{resourceUri}/providers/Microsoft.ConnectedVMwarevSphere/virtualMachineInstances/default/guestAgents/default",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VMInstanceGuestAgentsCreateInput =
@@ -5685,6 +5706,7 @@ export const VMInstanceGuestAgentsDeleteInput =
       method: "DELETE",
       path: "/{resourceUri}/providers/Microsoft.ConnectedVMwarevSphere/virtualMachineInstances/default/guestAgents/default",
       apiVersion: "2023-12-01",
+      longRunning: {},
     }),
   );
 export type VMInstanceGuestAgentsDeleteInput =

--- a/packages/azure/src/services/consumption.ts
+++ b/packages/azure/src/services/consumption.ts
@@ -1111,6 +1111,7 @@ export const PriceSheetDownloadByBillingAccountPeriodInput =
       method: "POST",
       path: "/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/billingPeriods/{billingPeriodName}/providers/Microsoft.Consumption/pricesheets/download",
       apiVersion: "2024-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PriceSheetDownloadByBillingAccountPeriodInput =

--- a/packages/azure/src/services/containerinstance.ts
+++ b/packages/azure/src/services/containerinstance.ts
@@ -1392,6 +1392,7 @@ export const ContainerGroupsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerInstance/containerGroups/{containerGroupName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ContainerGroupsCreateOrUpdateInput =
@@ -1437,6 +1438,7 @@ export const ContainerGroupsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerInstance/containerGroups/{containerGroupName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ContainerGroupsDeleteInput = typeof ContainerGroupsDeleteInput.Type;
@@ -2627,6 +2629,7 @@ export const ContainerGroupsRestartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerInstance/containerGroups/{containerGroupName}/restart",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ContainerGroupsRestartInput =
@@ -2666,6 +2669,7 @@ export const ContainerGroupsStartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerInstance/containerGroups/{containerGroupName}/start",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ContainerGroupsStartInput = typeof ContainerGroupsStartInput.Type;
@@ -3285,6 +3289,7 @@ export const NGroupsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerInstance/ngroups/{ngroupsName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NGroupsCreateOrUpdateInput = typeof NGroupsCreateOrUpdateInput.Type;
@@ -3340,6 +3345,7 @@ export const NGroupsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerInstance/ngroups/{ngroupsName}",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type NGroupsDeleteInput = typeof NGroupsDeleteInput.Type;
@@ -3546,6 +3552,7 @@ export const NGroupsRestartInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerInstance/ngroups/{ngroupsName}/restart",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type NGroupsRestartInput = typeof NGroupsRestartInput.Type;
@@ -3579,6 +3586,7 @@ export const NGroupsStartInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerInstance/ngroups/{ngroupsName}/start",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type NGroupsStartInput = typeof NGroupsStartInput.Type;
@@ -3849,6 +3857,7 @@ export const NGroupsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerInstance/ngroups/{ngroupsName}",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type NGroupsUpdateInput = typeof NGroupsUpdateInput.Type;
@@ -3943,6 +3952,7 @@ export const SubnetServiceAssociationLinkDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}/providers/Microsoft.ContainerInstance/serviceAssociationLinks/default",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SubnetServiceAssociationLinkDeleteInput =

--- a/packages/azure/src/services/containerregistry.ts
+++ b/packages/azure/src/services/containerregistry.ts
@@ -38,6 +38,7 @@ export const CacheRulesCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerRegistry/registries/{registryName}/cacheRules/{cacheRuleName}",
     apiVersion: "2025-11-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type CacheRulesCreateInput = typeof CacheRulesCreateInput.Type;
@@ -91,6 +92,7 @@ export const CacheRulesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerRegistry/registries/{registryName}/cacheRules/{cacheRuleName}",
     apiVersion: "2025-11-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type CacheRulesDeleteInput = typeof CacheRulesDeleteInput.Type;
@@ -246,6 +248,7 @@ export const CacheRulesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerRegistry/registries/{registryName}/cacheRules/{cacheRuleName}",
     apiVersion: "2025-11-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type CacheRulesUpdateInput = typeof CacheRulesUpdateInput.Type;
@@ -389,6 +392,7 @@ export const ConnectedRegistriesCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerRegistry/registries/{registryName}/connectedRegistries/{connectedRegistryName}",
       apiVersion: "2025-11-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ConnectedRegistriesCreateInput =
@@ -446,6 +450,7 @@ export const ConnectedRegistriesDeactivateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerRegistry/registries/{registryName}/connectedRegistries/{connectedRegistryName}/deactivate",
       apiVersion: "2025-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ConnectedRegistriesDeactivateInput =
@@ -484,6 +489,7 @@ export const ConnectedRegistriesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerRegistry/registries/{registryName}/connectedRegistries/{connectedRegistryName}",
       apiVersion: "2025-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ConnectedRegistriesDeleteInput =
@@ -689,6 +695,7 @@ export const ConnectedRegistriesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerRegistry/registries/{registryName}/connectedRegistries/{connectedRegistryName}",
       apiVersion: "2025-11-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ConnectedRegistriesUpdateInput =
@@ -803,6 +810,7 @@ export const CredentialSetsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerRegistry/registries/{registryName}/credentialSets/{credentialSetName}",
       apiVersion: "2025-11-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CredentialSetsCreateInput = typeof CredentialSetsCreateInput.Type;
@@ -858,6 +866,7 @@ export const CredentialSetsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerRegistry/registries/{registryName}/credentialSets/{credentialSetName}",
       apiVersion: "2025-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CredentialSetsDeleteInput = typeof CredentialSetsDeleteInput.Type;
@@ -1062,6 +1071,7 @@ export const CredentialSetsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerRegistry/registries/{registryName}/credentialSets/{credentialSetName}",
       apiVersion: "2025-11-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CredentialSetsUpdateInput = typeof CredentialSetsUpdateInput.Type;
@@ -1226,6 +1236,7 @@ export const PrivateEndpointConnectionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerRegistry/registries/{registryName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-11-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PrivateEndpointConnectionsCreateOrUpdateInput =
@@ -1282,6 +1293,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerRegistry/registries/{registryName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =
@@ -1647,6 +1659,7 @@ export const RegistriesCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerRegistry/registries/{registryName}",
     apiVersion: "2025-11-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type RegistriesCreateInput = typeof RegistriesCreateInput.Type;
@@ -1698,6 +1711,7 @@ export const RegistriesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerRegistry/registries/{registryName}",
     apiVersion: "2025-11-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type RegistriesDeleteInput = typeof RegistriesDeleteInput.Type;
@@ -1733,6 +1747,7 @@ export const RegistriesGenerateCredentialsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerRegistry/registries/{registryName}/generateCredentials",
       apiVersion: "2025-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RegistriesGenerateCredentialsInput =
@@ -1930,6 +1945,7 @@ export const RegistriesImportImageInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerRegistry/registries/{registryName}/importImage",
       apiVersion: "2025-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RegistriesImportImageInput = typeof RegistriesImportImageInput.Type;
@@ -2307,6 +2323,7 @@ export const RegistriesScheduleRunInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerRegistry/registries/{registryName}/scheduleRun",
       apiVersion: "2019-04-01",
+      longRunning: {},
     }),
   );
 export type RegistriesScheduleRunInput = typeof RegistriesScheduleRunInput.Type;
@@ -2452,6 +2469,7 @@ export const RegistriesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerRegistry/registries/{registryName}",
     apiVersion: "2025-11-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type RegistriesUpdateInput = typeof RegistriesUpdateInput.Type;
@@ -2532,6 +2550,7 @@ export const ReplicationsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerRegistry/registries/{registryName}/replications/{replicationName}",
       apiVersion: "2025-11-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ReplicationsCreateInput = typeof ReplicationsCreateInput.Type;
@@ -2585,6 +2604,7 @@ export const ReplicationsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerRegistry/registries/{registryName}/replications/{replicationName}",
       apiVersion: "2025-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationsDeleteInput = typeof ReplicationsDeleteInput.Type;
@@ -2744,6 +2764,7 @@ export const ReplicationsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerRegistry/registries/{registryName}/replications/{replicationName}",
       apiVersion: "2025-11-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ReplicationsUpdateInput = typeof ReplicationsUpdateInput.Type;
@@ -2793,6 +2814,7 @@ export const RunsCancelInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerRegistry/registries/{registryName}/runs/{runId}/cancel",
     apiVersion: "2019-04-01",
+    longRunning: {},
   }),
 );
 export type RunsCancelInput = typeof RunsCancelInput.Type;
@@ -2919,6 +2941,7 @@ export const RunsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerRegistry/registries/{registryName}/runs/{runId}",
     apiVersion: "2019-04-01",
+    longRunning: {},
   }),
 );
 export type RunsUpdateInput = typeof RunsUpdateInput.Type;
@@ -2970,6 +2993,7 @@ export const ScopeMapsCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerRegistry/registries/{registryName}/scopeMaps/{scopeMapName}",
     apiVersion: "2025-11-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type ScopeMapsCreateInput = typeof ScopeMapsCreateInput.Type;
@@ -3021,6 +3045,7 @@ export const ScopeMapsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerRegistry/registries/{registryName}/scopeMaps/{scopeMapName}",
     apiVersion: "2025-11-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ScopeMapsDeleteInput = typeof ScopeMapsDeleteInput.Type;
@@ -3177,6 +3202,7 @@ export const ScopeMapsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerRegistry/registries/{registryName}/scopeMaps/{scopeMapName}",
     apiVersion: "2025-11-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type ScopeMapsUpdateInput = typeof ScopeMapsUpdateInput.Type;
@@ -3380,6 +3406,7 @@ export const TasksCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerRegistry/registries/{registryName}/tasks/{taskName}",
     apiVersion: "2019-04-01",
+    longRunning: {},
   }),
 );
 export type TasksCreateInput = typeof TasksCreateInput.Type;
@@ -3410,6 +3437,7 @@ export const TasksDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerRegistry/registries/{registryName}/tasks/{taskName}",
     apiVersion: "2019-04-01",
+    longRunning: {},
   }),
 );
 export type TasksDeleteInput = typeof TasksDeleteInput.Type;
@@ -3669,6 +3697,7 @@ export const TasksUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerRegistry/registries/{registryName}/tasks/{taskName}",
     apiVersion: "2019-04-01",
+    longRunning: {},
   }),
 );
 export type TasksUpdateInput = typeof TasksUpdateInput.Type;
@@ -3747,6 +3776,7 @@ export const TokensCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerRegistry/registries/{registryName}/tokens/{tokenName}",
     apiVersion: "2025-11-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type TokensCreateInput = typeof TokensCreateInput.Type;
@@ -3798,6 +3828,7 @@ export const TokensDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerRegistry/registries/{registryName}/tokens/{tokenName}",
     apiVersion: "2025-11-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type TokensDeleteInput = typeof TokensDeleteInput.Type;
@@ -3982,6 +4013,7 @@ export const TokensUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerRegistry/registries/{registryName}/tokens/{tokenName}",
     apiVersion: "2025-11-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type TokensUpdateInput = typeof TokensUpdateInput.Type;
@@ -4054,6 +4086,7 @@ export const WebhooksCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerRegistry/registries/{registryName}/webhooks/{webhookName}",
     apiVersion: "2025-11-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type WebhooksCreateInput = typeof WebhooksCreateInput.Type;
@@ -4105,6 +4138,7 @@ export const WebhooksDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerRegistry/registries/{registryName}/webhooks/{webhookName}",
     apiVersion: "2025-11-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type WebhooksDeleteInput = typeof WebhooksDeleteInput.Type;
@@ -4398,6 +4432,7 @@ export const WebhooksUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerRegistry/registries/{registryName}/webhooks/{webhookName}",
     apiVersion: "2025-11-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type WebhooksUpdateInput = typeof WebhooksUpdateInput.Type;

--- a/packages/azure/src/services/containerservice.ts
+++ b/packages/azure/src/services/containerservice.ts
@@ -21,6 +21,7 @@ export const AgentPoolsAbortLatestOperationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/agentPools/{agentPoolName}/abort",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AgentPoolsAbortLatestOperationInput =
@@ -376,6 +377,7 @@ export const AgentPoolsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/agentPools/{agentPoolName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AgentPoolsCreateOrUpdateInput =
@@ -435,6 +437,7 @@ export const AgentPoolsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/agentPools/{agentPoolName}",
     apiVersion: "2026-01-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type AgentPoolsDeleteInput = typeof AgentPoolsDeleteInput.Type;
@@ -472,6 +475,7 @@ export const AgentPoolsDeleteMachinesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/agentPools/{agentPoolName}/deleteMachines",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AgentPoolsDeleteMachinesInput =
@@ -726,6 +730,7 @@ export const AgentPoolsUpgradeNodeImageVersionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/agentPools/{agentPoolName}/upgradeNodeImageVersion",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AgentPoolsUpgradeNodeImageVersionInput =
@@ -766,6 +771,7 @@ export const AutoUpgradeProfileOperationsGenerateUpdateRunInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/fleets/{fleetName}/autoUpgradeProfiles/{autoUpgradeProfileName}/generateUpdateRun",
       apiVersion: "2025-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AutoUpgradeProfileOperationsGenerateUpdateRunInput =
@@ -866,6 +872,7 @@ export const AutoUpgradeProfilesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/fleets/{fleetName}/autoUpgradeProfiles/{autoUpgradeProfileName}",
       apiVersion: "2025-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AutoUpgradeProfilesCreateOrUpdateInput =
@@ -924,6 +931,7 @@ export const AutoUpgradeProfilesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/fleets/{fleetName}/autoUpgradeProfiles/{autoUpgradeProfileName}",
       apiVersion: "2025-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AutoUpgradeProfilesDeleteInput =
@@ -1107,6 +1115,7 @@ export const DeploymentSafeguardsCreateInput =
       method: "PUT",
       path: "/{resourceUri}/providers/Microsoft.ContainerService/deploymentSafeguards/default",
       apiVersion: "2025-07-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DeploymentSafeguardsCreateInput =
@@ -1155,6 +1164,7 @@ export const DeploymentSafeguardsDeleteInput =
       method: "DELETE",
       path: "/{resourceUri}/providers/Microsoft.ContainerService/deploymentSafeguards/default",
       apiVersion: "2025-07-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeploymentSafeguardsDeleteInput =
@@ -1356,6 +1366,7 @@ export const FleetMembersCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/fleets/{fleetName}/members/{fleetMemberName}",
       apiVersion: "2025-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type FleetMembersCreateInput = typeof FleetMembersCreateInput.Type;
@@ -1411,6 +1422,7 @@ export const FleetMembersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/fleets/{fleetName}/members/{fleetMemberName}",
       apiVersion: "2025-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type FleetMembersDeleteInput = typeof FleetMembersDeleteInput.Type;
@@ -1572,6 +1584,7 @@ export const FleetMembersUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/fleets/{fleetName}/members/{fleetMemberName}",
       apiVersion: "2025-03-01",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type FleetMembersUpdateInput = typeof FleetMembersUpdateInput.Type;
@@ -1722,6 +1735,7 @@ export const FleetsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/fleets/{fleetName}",
       apiVersion: "2025-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type FleetsCreateOrUpdateInput = typeof FleetsCreateOrUpdateInput.Type;
@@ -1776,6 +1790,7 @@ export const FleetsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/fleets/{fleetName}",
     apiVersion: "2025-03-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type FleetsDeleteInput = typeof FleetsDeleteInput.Type;
@@ -2058,6 +2073,7 @@ export const FleetsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/fleets/{fleetName}",
     apiVersion: "2025-03-01",
+    longRunning: { finalStateVia: "original-uri" },
   }),
 );
 export type FleetsUpdateInput = typeof FleetsUpdateInput.Type;
@@ -2133,6 +2149,7 @@ export const FleetUpdateStrategiesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/fleets/{fleetName}/updateStrategies/{updateStrategyName}",
       apiVersion: "2025-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type FleetUpdateStrategiesCreateOrUpdateInput =
@@ -2191,6 +2208,7 @@ export const FleetUpdateStrategiesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/fleets/{fleetName}/updateStrategies/{updateStrategyName}",
       apiVersion: "2025-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type FleetUpdateStrategiesDeleteInput =
@@ -2778,6 +2796,7 @@ export const ManagedClustersAbortLatestOperationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/abort",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedClustersAbortLatestOperationInput =
@@ -3872,6 +3891,7 @@ export const ManagedClustersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ManagedClustersCreateOrUpdateInput =
@@ -3928,6 +3948,7 @@ export const ManagedClustersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ManagedClustersDeleteInput = typeof ManagedClustersDeleteInput.Type;
@@ -4769,6 +4790,7 @@ export const ManagedClustersResetServicePrincipalProfileInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/resetServicePrincipalProfile",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedClustersResetServicePrincipalProfileInput =
@@ -4807,6 +4829,7 @@ export const ManagedClustersRotateClusterCertificatesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/rotateClusterCertificates",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedClustersRotateClusterCertificatesInput =
@@ -4845,6 +4868,7 @@ export const ManagedClustersRotateServiceAccountSigningKeysInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/rotateServiceAccountSigningKeys",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedClustersRotateServiceAccountSigningKeysInput =
@@ -4884,6 +4908,7 @@ export const ManagedClustersRunCommandInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/runCommand",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedClustersRunCommandInput =
@@ -4935,6 +4960,7 @@ export const ManagedClustersStartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/start",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedClustersStartInput = typeof ManagedClustersStartInput.Type;
@@ -4972,6 +4998,7 @@ export const ManagedClustersStopInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/stop",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedClustersStopInput = typeof ManagedClustersStopInput.Type;
@@ -5008,6 +5035,7 @@ export const ManagedClustersUpdateTagsInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ManagedClustersUpdateTagsInput =
@@ -5109,6 +5137,7 @@ export const ManagedNamespacesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/managedNamespaces/{managedNamespaceName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ManagedNamespacesCreateOrUpdateInput =
@@ -5165,6 +5194,7 @@ export const ManagedNamespacesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/managedNamespaces/{managedNamespaceName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ManagedNamespacesDeleteInput =
@@ -5481,6 +5511,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =
@@ -6181,6 +6212,7 @@ export const TrustedAccessRoleBindingsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/trustedAccessRoleBindings/{trustedAccessRoleBindingName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type TrustedAccessRoleBindingsCreateOrUpdateInput =
@@ -6237,6 +6269,7 @@ export const TrustedAccessRoleBindingsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/trustedAccessRoleBindings/{trustedAccessRoleBindingName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type TrustedAccessRoleBindingsDeleteInput =
@@ -6830,6 +6863,7 @@ export const UpdateRunsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/fleets/{fleetName}/updateRuns/{updateRunName}",
       apiVersion: "2025-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type UpdateRunsCreateOrUpdateInput =
@@ -6888,6 +6922,7 @@ export const UpdateRunsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/fleets/{fleetName}/updateRuns/{updateRunName}",
     apiVersion: "2025-03-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type UpdateRunsDeleteInput = typeof UpdateRunsDeleteInput.Type;
@@ -7048,6 +7083,7 @@ export const UpdateRunsSkipInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/fleets/{fleetName}/updateRuns/{updateRunName}/skip",
     apiVersion: "2025-03-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type UpdateRunsSkipInput = typeof UpdateRunsSkipInput.Type;
@@ -7100,6 +7136,7 @@ export const UpdateRunsStartInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/fleets/{fleetName}/updateRuns/{updateRunName}/start",
     apiVersion: "2025-03-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type UpdateRunsStartInput = typeof UpdateRunsStartInput.Type;
@@ -7152,6 +7189,7 @@ export const UpdateRunsStopInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/fleets/{fleetName}/updateRuns/{updateRunName}/stop",
     apiVersion: "2025-03-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type UpdateRunsStopInput = typeof UpdateRunsStopInput.Type;

--- a/packages/azure/src/services/contosowidgetmanager.ts
+++ b/packages/azure/src/services/contosowidgetmanager.ts
@@ -39,6 +39,7 @@ export const EmployeesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Contoso/employees/{employeeName}",
       apiVersion: "2021-11-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type EmployeesCreateOrUpdateInput =
@@ -93,6 +94,7 @@ export const EmployeesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Contoso/employees/{employeeName}",
     apiVersion: "2021-11-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type EmployeesDeleteInput = typeof EmployeesDeleteInput.Type;

--- a/packages/azure/src/services/cosmos-db.ts
+++ b/packages/azure/src/services/cosmos-db.ts
@@ -109,6 +109,7 @@ export const CassandraClustersCreateUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/cassandraClusters/{clusterName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type CassandraClustersCreateUpdateInput =
@@ -156,6 +157,7 @@ export const CassandraClustersDeallocateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/cassandraClusters/{clusterName}/deallocate",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type CassandraClustersDeallocateInput =
@@ -191,6 +193,7 @@ export const CassandraClustersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/cassandraClusters/{clusterName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type CassandraClustersDeleteInput =
@@ -277,6 +280,7 @@ export const CassandraClustersInvokeCommandInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/cassandraClusters/{clusterName}/invokeCommand",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type CassandraClustersInvokeCommandInput =
@@ -419,6 +423,7 @@ export const CassandraClustersStartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/cassandraClusters/{clusterName}/start",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type CassandraClustersStartInput =
@@ -661,6 +666,7 @@ export const CassandraClustersUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/cassandraClusters/{clusterName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type CassandraClustersUpdateInput =
@@ -771,6 +777,7 @@ export const CassandraDataCentersCreateUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/cassandraClusters/{clusterName}/dataCenters/{dataCenterName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type CassandraDataCentersCreateUpdateInput =
@@ -809,6 +816,7 @@ export const CassandraDataCentersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/cassandraClusters/{clusterName}/dataCenters/{dataCenterName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type CassandraDataCentersDeleteInput =
@@ -990,6 +998,7 @@ export const CassandraDataCentersUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/cassandraClusters/{clusterName}/dataCenters/{dataCenterName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type CassandraDataCentersUpdateInput =
@@ -1049,6 +1058,7 @@ export const CassandraResourcesCreateUpdateCassandraKeyspaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/cassandraKeyspaces/{keyspaceName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type CassandraResourcesCreateUpdateCassandraKeyspaceInput =
@@ -1138,6 +1148,7 @@ export const CassandraResourcesCreateUpdateCassandraTableInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/cassandraKeyspaces/{keyspaceName}/tables/{tableName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type CassandraResourcesCreateUpdateCassandraTableInput =
@@ -1178,6 +1189,7 @@ export const CassandraResourcesDeleteCassandraKeyspaceInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/cassandraKeyspaces/{keyspaceName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type CassandraResourcesDeleteCassandraKeyspaceInput =
@@ -1212,6 +1224,7 @@ export const CassandraResourcesDeleteCassandraTableInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/cassandraKeyspaces/{keyspaceName}/tables/{tableName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type CassandraResourcesDeleteCassandraTableInput =
@@ -1498,6 +1511,7 @@ export const CassandraResourcesMigrateCassandraKeyspaceToAutoscaleInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/cassandraKeyspaces/{keyspaceName}/throughputSettings/default/migrateToAutoscale",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type CassandraResourcesMigrateCassandraKeyspaceToAutoscaleInput =
@@ -1538,6 +1552,7 @@ export const CassandraResourcesMigrateCassandraKeyspaceToManualThroughputInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/cassandraKeyspaces/{keyspaceName}/throughputSettings/default/migrateToManualThroughput",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type CassandraResourcesMigrateCassandraKeyspaceToManualThroughputInput =
@@ -1580,6 +1595,7 @@ export const CassandraResourcesMigrateCassandraTableToAutoscaleInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/cassandraKeyspaces/{keyspaceName}/tables/{tableName}/throughputSettings/default/migrateToAutoscale",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type CassandraResourcesMigrateCassandraTableToAutoscaleInput =
@@ -1620,6 +1636,7 @@ export const CassandraResourcesMigrateCassandraTableToManualThroughputInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/cassandraKeyspaces/{keyspaceName}/tables/{tableName}/throughputSettings/default/migrateToManualThroughput",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type CassandraResourcesMigrateCassandraTableToManualThroughputInput =
@@ -1691,6 +1708,7 @@ export const CassandraResourcesUpdateCassandraKeyspaceThroughputInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/cassandraKeyspaces/{keyspaceName}/throughputSettings/default",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type CassandraResourcesUpdateCassandraKeyspaceThroughputInput =
@@ -1761,6 +1779,7 @@ export const CassandraResourcesUpdateCassandraTableThroughputInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/cassandraKeyspaces/{keyspaceName}/tables/{tableName}/throughputSettings/default",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type CassandraResourcesUpdateCassandraTableThroughputInput =
@@ -2554,6 +2573,7 @@ export const DatabaseAccountsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type DatabaseAccountsCreateOrUpdateInput =
@@ -2594,6 +2614,7 @@ export const DatabaseAccountsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type DatabaseAccountsDeleteInput =
@@ -2636,6 +2657,7 @@ export const DatabaseAccountsFailoverPriorityChangeInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/failoverPriorityChange",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type DatabaseAccountsFailoverPriorityChangeInput =
@@ -3186,6 +3208,7 @@ export const DatabaseAccountsOfflineRegionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/offlineRegion",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type DatabaseAccountsOfflineRegionInput =
@@ -3221,6 +3244,7 @@ export const DatabaseAccountsOnlineRegionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/onlineRegion",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type DatabaseAccountsOnlineRegionInput =
@@ -3261,6 +3285,7 @@ export const DatabaseAccountsRegenerateKeyInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/regenerateKey",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type DatabaseAccountsRegenerateKeyInput =
@@ -3483,6 +3508,7 @@ export const DatabaseAccountsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type DatabaseAccountsUpdateInput =
@@ -3790,6 +3816,7 @@ export const FleetDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/fleets/{fleetName}",
     apiVersion: "2025-10-15",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type FleetDeleteInput = typeof FleetDeleteInput.Type;
@@ -4018,6 +4045,7 @@ export const FleetspaceAccountCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/fleets/{fleetName}/fleetspaces/{fleetspaceName}/fleetspaceAccounts/{fleetspaceAccountName}",
       apiVersion: "2025-10-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type FleetspaceAccountCreateInput =
@@ -4071,6 +4099,7 @@ export const FleetspaceAccountDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/fleets/{fleetName}/fleetspaces/{fleetspaceName}/fleetspaceAccounts/{fleetspaceAccountName}",
       apiVersion: "2025-10-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type FleetspaceAccountDeleteInput =
@@ -4249,6 +4278,7 @@ export const FleetspaceCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/fleets/{fleetName}/fleetspaces/{fleetspaceName}",
     apiVersion: "2025-10-15",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type FleetspaceCreateInput = typeof FleetspaceCreateInput.Type;
@@ -4298,6 +4328,7 @@ export const FleetspaceDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/fleets/{fleetName}/fleetspaces/{fleetspaceName}",
     apiVersion: "2025-10-15",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type FleetspaceDeleteInput = typeof FleetspaceDeleteInput.Type;
@@ -4462,6 +4493,7 @@ export const FleetspaceUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/fleets/{fleetName}/fleetspaces/{fleetspaceName}",
     apiVersion: "2025-10-15",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type FleetspaceUpdateInput = typeof FleetspaceUpdateInput.Type;
@@ -4600,6 +4632,7 @@ export const GremlinResourcesCreateUpdateGremlinDatabaseInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/gremlinDatabases/{databaseName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type GremlinResourcesCreateUpdateGremlinDatabaseInput =
@@ -4791,6 +4824,7 @@ export const GremlinResourcesCreateUpdateGremlinGraphInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/gremlinDatabases/{databaseName}/graphs/{graphName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type GremlinResourcesCreateUpdateGremlinGraphInput =
@@ -4831,6 +4865,7 @@ export const GremlinResourcesDeleteGremlinDatabaseInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/gremlinDatabases/{databaseName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type GremlinResourcesDeleteGremlinDatabaseInput =
@@ -4865,6 +4900,7 @@ export const GremlinResourcesDeleteGremlinGraphInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/gremlinDatabases/{databaseName}/graphs/{graphName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type GremlinResourcesDeleteGremlinGraphInput =
@@ -5151,6 +5187,7 @@ export const GremlinResourcesMigrateGremlinDatabaseToAutoscaleInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/gremlinDatabases/{databaseName}/throughputSettings/default/migrateToAutoscale",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type GremlinResourcesMigrateGremlinDatabaseToAutoscaleInput =
@@ -5191,6 +5228,7 @@ export const GremlinResourcesMigrateGremlinDatabaseToManualThroughputInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/gremlinDatabases/{databaseName}/throughputSettings/default/migrateToManualThroughput",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type GremlinResourcesMigrateGremlinDatabaseToManualThroughputInput =
@@ -5232,6 +5270,7 @@ export const GremlinResourcesMigrateGremlinGraphToAutoscaleInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/gremlinDatabases/{databaseName}/graphs/{graphName}/throughputSettings/default/migrateToAutoscale",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type GremlinResourcesMigrateGremlinGraphToAutoscaleInput =
@@ -5272,6 +5311,7 @@ export const GremlinResourcesMigrateGremlinGraphToManualThroughputInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/gremlinDatabases/{databaseName}/graphs/{graphName}/throughputSettings/default/migrateToManualThroughput",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type GremlinResourcesMigrateGremlinGraphToManualThroughputInput =
@@ -5316,6 +5356,7 @@ export const GremlinResourcesRetrieveContinuousBackupInformationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/gremlinDatabases/{databaseName}/graphs/{graphName}/retrieveContinuousBackupInformation",
       apiVersion: "2025-10-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type GremlinResourcesRetrieveContinuousBackupInformationInput =
@@ -5389,6 +5430,7 @@ export const GremlinResourcesUpdateGremlinDatabaseThroughputInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/gremlinDatabases/{databaseName}/throughputSettings/default",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type GremlinResourcesUpdateGremlinDatabaseThroughputInput =
@@ -5459,6 +5501,7 @@ export const GremlinResourcesUpdateGremlinGraphThroughputInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/gremlinDatabases/{databaseName}/graphs/{graphName}/throughputSettings/default",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type GremlinResourcesUpdateGremlinGraphThroughputInput =
@@ -5614,6 +5657,7 @@ export const MongoDBResourcesCreateUpdateMongoDBCollectionInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/collections/{collectionName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type MongoDBResourcesCreateUpdateMongoDBCollectionInput =
@@ -5682,6 +5726,7 @@ export const MongoDBResourcesCreateUpdateMongoDBDatabaseInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type MongoDBResourcesCreateUpdateMongoDBDatabaseInput =
@@ -5751,6 +5796,7 @@ export const MongoDBResourcesCreateUpdateMongoRoleDefinitionInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbRoleDefinitions/{mongoRoleDefinitionId}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type MongoDBResourcesCreateUpdateMongoRoleDefinitionInput =
@@ -5808,6 +5854,7 @@ export const MongoDBResourcesCreateUpdateMongoUserDefinitionInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbUserDefinitions/{mongoUserDefinitionId}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type MongoDBResourcesCreateUpdateMongoUserDefinitionInput =
@@ -5847,6 +5894,7 @@ export const MongoDBResourcesDeleteMongoDBCollectionInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/collections/{collectionName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type MongoDBResourcesDeleteMongoDBCollectionInput =
@@ -5881,6 +5929,7 @@ export const MongoDBResourcesDeleteMongoDBDatabaseInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type MongoDBResourcesDeleteMongoDBDatabaseInput =
@@ -5916,6 +5965,7 @@ export const MongoDBResourcesDeleteMongoRoleDefinitionInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbRoleDefinitions/{mongoRoleDefinitionId}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type MongoDBResourcesDeleteMongoRoleDefinitionInput =
@@ -5952,6 +6002,7 @@ export const MongoDBResourcesDeleteMongoUserDefinitionInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbUserDefinitions/{mongoUserDefinitionId}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type MongoDBResourcesDeleteMongoUserDefinitionInput =
@@ -6411,6 +6462,7 @@ export const MongoDBResourcesMigrateMongoDBCollectionToAutoscaleInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/collections/{collectionName}/throughputSettings/default/migrateToAutoscale",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type MongoDBResourcesMigrateMongoDBCollectionToAutoscaleInput =
@@ -6451,6 +6503,7 @@ export const MongoDBResourcesMigrateMongoDBCollectionToManualThroughputInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/collections/{collectionName}/throughputSettings/default/migrateToManualThroughput",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type MongoDBResourcesMigrateMongoDBCollectionToManualThroughputInput =
@@ -6493,6 +6546,7 @@ export const MongoDBResourcesMigrateMongoDBDatabaseToAutoscaleInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/throughputSettings/default/migrateToAutoscale",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type MongoDBResourcesMigrateMongoDBDatabaseToAutoscaleInput =
@@ -6533,6 +6587,7 @@ export const MongoDBResourcesMigrateMongoDBDatabaseToManualThroughputInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/throughputSettings/default/migrateToManualThroughput",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type MongoDBResourcesMigrateMongoDBDatabaseToManualThroughputInput =
@@ -6578,6 +6633,7 @@ export const MongoDBResourcesRetrieveContinuousBackupInformationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/collections/{collectionName}/retrieveContinuousBackupInformation",
       apiVersion: "2025-10-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type MongoDBResourcesRetrieveContinuousBackupInformationInput =
@@ -6651,6 +6707,7 @@ export const MongoDBResourcesUpdateMongoDBCollectionThroughputInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/collections/{collectionName}/throughputSettings/default",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type MongoDBResourcesUpdateMongoDBCollectionThroughputInput =
@@ -6721,6 +6778,7 @@ export const MongoDBResourcesUpdateMongoDBDatabaseThroughputInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/throughputSettings/default",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type MongoDBResourcesUpdateMongoDBDatabaseThroughputInput =
@@ -6764,6 +6822,7 @@ export const NotebookWorkspacesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/notebookWorkspaces/{notebookWorkspaceName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type NotebookWorkspacesCreateOrUpdateInput =
@@ -6802,6 +6861,7 @@ export const NotebookWorkspacesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/notebookWorkspaces/{notebookWorkspaceName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type NotebookWorkspacesDeleteInput =
@@ -6956,6 +7016,7 @@ export const NotebookWorkspacesRegenerateAuthTokenInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/notebookWorkspaces/{notebookWorkspaceName}/regenerateAuthToken",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type NotebookWorkspacesRegenerateAuthTokenInput =
@@ -6990,6 +7051,7 @@ export const NotebookWorkspacesStartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/notebookWorkspaces/{notebookWorkspaceName}/start",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type NotebookWorkspacesStartInput =
@@ -7452,6 +7514,7 @@ export const PrivateEndpointConnectionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type PrivateEndpointConnectionsCreateOrUpdateInput =
@@ -7490,6 +7553,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =
@@ -8786,6 +8850,7 @@ export const ServiceCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/services/{serviceName}",
     apiVersion: "2025-10-15",
+    longRunning: {},
   }),
 );
 export type ServiceCreateInput = typeof ServiceCreateInput.Type;
@@ -8819,6 +8884,7 @@ export const ServiceDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/services/{serviceName}",
     apiVersion: "2025-10-15",
+    longRunning: {},
   }),
 );
 export type ServiceDeleteInput = typeof ServiceDeleteInput.Type;
@@ -8936,6 +9002,7 @@ export const SqlResourcesCreateUpdateClientEncryptionKeyInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/clientEncryptionKeys/{clientEncryptionKeyName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type SqlResourcesCreateUpdateClientEncryptionKeyInput =
@@ -9182,6 +9249,7 @@ export const SqlResourcesCreateUpdateSqlContainerInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type SqlResourcesCreateUpdateSqlContainerInput =
@@ -9250,6 +9318,7 @@ export const SqlResourcesCreateUpdateSqlDatabaseInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type SqlResourcesCreateUpdateSqlDatabaseInput =
@@ -9298,6 +9367,7 @@ export const SqlResourcesCreateUpdateSqlRoleAssignmentInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlRoleAssignments/{roleAssignmentId}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type SqlResourcesCreateUpdateSqlRoleAssignmentInput =
@@ -9353,6 +9423,7 @@ export const SqlResourcesCreateUpdateSqlRoleDefinitionInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlRoleDefinitions/{roleDefinitionId}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type SqlResourcesCreateUpdateSqlRoleDefinitionInput =
@@ -9413,6 +9484,7 @@ export const SqlResourcesCreateUpdateSqlStoredProcedureInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/storedProcedures/{storedProcedureName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type SqlResourcesCreateUpdateSqlStoredProcedureInput =
@@ -9478,6 +9550,7 @@ export const SqlResourcesCreateUpdateSqlTriggerInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/triggers/{triggerName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type SqlResourcesCreateUpdateSqlTriggerInput =
@@ -9539,6 +9612,7 @@ export const SqlResourcesCreateUpdateSqlUserDefinedFunctionInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/userDefinedFunctions/{userDefinedFunctionName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type SqlResourcesCreateUpdateSqlUserDefinedFunctionInput =
@@ -9579,6 +9653,7 @@ export const SqlResourcesDeleteSqlContainerInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type SqlResourcesDeleteSqlContainerInput =
@@ -9613,6 +9688,7 @@ export const SqlResourcesDeleteSqlDatabaseInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type SqlResourcesDeleteSqlDatabaseInput =
@@ -9648,6 +9724,7 @@ export const SqlResourcesDeleteSqlRoleAssignmentInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlRoleAssignments/{roleAssignmentId}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type SqlResourcesDeleteSqlRoleAssignmentInput =
@@ -9684,6 +9761,7 @@ export const SqlResourcesDeleteSqlRoleDefinitionInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlRoleDefinitions/{roleDefinitionId}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type SqlResourcesDeleteSqlRoleDefinitionInput =
@@ -9719,6 +9797,7 @@ export const SqlResourcesDeleteSqlStoredProcedureInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/storedProcedures/{storedProcedureName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type SqlResourcesDeleteSqlStoredProcedureInput =
@@ -9753,6 +9832,7 @@ export const SqlResourcesDeleteSqlTriggerInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/triggers/{triggerName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type SqlResourcesDeleteSqlTriggerInput =
@@ -9787,6 +9867,7 @@ export const SqlResourcesDeleteSqlUserDefinedFunctionInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/userDefinedFunctions/{userDefinedFunctionName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type SqlResourcesDeleteSqlUserDefinedFunctionInput =
@@ -10589,6 +10670,7 @@ export const SqlResourcesMigrateSqlContainerToAutoscaleInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/throughputSettings/default/migrateToAutoscale",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type SqlResourcesMigrateSqlContainerToAutoscaleInput =
@@ -10629,6 +10711,7 @@ export const SqlResourcesMigrateSqlContainerToManualThroughputInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/throughputSettings/default/migrateToManualThroughput",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type SqlResourcesMigrateSqlContainerToManualThroughputInput =
@@ -10669,6 +10752,7 @@ export const SqlResourcesMigrateSqlDatabaseToAutoscaleInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/throughputSettings/default/migrateToAutoscale",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type SqlResourcesMigrateSqlDatabaseToAutoscaleInput =
@@ -10709,6 +10793,7 @@ export const SqlResourcesMigrateSqlDatabaseToManualThroughputInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/throughputSettings/default/migrateToManualThroughput",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type SqlResourcesMigrateSqlDatabaseToManualThroughputInput =
@@ -10753,6 +10838,7 @@ export const SqlResourcesRetrieveContinuousBackupInformationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/retrieveContinuousBackupInformation",
       apiVersion: "2025-10-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SqlResourcesRetrieveContinuousBackupInformationInput =
@@ -10826,6 +10912,7 @@ export const SqlResourcesUpdateSqlContainerThroughputInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/throughputSettings/default",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type SqlResourcesUpdateSqlContainerThroughputInput =
@@ -10896,6 +10983,7 @@ export const SqlResourcesUpdateSqlDatabaseThroughputInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/throughputSettings/default",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type SqlResourcesUpdateSqlDatabaseThroughputInput =
@@ -10964,6 +11052,7 @@ export const TableResourcesCreateUpdateTableInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/tables/{tableName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type TableResourcesCreateUpdateTableInput =
@@ -11004,6 +11093,7 @@ export const TableResourcesDeleteTableInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/tables/{tableName}",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type TableResourcesDeleteTableInput =
@@ -11167,6 +11257,7 @@ export const TableResourcesMigrateTableToAutoscaleInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/tables/{tableName}/throughputSettings/default/migrateToAutoscale",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type TableResourcesMigrateTableToAutoscaleInput =
@@ -11207,6 +11298,7 @@ export const TableResourcesMigrateTableToManualThroughputInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/tables/{tableName}/throughputSettings/default/migrateToManualThroughput",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type TableResourcesMigrateTableToManualThroughputInput =
@@ -11250,6 +11342,7 @@ export const TableResourcesRetrieveContinuousBackupInformationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/tables/{tableName}/retrieveContinuousBackupInformation",
       apiVersion: "2025-10-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type TableResourcesRetrieveContinuousBackupInformationInput =
@@ -11322,6 +11415,7 @@ export const TableResourcesUpdateTableThroughputInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/tables/{tableName}/throughputSettings/default",
       apiVersion: "2025-10-15",
+      longRunning: {},
     }),
   );
 export type TableResourcesUpdateTableThroughputInput =

--- a/packages/azure/src/services/cost-management.ts
+++ b/packages/azure/src/services/cost-management.ts
@@ -1985,6 +1985,7 @@ export const GenerateBenefitUtilizationSummariesReportGenerateByBillingAccountIn
       method: "POST",
       path: "/providers/microsoft.Billing/billingAccounts/{billingAccountId}/providers/Microsoft.CostManagement/generateBenefitUtilizationSummariesReport",
       apiVersion: "2025-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type GenerateBenefitUtilizationSummariesReportGenerateByBillingAccountInput =
@@ -2077,6 +2078,7 @@ export const GenerateBenefitUtilizationSummariesReportGenerateByBillingProfileIn
       method: "POST",
       path: "/providers/microsoft.Billing/billingAccounts/{billingAccountId}/billingProfiles/{billingProfileId}/providers/Microsoft.CostManagement/generateBenefitUtilizationSummariesReport",
       apiVersion: "2025-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type GenerateBenefitUtilizationSummariesReportGenerateByBillingProfileInput =
@@ -2172,6 +2174,7 @@ export const GenerateBenefitUtilizationSummariesReportGenerateByReservationIdInp
       method: "POST",
       path: "/providers/microsoft.Capacity/reservationorders/{reservationOrderId}/reservations/{reservationId}/providers/Microsoft.CostManagement/generateBenefitUtilizationSummariesReport",
       apiVersion: "2025-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type GenerateBenefitUtilizationSummariesReportGenerateByReservationIdInput =
@@ -2266,6 +2269,7 @@ export const GenerateBenefitUtilizationSummariesReportGenerateByReservationOrder
       method: "POST",
       path: "/providers/microsoft.Capacity/reservationorders/{reservationOrderId}/providers/Microsoft.CostManagement/generateBenefitUtilizationSummariesReport",
       apiVersion: "2025-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type GenerateBenefitUtilizationSummariesReportGenerateByReservationOrderIdInput =
@@ -2360,6 +2364,7 @@ export const GenerateBenefitUtilizationSummariesReportGenerateBySavingsPlanIdInp
       method: "POST",
       path: "/providers/microsoft.BillingBenefits/savingsPlanOrders/{savingsPlanOrderId}/savingsPlans/{savingsPlanId}/providers/Microsoft.CostManagement/generateBenefitUtilizationSummariesReport",
       apiVersion: "2025-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type GenerateBenefitUtilizationSummariesReportGenerateBySavingsPlanIdInput =
@@ -2454,6 +2459,7 @@ export const GenerateBenefitUtilizationSummariesReportGenerateBySavingsPlanOrder
       method: "POST",
       path: "/providers/microsoft.BillingBenefits/savingsPlanOrders/{savingsPlanOrderId}/providers/Microsoft.CostManagement/generateBenefitUtilizationSummariesReport",
       apiVersion: "2025-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type GenerateBenefitUtilizationSummariesReportGenerateBySavingsPlanOrderIdInput =
@@ -2546,6 +2552,7 @@ export const GenerateCostDetailsReportCreateOperationInput =
       method: "POST",
       path: "/{scope}/providers/Microsoft.CostManagement/generateCostDetailsReport",
       apiVersion: "2025-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type GenerateCostDetailsReportCreateOperationInput =
@@ -2630,6 +2637,7 @@ export const GenerateCostDetailsReportGetOperationResultsInput =
       method: "GET",
       path: "/{scope}/providers/Microsoft.CostManagement/costDetailsOperationResults/{operationId}",
       apiVersion: "2025-03-01",
+      longRunning: {},
     }),
   );
 export type GenerateCostDetailsReportGetOperationResultsInput =
@@ -2724,6 +2732,7 @@ export const GenerateDetailedCostReportCreateOperationInput =
       method: "POST",
       path: "/{scope}/providers/Microsoft.CostManagement/generateDetailedCostReport",
       apiVersion: "2025-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type GenerateDetailedCostReportCreateOperationInput =
@@ -2775,6 +2784,7 @@ export const GenerateDetailedCostReportOperationResultsGetInput =
       method: "GET",
       path: "/{scope}/providers/Microsoft.CostManagement/operationResults/{operationId}",
       apiVersion: "2025-03-01",
+      longRunning: {},
     }),
   );
 export type GenerateDetailedCostReportOperationResultsGetInput =
@@ -2880,6 +2890,7 @@ export const GenerateReservationDetailsReportByBillingAccountIdInput =
       method: "POST",
       path: "/providers/microsoft.Billing/billingAccounts/{billingAccountId}/providers/Microsoft.CostManagement/generateReservationDetailsReport",
       apiVersion: "2025-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type GenerateReservationDetailsReportByBillingAccountIdInput =
@@ -2941,6 +2952,7 @@ export const GenerateReservationDetailsReportByBillingProfileIdInput =
       method: "POST",
       path: "/providers/microsoft.Billing/billingAccounts/{billingAccountId}/billingProfiles/{billingProfileId}/providers/Microsoft.CostManagement/generateReservationDetailsReport",
       apiVersion: "2025-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type GenerateReservationDetailsReportByBillingProfileIdInput =
@@ -3049,6 +3061,7 @@ export const PriceSheetDownloadByBillingAccountInput =
       method: "POST",
       path: "/providers/microsoft.Billing/billingAccounts/{billingAccountId}/billingPeriods/{billingPeriodName}/providers/Microsoft.CostManagement/pricesheets/default/download",
       apiVersion: "2025-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PriceSheetDownloadByBillingAccountInput =
@@ -3114,6 +3127,7 @@ export const PriceSheetDownloadByBillingProfileInput =
       method: "POST",
       path: "/providers/microsoft.Billing/billingAccounts/{billingAccountName}/billingProfiles/{billingProfileName}/providers/Microsoft.CostManagement/pricesheets/default/download",
       apiVersion: "2025-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PriceSheetDownloadByBillingProfileInput =
@@ -3184,6 +3198,7 @@ export const PriceSheetDownloadByInvoiceInput =
       method: "POST",
       path: "/providers/microsoft.Billing/billingAccounts/{billingAccountName}/billingProfiles/{billingProfileName}/invoices/{invoiceName}/providers/Microsoft.CostManagement/pricesheets/default/download",
       apiVersion: "2025-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PriceSheetDownloadByInvoiceInput =

--- a/packages/azure/src/services/cpim.ts
+++ b/packages/azure/src/services/cpim.ts
@@ -65,6 +65,7 @@ export const B2CTenantsCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureActiveDirectory/b2cDirectories/{resourceName}",
     apiVersion: "2021-04-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type B2CTenantsCreateInput = typeof B2CTenantsCreateInput.Type;
@@ -130,6 +131,7 @@ export const B2CTenantsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureActiveDirectory/b2cDirectories/{resourceName}",
     apiVersion: "2021-04-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type B2CTenantsDeleteInput = typeof B2CTenantsDeleteInput.Type;

--- a/packages/azure/src/services/customer-insights.ts
+++ b/packages/azure/src/services/customer-insights.ts
@@ -518,6 +518,7 @@ export const ConnectorsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CustomerInsights/hubs/{hubName}/connectors/{connectorName}",
       apiVersion: "2017-04-26",
+      longRunning: {},
     }),
   );
 export type ConnectorsCreateOrUpdateInput =
@@ -557,6 +558,7 @@ export const ConnectorsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CustomerInsights/hubs/{hubName}/connectors/{connectorName}",
     apiVersion: "2017-04-26",
+    longRunning: {},
   }),
 );
 export type ConnectorsDeleteInput = typeof ConnectorsDeleteInput.Type;
@@ -717,6 +719,7 @@ export const HubsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CustomerInsights/hubs/{hubName}",
     apiVersion: "2017-04-26",
+    longRunning: {},
   }),
 );
 export type HubsDeleteInput = typeof HubsDeleteInput.Type;
@@ -1021,6 +1024,7 @@ export const InteractionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CustomerInsights/hubs/{hubName}/interactions/{interactionName}",
       apiVersion: "2017-04-26",
+      longRunning: {},
     }),
   );
 export type InteractionsCreateOrUpdateInput =
@@ -1301,6 +1305,7 @@ export const KpiCreateOrUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CustomerInsights/hubs/{hubName}/kpi/{kpiName}",
     apiVersion: "2017-04-26",
+    longRunning: {},
   }),
 );
 export type KpiCreateOrUpdateInput = typeof KpiCreateOrUpdateInput.Type;
@@ -1336,6 +1341,7 @@ export const KpiDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CustomerInsights/hubs/{hubName}/kpi/{kpiName}",
     apiVersion: "2017-04-26",
+    longRunning: {},
   }),
 );
 export type KpiDeleteInput = typeof KpiDeleteInput.Type;
@@ -1528,6 +1534,7 @@ export const LinksCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CustomerInsights/hubs/{hubName}/links/{linkName}",
       apiVersion: "2017-04-26",
+      longRunning: {},
     }),
   );
 export type LinksCreateOrUpdateInput = typeof LinksCreateOrUpdateInput.Type;
@@ -1766,6 +1773,7 @@ export const PredictionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CustomerInsights/hubs/{hubName}/predictions/{predictionName}",
       apiVersion: "2017-04-26",
+      longRunning: {},
     }),
   );
 export type PredictionsCreateOrUpdateInput =
@@ -1807,6 +1815,7 @@ export const PredictionsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CustomerInsights/hubs/{hubName}/predictions/{predictionName}",
     apiVersion: "2017-04-26",
+    longRunning: {},
   }),
 );
 export type PredictionsDeleteInput = typeof PredictionsDeleteInput.Type;
@@ -2153,6 +2162,7 @@ export const ProfilesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CustomerInsights/hubs/{hubName}/profiles/{profileName}",
       apiVersion: "2017-04-26",
+      longRunning: {},
     }),
   );
 export type ProfilesCreateOrUpdateInput =
@@ -2193,6 +2203,7 @@ export const ProfilesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CustomerInsights/hubs/{hubName}/profiles/{profileName}",
     apiVersion: "2017-04-26",
+    longRunning: {},
   }),
 );
 export type ProfilesDeleteInput = typeof ProfilesDeleteInput.Type;
@@ -2479,6 +2490,7 @@ export const RelationshipLinksCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CustomerInsights/hubs/{hubName}/relationshipLinks/{relationshipLinkName}",
       apiVersion: "2017-04-26",
+      longRunning: {},
     }),
   );
 export type RelationshipLinksCreateOrUpdateInput =
@@ -2518,6 +2530,7 @@ export const RelationshipLinksDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CustomerInsights/hubs/{hubName}/relationshipLinks/{relationshipLinkName}",
       apiVersion: "2017-04-26",
+      longRunning: {},
     }),
   );
 export type RelationshipLinksDeleteInput =
@@ -2735,6 +2748,7 @@ export const RelationshipsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CustomerInsights/hubs/{hubName}/relationships/{relationshipName}",
       apiVersion: "2017-04-26",
+      longRunning: {},
     }),
   );
 export type RelationshipsCreateOrUpdateInput =
@@ -2775,6 +2789,7 @@ export const RelationshipsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CustomerInsights/hubs/{hubName}/relationships/{relationshipName}",
       apiVersion: "2017-04-26",
+      longRunning: {},
     }),
   );
 export type RelationshipsDeleteInput = typeof RelationshipsDeleteInput.Type;
@@ -3008,6 +3023,7 @@ export const RoleAssignmentsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CustomerInsights/hubs/{hubName}/roleAssignments/{assignmentName}",
       apiVersion: "2017-04-26",
+      longRunning: {},
     }),
   );
 export type RoleAssignmentsCreateOrUpdateInput =

--- a/packages/azure/src/services/dashboard.ts
+++ b/packages/azure/src/services/dashboard.ts
@@ -415,6 +415,7 @@ export const GrafanaCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Dashboard/grafana/{workspaceName}",
     apiVersion: "2025-08-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type GrafanaCreateInput = typeof GrafanaCreateInput.Type;
@@ -464,6 +465,7 @@ export const GrafanaDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Dashboard/grafana/{workspaceName}",
     apiVersion: "2025-08-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type GrafanaDeleteInput = typeof GrafanaDeleteInput.Type;
@@ -826,6 +828,7 @@ export const GrafanaUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Dashboard/grafana/{workspaceName}",
     apiVersion: "2025-08-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type GrafanaUpdateInput = typeof GrafanaUpdateInput.Type;
@@ -899,6 +902,7 @@ export const IntegrationFabricsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Dashboard/grafana/{workspaceName}/integrationFabrics/{integrationFabricName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type IntegrationFabricsCreateInput =
@@ -956,6 +960,7 @@ export const IntegrationFabricsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Dashboard/grafana/{workspaceName}/integrationFabrics/{integrationFabricName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type IntegrationFabricsDeleteInput =
@@ -1127,6 +1132,7 @@ export const IntegrationFabricsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Dashboard/grafana/{workspaceName}/integrationFabrics/{integrationFabricName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type IntegrationFabricsUpdateInput =
@@ -1202,6 +1208,7 @@ export const ManagedDashboardsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Dashboard/dashboards/{dashboardName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ManagedDashboardsCreateInput =
@@ -1389,6 +1396,7 @@ export const ManagedPrivateEndpointsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Dashboard/grafana/{workspaceName}/managedPrivateEndpoints/{managedPrivateEndpointName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type ManagedPrivateEndpointsCreateInput =
@@ -1445,6 +1453,7 @@ export const ManagedPrivateEndpointsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Dashboard/grafana/{workspaceName}/managedPrivateEndpoints/{managedPrivateEndpointName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ManagedPrivateEndpointsDeleteInput =
@@ -1609,6 +1618,7 @@ export const ManagedPrivateEndpointsRefreshInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Dashboard/grafana/{workspaceName}/refreshManagedPrivateEndpoints",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ManagedPrivateEndpointsRefreshInput =
@@ -1647,6 +1657,7 @@ export const ManagedPrivateEndpointsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Dashboard/grafana/{workspaceName}/managedPrivateEndpoints/{managedPrivateEndpointName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ManagedPrivateEndpointsUpdateInput =
@@ -1771,6 +1782,7 @@ export const PrivateEndpointConnectionsApproveInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Dashboard/grafana/{workspaceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PrivateEndpointConnectionsApproveInput =
@@ -1827,6 +1839,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Dashboard/grafana/{workspaceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =

--- a/packages/azure/src/services/databasewatcher.ts
+++ b/packages/azure/src/services/databasewatcher.ts
@@ -380,6 +380,7 @@ export const HealthValidationsStartValidationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DatabaseWatcher/watchers/{watcherName}/healthValidations/{healthValidationName}/startValidation",
       apiVersion: "2025-01-02",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type HealthValidationsStartValidationInput =
@@ -498,6 +499,7 @@ export const SharedPrivateLinkResourcesCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DatabaseWatcher/watchers/{watcherName}/sharedPrivateLinkResources/{sharedPrivateLinkResourceName}",
       apiVersion: "2025-01-02",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SharedPrivateLinkResourcesCreateInput =
@@ -554,6 +556,7 @@ export const SharedPrivateLinkResourcesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DatabaseWatcher/watchers/{watcherName}/sharedPrivateLinkResources/{sharedPrivateLinkResourceName}",
       apiVersion: "2025-01-02",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SharedPrivateLinkResourcesDeleteInput =
@@ -992,6 +995,7 @@ export const WatchersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DatabaseWatcher/watchers/{watcherName}",
       apiVersion: "2025-01-02",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type WatchersCreateOrUpdateInput =
@@ -1046,6 +1050,7 @@ export const WatchersDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DatabaseWatcher/watchers/{watcherName}",
     apiVersion: "2025-01-02",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type WatchersDeleteInput = typeof WatchersDeleteInput.Type;
@@ -1260,6 +1265,7 @@ export const WatchersStartInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DatabaseWatcher/watchers/{watcherName}/start",
     apiVersion: "2025-01-02",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type WatchersStartInput = typeof WatchersStartInput.Type;
@@ -1309,6 +1315,7 @@ export const WatchersStopInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DatabaseWatcher/watchers/{watcherName}/stop",
     apiVersion: "2025-01-02",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type WatchersStopInput = typeof WatchersStopInput.Type;
@@ -1398,6 +1405,7 @@ export const WatchersUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DatabaseWatcher/watchers/{watcherName}",
     apiVersion: "2025-01-02",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type WatchersUpdateInput = typeof WatchersUpdateInput.Type;

--- a/packages/azure/src/services/databox.ts
+++ b/packages/azure/src/services/databox.ts
@@ -699,6 +699,7 @@ export const JobsCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataBox/jobs/{jobName}",
     apiVersion: "2025-07-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type JobsCreateInput = typeof JobsCreateInput.Type;
@@ -748,6 +749,7 @@ export const JobsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataBox/jobs/{jobName}",
     apiVersion: "2025-07-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type JobsDeleteInput = typeof JobsDeleteInput.Type;
@@ -1229,6 +1231,7 @@ export const JobsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataBox/jobs/{jobName}",
     apiVersion: "2025-07-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type JobsUpdateInput = typeof JobsUpdateInput.Type;

--- a/packages/azure/src/services/databoxedge.ts
+++ b/packages/azure/src/services/databoxedge.ts
@@ -23,6 +23,7 @@ export const AddonsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataBoxEdge/dataBoxEdgeDevices/{deviceName}/roles/{roleName}/addons/{addonName}",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AddonsCreateOrUpdateInput = typeof AddonsCreateOrUpdateInput.Type;
@@ -79,6 +80,7 @@ export const AddonsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataBoxEdge/dataBoxEdgeDevices/{deviceName}/roles/{roleName}/addons/{addonName}",
     apiVersion: "2023-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type AddonsDeleteInput = typeof AddonsDeleteInput.Type;
@@ -487,6 +489,7 @@ export const BandwidthSchedulesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataBoxEdge/dataBoxEdgeDevices/{deviceName}/bandwidthSchedules/{name}",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BandwidthSchedulesCreateOrUpdateInput =
@@ -543,6 +546,7 @@ export const BandwidthSchedulesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataBoxEdge/dataBoxEdgeDevices/{deviceName}/bandwidthSchedules/{name}",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BandwidthSchedulesDeleteInput =
@@ -729,6 +733,7 @@ export const ContainersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataBoxEdge/dataBoxEdgeDevices/{deviceName}/storageAccounts/{storageAccountName}/containers/{containerName}",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ContainersCreateOrUpdateInput =
@@ -787,6 +792,7 @@ export const ContainersDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataBoxEdge/dataBoxEdgeDevices/{deviceName}/storageAccounts/{storageAccountName}/containers/{containerName}",
     apiVersion: "2023-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ContainersDeleteInput = typeof ContainersDeleteInput.Type;
@@ -948,6 +954,7 @@ export const ContainersRefreshInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataBoxEdge/dataBoxEdgeDevices/{deviceName}/storageAccounts/{storageAccountName}/containers/{containerName}/refresh",
     apiVersion: "2023-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ContainersRefreshInput = typeof ContainersRefreshInput.Type;
@@ -996,6 +1003,7 @@ export const DeviceCapacityCheckCheckResourceCreationFeasibilityInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataBoxEdge/dataBoxEdgeDevices/{deviceName}/deviceCapacityCheck",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DeviceCapacityCheckCheckResourceCreationFeasibilityInput =
@@ -1334,6 +1342,7 @@ export const DevicesCreateOrUpdateSecuritySettingsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataBoxEdge/dataBoxEdgeDevices/{deviceName}/securitySettings/default/update",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DevicesCreateOrUpdateSecuritySettingsInput =
@@ -1369,6 +1378,7 @@ export const DevicesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataBoxEdge/dataBoxEdgeDevices/{deviceName}",
     apiVersion: "2023-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type DevicesDeleteInput = typeof DevicesDeleteInput.Type;
@@ -1401,6 +1411,7 @@ export const DevicesDownloadUpdatesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataBoxEdge/dataBoxEdgeDevices/{deviceName}/downloadUpdates",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DevicesDownloadUpdatesInput =
@@ -1678,6 +1689,7 @@ export const DevicesInstallUpdatesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataBoxEdge/dataBoxEdgeDevices/{deviceName}/installUpdates",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DevicesInstallUpdatesInput = typeof DevicesInstallUpdatesInput.Type;
@@ -1852,6 +1864,7 @@ export const DevicesScanForUpdatesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataBoxEdge/dataBoxEdgeDevices/{deviceName}/scanForUpdates",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DevicesScanForUpdatesInput = typeof DevicesScanForUpdatesInput.Type;
@@ -2181,6 +2194,7 @@ export const DiagnosticSettingsUpdateDiagnosticProactiveLogCollectionSettingsInp
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataBoxEdge/dataBoxEdgeDevices/{deviceName}/diagnosticProactiveLogCollectionSettings/default",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DiagnosticSettingsUpdateDiagnosticProactiveLogCollectionSettingsInput =
@@ -2257,6 +2271,7 @@ export const DiagnosticSettingsUpdateDiagnosticRemoteSupportSettingsInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataBoxEdge/dataBoxEdgeDevices/{deviceName}/diagnosticRemoteSupportSettings/default",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DiagnosticSettingsUpdateDiagnosticRemoteSupportSettingsInput =
@@ -2398,6 +2413,7 @@ export const MonitoringConfigCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataBoxEdge/dataBoxEdgeDevices/{deviceName}/roles/{roleName}/monitoringConfig/default",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type MonitoringConfigCreateOrUpdateInput =
@@ -2454,6 +2470,7 @@ export const MonitoringConfigDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataBoxEdge/dataBoxEdgeDevices/{deviceName}/roles/{roleName}/monitoringConfig/default",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type MonitoringConfigDeleteInput =
@@ -2964,6 +2981,7 @@ export const OrdersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataBoxEdge/dataBoxEdgeDevices/{deviceName}/orders/default",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type OrdersCreateOrUpdateInput = typeof OrdersCreateOrUpdateInput.Type;
@@ -3016,6 +3034,7 @@ export const OrdersDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataBoxEdge/dataBoxEdgeDevices/{deviceName}/orders/default",
     apiVersion: "2023-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type OrdersDeleteInput = typeof OrdersDeleteInput.Type;
@@ -3219,6 +3238,7 @@ export const RolesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataBoxEdge/dataBoxEdgeDevices/{deviceName}/roles/{name}",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RolesCreateOrUpdateInput = typeof RolesCreateOrUpdateInput.Type;
@@ -3271,6 +3291,7 @@ export const RolesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataBoxEdge/dataBoxEdgeDevices/{deviceName}/roles/{name}",
     apiVersion: "2023-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type RolesDeleteInput = typeof RolesDeleteInput.Type;
@@ -3494,6 +3515,7 @@ export const SharesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataBoxEdge/dataBoxEdgeDevices/{deviceName}/shares/{name}",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SharesCreateOrUpdateInput = typeof SharesCreateOrUpdateInput.Type;
@@ -3548,6 +3570,7 @@ export const SharesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataBoxEdge/dataBoxEdgeDevices/{deviceName}/shares/{name}",
     apiVersion: "2023-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type SharesDeleteInput = typeof SharesDeleteInput.Type;
@@ -3701,6 +3724,7 @@ export const SharesRefreshInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataBoxEdge/dataBoxEdgeDevices/{deviceName}/shares/{name}/refresh",
     apiVersion: "2023-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type SharesRefreshInput = typeof SharesRefreshInput.Type;
@@ -3755,6 +3779,7 @@ export const StorageAccountCredentialsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataBoxEdge/dataBoxEdgeDevices/{deviceName}/storageAccountCredentials/{name}",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StorageAccountCredentialsCreateOrUpdateInput =
@@ -3811,6 +3836,7 @@ export const StorageAccountCredentialsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataBoxEdge/dataBoxEdgeDevices/{deviceName}/storageAccountCredentials/{name}",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StorageAccountCredentialsDeleteInput =
@@ -3990,6 +4016,7 @@ export const StorageAccountsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataBoxEdge/dataBoxEdgeDevices/{deviceName}/storageAccounts/{storageAccountName}",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StorageAccountsCreateOrUpdateInput =
@@ -4046,6 +4073,7 @@ export const StorageAccountsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataBoxEdge/dataBoxEdgeDevices/{deviceName}/storageAccounts/{storageAccountName}",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StorageAccountsDeleteInput = typeof StorageAccountsDeleteInput.Type;
@@ -4213,6 +4241,7 @@ export const SupportPackagesTriggerSupportPackageInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataBoxEdge/dataBoxEdgeDevices/{deviceName}/triggerSupportPackage",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SupportPackagesTriggerSupportPackageInput =
@@ -4251,6 +4280,7 @@ export const TriggersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataBoxEdge/dataBoxEdgeDevices/{deviceName}/triggers/{name}",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type TriggersCreateOrUpdateInput =
@@ -4307,6 +4337,7 @@ export const TriggersDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataBoxEdge/dataBoxEdgeDevices/{deviceName}/triggers/{name}",
     apiVersion: "2023-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type TriggersDeleteInput = typeof TriggersDeleteInput.Type;
@@ -4485,6 +4516,7 @@ export const UsersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataBoxEdge/dataBoxEdgeDevices/{deviceName}/users/{name}",
       apiVersion: "2023-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type UsersCreateOrUpdateInput = typeof UsersCreateOrUpdateInput.Type;
@@ -4537,6 +4569,7 @@ export const UsersDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataBoxEdge/dataBoxEdgeDevices/{deviceName}/users/{name}",
     apiVersion: "2023-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type UsersDeleteInput = typeof UsersDeleteInput.Type;

--- a/packages/azure/src/services/databricks.ts
+++ b/packages/azure/src/services/databricks.ts
@@ -62,6 +62,7 @@ export const AccessConnectorsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Databricks/accessConnectors/{connectorName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AccessConnectorsCreateOrUpdateInput =
@@ -102,6 +103,7 @@ export const AccessConnectorsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Databricks/accessConnectors/{connectorName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AccessConnectorsDeleteInput =
@@ -282,6 +284,7 @@ export const AccessConnectorsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Databricks/accessConnectors/{connectorName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AccessConnectorsUpdateInput =
@@ -453,6 +456,7 @@ export const PrivateEndpointConnectionsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Databricks/workspaces/{workspaceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsCreateInput =
@@ -497,6 +501,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Databricks/workspaces/{workspaceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =
@@ -751,6 +756,7 @@ export const VNetPeeringCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Databricks/workspaces/{workspaceName}/virtualNetworkPeerings/{peeringName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VNetPeeringCreateOrUpdateInput =
@@ -795,6 +801,7 @@ export const VNetPeeringDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Databricks/workspaces/{workspaceName}/virtualNetworkPeerings/{peeringName}",
     apiVersion: "2026-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type VNetPeeringDeleteInput = typeof VNetPeeringDeleteInput.Type;
@@ -1209,6 +1216,7 @@ export const WorkspacesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Databricks/workspaces/{workspaceName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkspacesCreateOrUpdateInput =
@@ -1250,6 +1258,7 @@ export const WorkspacesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Databricks/workspaces/{workspaceName}",
     apiVersion: "2026-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type WorkspacesDeleteInput = typeof WorkspacesDeleteInput.Type;
@@ -1402,6 +1411,7 @@ export const WorkspacesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Databricks/workspaces/{workspaceName}",
     apiVersion: "2026-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type WorkspacesUpdateInput = typeof WorkspacesUpdateInput.Type;

--- a/packages/azure/src/services/datacatalog.ts
+++ b/packages/azure/src/services/datacatalog.ts
@@ -84,6 +84,7 @@ export const ADCCatalogsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataCatalog/catalogs/{catalogName}",
     apiVersion: "2016-03-30",
+    longRunning: {},
   }),
 );
 export type ADCCatalogsDeleteInput = typeof ADCCatalogsDeleteInput.Type;

--- a/packages/azure/src/services/datadog.ts
+++ b/packages/azure/src/services/datadog.ts
@@ -416,6 +416,7 @@ export const MonitoredSubscriptionsCreateorUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Datadog/monitors/{monitorName}/monitoredSubscriptions/{configurationName}",
       apiVersion: "2025-06-11",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type MonitoredSubscriptionsCreateorUpdateInput =
@@ -472,6 +473,7 @@ export const MonitoredSubscriptionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Datadog/monitors/{monitorName}/monitoredSubscriptions/{configurationName}",
       apiVersion: "2025-06-11",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type MonitoredSubscriptionsDeleteInput =
@@ -729,6 +731,7 @@ export const MonitoredSubscriptionsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Datadog/monitors/{monitorName}/monitoredSubscriptions/{configurationName}",
       apiVersion: "2025-06-11",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type MonitoredSubscriptionsUpdateInput =
@@ -852,6 +855,7 @@ export const MonitorsCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Datadog/monitors/{monitorName}",
     apiVersion: "2025-06-11",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type MonitorsCreateInput = typeof MonitorsCreateInput.Type;
@@ -901,6 +905,7 @@ export const MonitorsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Datadog/monitors/{monitorName}",
     apiVersion: "2025-06-11",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type MonitorsDeleteInput = typeof MonitorsDeleteInput.Type;
@@ -1428,6 +1433,7 @@ export const MonitorsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Datadog/monitors/{monitorName}",
     apiVersion: "2025-06-11",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type MonitorsUpdateInput = typeof MonitorsUpdateInput.Type;
@@ -1527,6 +1533,7 @@ export const OrganizationsResubscribeInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Datadog/monitors/{monitorName}/resubscribe",
       apiVersion: "2025-06-11",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type OrganizationsResubscribeInput =
@@ -1605,6 +1612,7 @@ export const SingleSignOnConfigurationsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Datadog/monitors/{monitorName}/singleSignOnConfigurations/{configurationName}",
       apiVersion: "2025-06-11",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SingleSignOnConfigurationsCreateOrUpdateInput =

--- a/packages/azure/src/services/datafactory.ts
+++ b/packages/azure/src/services/datafactory.ts
@@ -988,6 +988,7 @@ export const DataFlowDebugSessionCreateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataFactory/factories/{factoryName}/createDataFlowDebugSession",
       apiVersion: "2018-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DataFlowDebugSessionCreateInput =
@@ -1082,6 +1083,7 @@ export const DataFlowDebugSessionExecuteCommandInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataFactory/factories/{factoryName}/executeDataFlowDebugCommand",
       apiVersion: "2018-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DataFlowDebugSessionExecuteCommandInput =
@@ -2585,6 +2587,7 @@ export const IntegrationRuntimeDisableInteractiveQueryInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataFactory/factories/{factoryName}/integrationRuntimes/{integrationRuntimeName}/disableInteractiveQuery",
       apiVersion: "2018-06-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type IntegrationRuntimeDisableInteractiveQueryInput =
@@ -2642,6 +2645,7 @@ export const IntegrationRuntimeEnableInteractiveQueryInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataFactory/factories/{factoryName}/integrationRuntimes/{integrationRuntimeName}/enableInteractiveQuery",
       apiVersion: "2018-06-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type IntegrationRuntimeEnableInteractiveQueryInput =
@@ -2965,6 +2969,7 @@ export const IntegrationRuntimeObjectMetadataRefreshInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataFactory/factories/{factoryName}/integrationRuntimes/{integrationRuntimeName}/refreshObjectMetadata",
       apiVersion: "2018-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type IntegrationRuntimeObjectMetadataRefreshInput =
@@ -3637,6 +3642,7 @@ export const IntegrationRuntimesStartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataFactory/factories/{factoryName}/integrationRuntimes/{integrationRuntimeName}/start",
       apiVersion: "2018-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type IntegrationRuntimesStartInput =
@@ -3696,6 +3702,7 @@ export const IntegrationRuntimesStopInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataFactory/factories/{factoryName}/integrationRuntimes/{integrationRuntimeName}/stop",
       apiVersion: "2018-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type IntegrationRuntimesStopInput =
@@ -5996,6 +6003,7 @@ export const TriggersStartInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataFactory/factories/{factoryName}/triggers/{triggerName}/start",
     apiVersion: "2018-06-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type TriggersStartInput = typeof TriggersStartInput.Type;
@@ -6029,6 +6037,7 @@ export const TriggersStopInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataFactory/factories/{factoryName}/triggers/{triggerName}/stop",
     apiVersion: "2018-06-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type TriggersStopInput = typeof TriggersStopInput.Type;
@@ -6063,6 +6072,7 @@ export const TriggersSubscribeToEventsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataFactory/factories/{factoryName}/triggers/{triggerName}/subscribeToEvents",
       apiVersion: "2018-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type TriggersSubscribeToEventsInput =
@@ -6113,6 +6123,7 @@ export const TriggersUnsubscribeFromEventsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataFactory/factories/{factoryName}/triggers/{triggerName}/unsubscribeFromEvents",
       apiVersion: "2018-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type TriggersUnsubscribeFromEventsInput =

--- a/packages/azure/src/services/datalake-analytics.ts
+++ b/packages/azure/src/services/datalake-analytics.ts
@@ -125,6 +125,7 @@ export const AccountsCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataLakeAnalytics/accounts/{accountName}",
     apiVersion: "2016-11-01",
+    longRunning: {},
   }),
 );
 export type AccountsCreateInput = typeof AccountsCreateInput.Type;
@@ -155,6 +156,7 @@ export const AccountsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataLakeAnalytics/accounts/{accountName}",
     apiVersion: "2016-11-01",
+    longRunning: {},
   }),
 );
 export type AccountsDeleteInput = typeof AccountsDeleteInput.Type;
@@ -396,6 +398,7 @@ export const AccountsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataLakeAnalytics/accounts/{accountName}",
     apiVersion: "2016-11-01",
+    longRunning: {},
   }),
 );
 export type AccountsUpdateInput = typeof AccountsUpdateInput.Type;

--- a/packages/azure/src/services/datalake-store.ts
+++ b/packages/azure/src/services/datalake-store.ts
@@ -130,6 +130,7 @@ export const AccountsCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataLakeStore/accounts/{accountName}",
     apiVersion: "2016-11-01",
+    longRunning: {},
   }),
 );
 export type AccountsCreateInput = typeof AccountsCreateInput.Type;
@@ -160,6 +161,7 @@ export const AccountsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataLakeStore/accounts/{accountName}",
     apiVersion: "2016-11-01",
+    longRunning: {},
   }),
 );
 export type AccountsDeleteInput = typeof AccountsDeleteInput.Type;
@@ -415,6 +417,7 @@ export const AccountsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataLakeStore/accounts/{accountName}",
     apiVersion: "2016-11-01",
+    longRunning: {},
   }),
 );
 export type AccountsUpdateInput = typeof AccountsUpdateInput.Type;

--- a/packages/azure/src/services/datamigration.ts
+++ b/packages/azure/src/services/datamigration.ts
@@ -48,6 +48,7 @@ export const DatabaseMigrationsMongoToCosmosDbRUMongoCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{targetResourceName}/providers/Microsoft.DataMigration/databaseMigrations/{migrationName}",
       apiVersion: "2025-06-30",
+      longRunning: {},
     }),
   );
 export type DatabaseMigrationsMongoToCosmosDbRUMongoCreateInput =
@@ -95,6 +96,7 @@ export const DatabaseMigrationsMongoToCosmosDbRUMongoDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{targetResourceName}/providers/Microsoft.DataMigration/databaseMigrations/{migrationName}",
       apiVersion: "2025-06-30",
+      longRunning: {},
     }),
   );
 export type DatabaseMigrationsMongoToCosmosDbRUMongoDeleteInput =
@@ -264,6 +266,7 @@ export const DatabaseMigrationsMongoToCosmosDbvCoreMongoCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/mongoClusters/{targetResourceName}/providers/Microsoft.DataMigration/databaseMigrations/{migrationName}",
       apiVersion: "2025-06-30",
+      longRunning: {},
     }),
   );
 export type DatabaseMigrationsMongoToCosmosDbvCoreMongoCreateInput =
@@ -311,6 +314,7 @@ export const DatabaseMigrationsMongoToCosmosDbvCoreMongoDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/mongoClusters/{targetResourceName}/providers/Microsoft.DataMigration/databaseMigrations/{migrationName}",
       apiVersion: "2025-06-30",
+      longRunning: {},
     }),
   );
 export type DatabaseMigrationsMongoToCosmosDbvCoreMongoDeleteInput =
@@ -450,6 +454,7 @@ export const DatabaseMigrationsSqlDbCancelInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{sqlDbInstanceName}/providers/Microsoft.DataMigration/databaseMigrations/{targetDbName}/cancel",
       apiVersion: "2025-06-30",
+      longRunning: {},
     }),
   );
 export type DatabaseMigrationsSqlDbCancelInput =
@@ -511,6 +516,7 @@ export const DatabaseMigrationsSqlDbCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{sqlDbInstanceName}/providers/Microsoft.DataMigration/databaseMigrations/{targetDbName}",
       apiVersion: "2025-06-30",
+      longRunning: {},
     }),
   );
 export type DatabaseMigrationsSqlDbCreateOrUpdateInput =
@@ -559,6 +565,7 @@ export const DatabaseMigrationsSqlDbDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{sqlDbInstanceName}/providers/Microsoft.DataMigration/databaseMigrations/{targetDbName}",
       apiVersion: "2025-06-30",
+      longRunning: {},
     }),
   );
 export type DatabaseMigrationsSqlDbDeleteInput =
@@ -645,6 +652,7 @@ export const DatabaseMigrationsSqlDbRetryInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{sqlDbInstanceName}/providers/Microsoft.DataMigration/databaseMigrations/{targetDbName}/retry",
       apiVersion: "2025-06-30",
+      longRunning: {},
     }),
   );
 export type DatabaseMigrationsSqlDbRetryInput =
@@ -677,6 +685,7 @@ export const DatabaseMigrationsSqlMiCancelInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/providers/Microsoft.DataMigration/databaseMigrations/{targetDbName}/cancel",
       apiVersion: "2025-06-30",
+      longRunning: {},
     }),
   );
 export type DatabaseMigrationsSqlMiCancelInput =
@@ -738,6 +747,7 @@ export const DatabaseMigrationsSqlMiCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/providers/Microsoft.DataMigration/databaseMigrations/{targetDbName}",
       apiVersion: "2025-06-30",
+      longRunning: {},
     }),
   );
 export type DatabaseMigrationsSqlMiCreateOrUpdateInput =
@@ -786,6 +796,7 @@ export const DatabaseMigrationsSqlMiCutoverInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/providers/Microsoft.DataMigration/databaseMigrations/{targetDbName}/cutover",
       apiVersion: "2025-06-30",
+      longRunning: {},
     }),
   );
 export type DatabaseMigrationsSqlMiCutoverInput =
@@ -816,6 +827,7 @@ export const DatabaseMigrationsSqlMiDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/providers/Microsoft.DataMigration/databaseMigrations/{targetDbName}",
       apiVersion: "2025-06-30",
+      longRunning: {},
     }),
   );
 export type DatabaseMigrationsSqlMiDeleteInput =
@@ -919,6 +931,7 @@ export const DatabaseMigrationsSqlVmCancelInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/{sqlVirtualMachineName}/providers/Microsoft.DataMigration/databaseMigrations/{targetDbName}/cancel",
       apiVersion: "2025-06-30",
+      longRunning: {},
     }),
   );
 export type DatabaseMigrationsSqlVmCancelInput =
@@ -980,6 +993,7 @@ export const DatabaseMigrationsSqlVmCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/{sqlVirtualMachineName}/providers/Microsoft.DataMigration/databaseMigrations/{targetDbName}",
       apiVersion: "2025-06-30",
+      longRunning: {},
     }),
   );
 export type DatabaseMigrationsSqlVmCreateOrUpdateInput =
@@ -1028,6 +1042,7 @@ export const DatabaseMigrationsSqlVmCutoverInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/{sqlVirtualMachineName}/providers/Microsoft.DataMigration/databaseMigrations/{targetDbName}/cutover",
       apiVersion: "2025-06-30",
+      longRunning: {},
     }),
   );
 export type DatabaseMigrationsSqlVmCutoverInput =
@@ -1058,6 +1073,7 @@ export const DatabaseMigrationsSqlVmDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/{sqlVirtualMachineName}/providers/Microsoft.DataMigration/databaseMigrations/{targetDbName}",
       apiVersion: "2025-06-30",
+      longRunning: {},
     }),
   );
 export type DatabaseMigrationsSqlVmDeleteInput =
@@ -1456,6 +1472,7 @@ export const MigrationServicesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataMigration/migrationServices/{migrationServiceName}",
       apiVersion: "2025-06-30",
+      longRunning: {},
     }),
   );
 export type MigrationServicesCreateOrUpdateInput =
@@ -1501,6 +1518,7 @@ export const MigrationServicesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataMigration/migrationServices/{migrationServiceName}",
       apiVersion: "2025-06-30",
+      longRunning: {},
     }),
   );
 export type MigrationServicesDeleteInput =
@@ -1761,6 +1779,7 @@ export const MigrationServicesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataMigration/migrationServices/{migrationServiceName}",
       apiVersion: "2025-06-30",
+      longRunning: {},
     }),
   );
 export type MigrationServicesUpdateInput =
@@ -2272,6 +2291,7 @@ export const ServicesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.DataMigration/services/{serviceName}",
       apiVersion: "2025-06-30",
+      longRunning: {},
     }),
   );
 export type ServicesCreateOrUpdateInput =
@@ -2321,6 +2341,7 @@ export const ServicesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.DataMigration/services/{serviceName}",
     apiVersion: "2025-06-30",
+    longRunning: {},
   }),
 );
 export type ServicesDeleteInput = typeof ServicesDeleteInput.Type;
@@ -2580,6 +2601,7 @@ export const ServicesStartInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.DataMigration/services/{serviceName}/start",
     apiVersion: "2025-06-30",
+    longRunning: {},
   }),
 );
 export type ServicesStartInput = typeof ServicesStartInput.Type;
@@ -2608,6 +2630,7 @@ export const ServicesStopInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.DataMigration/services/{serviceName}/stop",
     apiVersion: "2025-06-30",
+    longRunning: {},
   }),
 );
 export type ServicesStopInput = typeof ServicesStopInput.Type;
@@ -2636,6 +2659,7 @@ export const ServicesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.DataMigration/services/{serviceName}",
     apiVersion: "2025-06-30",
+    longRunning: {},
   }),
 );
 export type ServicesUpdateInput = typeof ServicesUpdateInput.Type;
@@ -2964,6 +2988,7 @@ export const SqlMigrationServicesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataMigration/sqlMigrationServices/{sqlMigrationServiceName}",
       apiVersion: "2025-06-30",
+      longRunning: {},
     }),
   );
 export type SqlMigrationServicesCreateOrUpdateInput =
@@ -3009,6 +3034,7 @@ export const SqlMigrationServicesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataMigration/sqlMigrationServices/{sqlMigrationServiceName}",
       apiVersion: "2025-06-30",
+      longRunning: {},
     }),
   );
 export type SqlMigrationServicesDeleteInput =
@@ -3415,6 +3441,7 @@ export const SqlMigrationServicesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataMigration/sqlMigrationServices/{sqlMigrationServiceName}",
       apiVersion: "2025-06-30",
+      longRunning: {},
     }),
   );
 export type SqlMigrationServicesUpdateInput =

--- a/packages/azure/src/services/dataprotection.ts
+++ b/packages/azure/src/services/dataprotection.ts
@@ -26,6 +26,7 @@ export const BackupInstancesAdhocBackupInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupInstances/{backupInstanceName}/backup",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BackupInstancesAdhocBackupInput =
@@ -225,6 +226,7 @@ export const BackupInstancesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupInstances/{backupInstanceName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BackupInstancesCreateOrUpdateInput =
@@ -281,6 +283,7 @@ export const BackupInstancesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupInstances/{backupInstanceName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BackupInstancesDeleteInput = typeof BackupInstancesDeleteInput.Type;
@@ -499,6 +502,7 @@ export const BackupInstancesResumeBackupsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupInstances/{backupInstanceName}/resumeBackups",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BackupInstancesResumeBackupsInput =
@@ -537,6 +541,7 @@ export const BackupInstancesResumeProtectionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupInstances/{backupInstanceName}/resumeProtection",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BackupInstancesResumeProtectionInput =
@@ -578,6 +583,7 @@ export const BackupInstancesStopProtectionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupInstances/{backupInstanceName}/stopProtection",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BackupInstancesStopProtectionInput =
@@ -619,6 +625,7 @@ export const BackupInstancesSuspendBackupsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupInstances/{backupInstanceName}/suspendBackups",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BackupInstancesSuspendBackupsInput =
@@ -658,6 +665,7 @@ export const BackupInstancesSyncBackupInstanceInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupInstances/{backupInstanceName}/sync",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BackupInstancesSyncBackupInstanceInput =
@@ -724,6 +732,7 @@ export const BackupInstancesTriggerCrossRegionRestoreInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/locations/{location}/crossRegionRestore",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BackupInstancesTriggerCrossRegionRestoreInput =
@@ -768,6 +777,7 @@ export const BackupInstancesTriggerRehydrateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupInstances/{backupInstanceName}/rehydrate",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BackupInstancesTriggerRehydrateInput =
@@ -828,6 +838,7 @@ export const BackupInstancesTriggerRestoreInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupInstances/{backupInstanceName}/restore",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BackupInstancesTriggerRestoreInput =
@@ -895,6 +906,7 @@ export const BackupInstancesValidateCrossRegionRestoreInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/locations/{location}/validateCrossRegionRestore",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BackupInstancesValidateCrossRegionRestoreInput =
@@ -1088,6 +1100,7 @@ export const BackupInstancesValidateForBackupInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/validateForBackup",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BackupInstancesValidateForBackupInput =
@@ -1282,6 +1295,7 @@ export const BackupInstancesValidateForModifyBackupInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupInstances/{backupInstanceName}/validateForModifyBackup",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BackupInstancesValidateForModifyBackupInput =
@@ -1344,6 +1358,7 @@ export const BackupInstancesValidateForRestoreInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupInstances/{backupInstanceName}/validateRestore",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BackupInstancesValidateForRestoreInput =
@@ -1825,6 +1840,7 @@ export const BackupVaultsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BackupVaultsCreateOrUpdateInput =
@@ -1881,6 +1897,7 @@ export const BackupVaultsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BackupVaultsDeleteInput = typeof BackupVaultsDeleteInput.Type;
@@ -2131,6 +2148,7 @@ export const BackupVaultsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BackupVaultsUpdateInput = typeof BackupVaultsUpdateInput.Type;
@@ -2367,6 +2385,7 @@ export const DeletedBackupInstancesUndeleteInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/deletedBackupInstances/{backupInstanceName}/undelete",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeletedBackupInstancesUndeleteInput =
@@ -2820,6 +2839,7 @@ export const ExportJobsTriggerInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/exportBackupJobs",
     apiVersion: "2026-03-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ExportJobsTriggerInput = typeof ExportJobsTriggerInput.Type;

--- a/packages/azure/src/services/datashare.ts
+++ b/packages/azure/src/services/datashare.ts
@@ -38,6 +38,7 @@ export const AccountsCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataShare/accounts/{accountName}",
     apiVersion: "2021-08-01",
+    longRunning: {},
   }),
 );
 export type AccountsCreateInput = typeof AccountsCreateInput.Type;
@@ -82,6 +83,7 @@ export const AccountsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataShare/accounts/{accountName}",
     apiVersion: "2021-08-01",
+    longRunning: {},
   }),
 );
 export type AccountsDeleteInput = typeof AccountsDeleteInput.Type;
@@ -948,6 +950,7 @@ export const DataSetsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataShare/accounts/{accountName}/shares/{shareName}/dataSets/{dataSetName}",
     apiVersion: "2021-08-01",
+    longRunning: {},
   }),
 );
 export type DataSetsDeleteInput = typeof DataSetsDeleteInput.Type;
@@ -1817,6 +1820,7 @@ export const ProviderShareSubscriptionsRevokeInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataShare/accounts/{accountName}/shares/{shareName}/providerShareSubscriptions/{providerShareSubscriptionId}/revoke",
       apiVersion: "2021-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ProviderShareSubscriptionsRevokeInput =
@@ -1950,6 +1954,7 @@ export const SharesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataShare/accounts/{accountName}/shares/{shareName}",
     apiVersion: "2021-08-01",
+    longRunning: {},
   }),
 );
 export type SharesDeleteInput = typeof SharesDeleteInput.Type;
@@ -2267,6 +2272,7 @@ export const ShareSubscriptionsCancelSynchronizationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataShare/accounts/{accountName}/shareSubscriptions/{shareSubscriptionName}/cancelSynchronization",
       apiVersion: "2021-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ShareSubscriptionsCancelSynchronizationInput =
@@ -2406,6 +2412,7 @@ export const ShareSubscriptionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataShare/accounts/{accountName}/shareSubscriptions/{shareSubscriptionName}",
       apiVersion: "2021-08-01",
+      longRunning: {},
     }),
   );
 export type ShareSubscriptionsDeleteInput =
@@ -2766,6 +2773,7 @@ export const ShareSubscriptionsSynchronizeInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataShare/accounts/{accountName}/shareSubscriptions/{shareSubscriptionName}/synchronize",
       apiVersion: "2021-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ShareSubscriptionsSynchronizeInput =
@@ -2881,6 +2889,7 @@ export const SynchronizationSettingsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataShare/accounts/{accountName}/shares/{shareName}/synchronizationSettings/{synchronizationSettingName}",
       apiVersion: "2021-08-01",
+      longRunning: {},
     }),
   );
 export type SynchronizationSettingsDeleteInput =
@@ -3074,6 +3083,7 @@ export const TriggersCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataShare/accounts/{accountName}/shareSubscriptions/{shareSubscriptionName}/triggers/{triggerName}",
     apiVersion: "2021-08-01",
+    longRunning: {},
   }),
 );
 export type TriggersCreateInput = typeof TriggersCreateInput.Type;
@@ -3122,6 +3132,7 @@ export const TriggersDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataShare/accounts/{accountName}/shareSubscriptions/{shareSubscriptionName}/triggers/{triggerName}",
     apiVersion: "2021-08-01",
+    longRunning: {},
   }),
 );
 export type TriggersDeleteInput = typeof TriggersDeleteInput.Type;

--- a/packages/azure/src/services/devcenter.ts
+++ b/packages/azure/src/services/devcenter.ts
@@ -76,6 +76,7 @@ export const AttachedNetworksCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/devcenters/{devCenterName}/attachednetworks/{attachedNetworkConnectionName}",
       apiVersion: "2025-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AttachedNetworksCreateOrUpdateInput =
@@ -128,6 +129,7 @@ export const AttachedNetworksDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/devcenters/{devCenterName}/attachednetworks/{attachedNetworkConnectionName}",
       apiVersion: "2025-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AttachedNetworksDeleteInput =
@@ -408,6 +410,7 @@ export const CatalogsConnectInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/devcenters/{devCenterName}/catalogs/{catalogName}/connect",
     apiVersion: "2025-02-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type CatalogsConnectInput = typeof CatalogsConnectInput.Type;
@@ -477,6 +480,7 @@ export const CatalogsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/devcenters/{devCenterName}/catalogs/{catalogName}",
       apiVersion: "2025-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CatalogsCreateOrUpdateInput =
@@ -529,6 +533,7 @@ export const CatalogsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/devcenters/{devCenterName}/catalogs/{catalogName}",
     apiVersion: "2025-02-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type CatalogsDeleteInput = typeof CatalogsDeleteInput.Type;
@@ -735,6 +740,7 @@ export const CatalogsSyncInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/devcenters/{devCenterName}/catalogs/{catalogName}/sync",
     apiVersion: "2025-02-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type CatalogsSyncInput = typeof CatalogsSyncInput.Type;
@@ -786,6 +792,7 @@ export const CatalogsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/devcenters/{devCenterName}/catalogs/{catalogName}",
     apiVersion: "2025-02-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type CatalogsUpdateInput = typeof CatalogsUpdateInput.Type;
@@ -1081,6 +1088,7 @@ export const DevBoxDefinitionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/devcenters/{devCenterName}/devboxdefinitions/{devBoxDefinitionName}",
       apiVersion: "2025-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DevBoxDefinitionsCreateOrUpdateInput =
@@ -1126,6 +1134,7 @@ export const DevBoxDefinitionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/devcenters/{devCenterName}/devboxdefinitions/{devBoxDefinitionName}",
       apiVersion: "2025-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DevBoxDefinitionsDeleteInput =
@@ -1395,6 +1404,7 @@ export const DevBoxDefinitionsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/devcenters/{devCenterName}/devboxdefinitions/{devBoxDefinitionName}",
       apiVersion: "2025-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DevBoxDefinitionsUpdateInput =
@@ -1517,6 +1527,7 @@ export const DevCentersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/devcenters/{devCenterName}",
       apiVersion: "2025-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DevCentersCreateOrUpdateInput =
@@ -1569,6 +1580,7 @@ export const DevCentersDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/devcenters/{devCenterName}",
     apiVersion: "2025-02-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type DevCentersDeleteInput = typeof DevCentersDeleteInput.Type;
@@ -1858,6 +1870,7 @@ export const DevCentersUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/devcenters/{devCenterName}",
     apiVersion: "2025-02-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type DevCentersUpdateInput = typeof DevCentersUpdateInput.Type;
@@ -2506,6 +2519,7 @@ export const GalleriesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/devcenters/{devCenterName}/galleries/{galleryName}",
       apiVersion: "2025-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type GalleriesCreateOrUpdateInput =
@@ -2558,6 +2572,7 @@ export const GalleriesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/devcenters/{devCenterName}/galleries/{galleryName}",
     apiVersion: "2025-02-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type GalleriesDeleteInput = typeof GalleriesDeleteInput.Type;
@@ -3267,6 +3282,7 @@ export const NetworkConnectionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/networkConnections/{networkConnectionName}",
       apiVersion: "2025-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NetworkConnectionsCreateOrUpdateInput =
@@ -3312,6 +3328,7 @@ export const NetworkConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/networkConnections/{networkConnectionName}",
       apiVersion: "2025-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NetworkConnectionsDeleteInput =
@@ -3679,6 +3696,7 @@ export const NetworkConnectionsRunHealthChecksInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/networkConnections/{networkConnectionName}/runHealthChecks",
       apiVersion: "2025-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NetworkConnectionsRunHealthChecksInput =
@@ -3722,6 +3740,7 @@ export const NetworkConnectionsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/networkConnections/{networkConnectionName}",
       apiVersion: "2025-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NetworkConnectionsUpdateInput =
@@ -3968,6 +3987,7 @@ export const PoolsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/projects/{projectName}/pools/{poolName}",
       apiVersion: "2025-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PoolsCreateOrUpdateInput = typeof PoolsCreateOrUpdateInput.Type;
@@ -4011,6 +4031,7 @@ export const PoolsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/projects/{projectName}/pools/{poolName}",
     apiVersion: "2025-02-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type PoolsDeleteInput = typeof PoolsDeleteInput.Type;
@@ -4137,6 +4158,7 @@ export const PoolsRunHealthChecksInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/projects/{projectName}/pools/{poolName}/runHealthChecks",
       apiVersion: "2025-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PoolsRunHealthChecksInput = typeof PoolsRunHealthChecksInput.Type;
@@ -4232,6 +4254,7 @@ export const PoolsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/projects/{projectName}/pools/{poolName}",
     apiVersion: "2025-02-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type PoolsUpdateInput = typeof PoolsUpdateInput.Type;
@@ -4439,6 +4462,7 @@ export const ProjectCatalogImageDefinitionBuildCancelInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/projects/{projectName}/catalogs/{catalogName}/imageDefinitions/{imageDefinitionName}/builds/{buildName}/cancel",
       apiVersion: "2025-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ProjectCatalogImageDefinitionBuildCancelInput =
@@ -4626,6 +4650,7 @@ export const ProjectCatalogImageDefinitionsBuildImageInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/projects/{projectName}/catalogs/{catalogName}/imageDefinitions/{imageDefinitionName}/buildImage",
       apiVersion: "2025-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ProjectCatalogImageDefinitionsBuildImageInput =
@@ -4806,6 +4831,7 @@ export const ProjectCatalogsConnectInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/projects/{projectName}/catalogs/{catalogName}/connect",
       apiVersion: "2025-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ProjectCatalogsConnectInput =
@@ -4880,6 +4906,7 @@ export const ProjectCatalogsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/projects/{projectName}/catalogs/{catalogName}",
       apiVersion: "2025-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ProjectCatalogsCreateOrUpdateInput =
@@ -4932,6 +4959,7 @@ export const ProjectCatalogsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/projects/{projectName}/catalogs/{catalogName}",
       apiVersion: "2025-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ProjectCatalogsDeleteInput = typeof ProjectCatalogsDeleteInput.Type;
@@ -5169,6 +5197,7 @@ export const ProjectCatalogsPatchInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/projects/{projectName}/catalogs/{catalogName}",
       apiVersion: "2025-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ProjectCatalogsPatchInput = typeof ProjectCatalogsPatchInput.Type;
@@ -5220,6 +5249,7 @@ export const ProjectCatalogsSyncInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/projects/{projectName}/catalogs/{catalogName}/sync",
       apiVersion: "2025-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ProjectCatalogsSyncInput = typeof ProjectCatalogsSyncInput.Type;
@@ -5682,6 +5712,7 @@ export const ProjectPoliciesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/devcenters/{devCenterName}/projectPolicies/{projectPolicyName}",
       apiVersion: "2025-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ProjectPoliciesCreateOrUpdateInput =
@@ -5734,6 +5765,7 @@ export const ProjectPoliciesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/devcenters/{devCenterName}/projectPolicies/{projectPolicyName}",
       apiVersion: "2025-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ProjectPoliciesDeleteInput = typeof ProjectPoliciesDeleteInput.Type;
@@ -5905,6 +5937,7 @@ export const ProjectPoliciesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/devcenters/{devCenterName}/projectPolicies/{projectPolicyName}",
       apiVersion: "2025-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ProjectPoliciesUpdateInput = typeof ProjectPoliciesUpdateInput.Type;
@@ -5997,6 +6030,7 @@ export const ProjectsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/projects/{projectName}",
       apiVersion: "2025-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ProjectsCreateOrUpdateInput =
@@ -6049,6 +6083,7 @@ export const ProjectsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/projects/{projectName}",
     apiVersion: "2025-02-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type ProjectsDeleteInput = typeof ProjectsDeleteInput.Type;
@@ -6356,6 +6391,7 @@ export const ProjectsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/projects/{projectName}",
     apiVersion: "2025-02-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type ProjectsUpdateInput = typeof ProjectsUpdateInput.Type;
@@ -6425,6 +6461,7 @@ export const SchedulesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/projects/{projectName}/pools/{poolName}/schedules/{scheduleName}",
       apiVersion: "2025-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SchedulesCreateOrUpdateInput =
@@ -6472,6 +6509,7 @@ export const SchedulesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/projects/{projectName}/pools/{poolName}/schedules/{scheduleName}",
     apiVersion: "2025-02-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type SchedulesDeleteInput = typeof SchedulesDeleteInput.Type;
@@ -6602,6 +6640,7 @@ export const SchedulesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevCenter/projects/{projectName}/pools/{poolName}/schedules/{scheduleName}",
     apiVersion: "2025-02-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type SchedulesUpdateInput = typeof SchedulesUpdateInput.Type;

--- a/packages/azure/src/services/deviceprovisioningservices.ts
+++ b/packages/azure/src/services/deviceprovisioningservices.ts
@@ -651,6 +651,7 @@ export const IotDpsResourceCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/provisioningServices/{provisioningServiceName}",
       apiVersion: "2022-12-12",
+      longRunning: {},
     }),
   );
 export type IotDpsResourceCreateOrUpdateInput =
@@ -726,6 +727,7 @@ export const IotDpsResourceCreateOrUpdatePrivateEndpointConnectionInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/provisioningServices/{resourceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2022-12-12",
+      longRunning: {},
     }),
   );
 export type IotDpsResourceCreateOrUpdatePrivateEndpointConnectionInput =
@@ -793,6 +795,7 @@ export const IotDpsResourceDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/provisioningServices/{provisioningServiceName}",
       apiVersion: "2022-12-12",
+      longRunning: {},
     }),
   );
 export type IotDpsResourceDeleteInput = typeof IotDpsResourceDeleteInput.Type;
@@ -824,6 +827,7 @@ export const IotDpsResourceDeletePrivateEndpointConnectionInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/provisioningServices/{resourceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2022-12-12",
+      longRunning: {},
     }),
   );
 export type IotDpsResourceDeletePrivateEndpointConnectionInput =
@@ -1430,6 +1434,7 @@ export const IotDpsResourceUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/provisioningServices/{provisioningServiceName}",
       apiVersion: "2022-12-12",
+      longRunning: {},
     }),
   );
 export type IotDpsResourceUpdateInput = typeof IotDpsResourceUpdateInput.Type;

--- a/packages/azure/src/services/deviceregistry.ts
+++ b/packages/azure/src/services/deviceregistry.ts
@@ -76,6 +76,7 @@ export const AssetEndpointProfilesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/assetEndpointProfiles/{assetEndpointProfileName}",
       apiVersion: "2026-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AssetEndpointProfilesCreateOrReplaceInput =
@@ -130,6 +131,7 @@ export const AssetEndpointProfilesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/assetEndpointProfiles/{assetEndpointProfileName}",
       apiVersion: "2026-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AssetEndpointProfilesDeleteInput =
@@ -380,6 +382,7 @@ export const AssetEndpointProfilesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/assetEndpointProfiles/{assetEndpointProfileName}",
       apiVersion: "2026-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AssetEndpointProfilesUpdateInput =
@@ -560,6 +563,7 @@ export const AssetsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/assets/{assetName}",
       apiVersion: "2026-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AssetsCreateOrReplaceInput = typeof AssetsCreateOrReplaceInput.Type;
@@ -613,6 +617,7 @@ export const AssetsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/assets/{assetName}",
     apiVersion: "2026-04-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type AssetsDeleteInput = typeof AssetsDeleteInput.Type;
@@ -890,6 +895,7 @@ export const AssetsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/assets/{assetName}",
     apiVersion: "2026-04-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type AssetsUpdateInput = typeof AssetsUpdateInput.Type;
@@ -1416,6 +1422,7 @@ export const NamespaceAssetsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/assets/{assetName}",
       apiVersion: "2026-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NamespaceAssetsCreateOrReplaceInput =
@@ -1472,6 +1479,7 @@ export const NamespaceAssetsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/assets/{assetName}",
       apiVersion: "2026-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NamespaceAssetsDeleteInput = typeof NamespaceAssetsDeleteInput.Type;
@@ -1513,6 +1521,7 @@ export const NamespaceAssetsExecuteActionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/assets/{assetName}/executeAction",
       apiVersion: "2026-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NamespaceAssetsExecuteActionInput =
@@ -1848,6 +1857,7 @@ export const NamespaceAssetsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/assets/{assetName}",
       apiVersion: "2026-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NamespaceAssetsUpdateInput = typeof NamespaceAssetsUpdateInput.Type;
@@ -2072,6 +2082,7 @@ export const NamespaceDevicesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/devices/{deviceName}",
       apiVersion: "2026-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NamespaceDevicesCreateOrReplaceInput =
@@ -2128,6 +2139,7 @@ export const NamespaceDevicesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/devices/{deviceName}",
       apiVersion: "2026-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NamespaceDevicesDeleteInput =
@@ -2367,6 +2379,7 @@ export const NamespaceDevicesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/devices/{deviceName}",
       apiVersion: "2026-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NamespaceDevicesUpdateInput =
@@ -2603,6 +2616,7 @@ export const NamespaceDiscoveredAssetsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/discoveredAssets/{discoveredAssetName}",
       apiVersion: "2026-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NamespaceDiscoveredAssetsCreateOrReplaceInput =
@@ -2659,6 +2673,7 @@ export const NamespaceDiscoveredAssetsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/discoveredAssets/{discoveredAssetName}",
       apiVersion: "2026-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NamespaceDiscoveredAssetsDeleteInput =
@@ -2988,6 +3003,7 @@ export const NamespaceDiscoveredAssetsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/discoveredAssets/{discoveredAssetName}",
       apiVersion: "2026-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NamespaceDiscoveredAssetsUpdateInput =
@@ -3109,6 +3125,7 @@ export const NamespaceDiscoveredDevicesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/discoveredDevices/{discoveredDeviceName}",
       apiVersion: "2026-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NamespaceDiscoveredDevicesCreateOrReplaceInput =
@@ -3165,6 +3182,7 @@ export const NamespaceDiscoveredDevicesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/discoveredDevices/{discoveredDeviceName}",
       apiVersion: "2026-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NamespaceDiscoveredDevicesDeleteInput =
@@ -3378,6 +3396,7 @@ export const NamespaceDiscoveredDevicesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/discoveredDevices/{discoveredDeviceName}",
       apiVersion: "2026-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NamespaceDiscoveredDevicesUpdateInput =
@@ -3485,6 +3504,7 @@ export const NamespacesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}",
       apiVersion: "2026-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NamespacesCreateOrReplaceInput =
@@ -3539,6 +3559,7 @@ export const NamespacesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}",
     apiVersion: "2026-04-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type NamespacesDeleteInput = typeof NamespacesDeleteInput.Type;
@@ -3755,6 +3776,7 @@ export const NamespacesMigrateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/migrate",
     apiVersion: "2026-04-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type NamespacesMigrateInput = typeof NamespacesMigrateInput.Type;
@@ -3853,6 +3875,7 @@ export const NamespacesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}",
     apiVersion: "2026-04-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type NamespacesUpdateInput = typeof NamespacesUpdateInput.Type;
@@ -4067,6 +4090,7 @@ export const SchemaRegistriesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/schemaRegistries/{schemaRegistryName}",
       apiVersion: "2026-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SchemaRegistriesCreateOrReplaceInput =
@@ -4121,6 +4145,7 @@ export const SchemaRegistriesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/schemaRegistries/{schemaRegistryName}",
       apiVersion: "2026-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SchemaRegistriesDeleteInput =
@@ -4355,6 +4380,7 @@ export const SchemaRegistriesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/schemaRegistries/{schemaRegistryName}",
       apiVersion: "2026-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SchemaRegistriesUpdateInput =
@@ -4486,6 +4512,7 @@ export const SchemasDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/schemaRegistries/{schemaRegistryName}/schemas/{schemaName}",
     apiVersion: "2026-04-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type SchemasDeleteInput = typeof SchemasDeleteInput.Type;
@@ -4717,6 +4744,7 @@ export const SchemaVersionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/schemaRegistries/{schemaRegistryName}/schemas/{schemaName}/schemaVersions/{schemaVersionName}",
       apiVersion: "2026-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SchemaVersionsDeleteInput = typeof SchemaVersionsDeleteInput.Type;

--- a/packages/azure/src/services/deviceupdate.ts
+++ b/packages/azure/src/services/deviceupdate.ts
@@ -107,6 +107,7 @@ export const AccountsCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceUpdate/accounts/{accountName}",
     apiVersion: "2023-07-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type AccountsCreateInput = typeof AccountsCreateInput.Type;
@@ -149,6 +150,7 @@ export const AccountsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceUpdate/accounts/{accountName}",
     apiVersion: "2023-07-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type AccountsDeleteInput = typeof AccountsDeleteInput.Type;
@@ -365,6 +367,7 @@ export const AccountsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceUpdate/accounts/{accountName}",
     apiVersion: "2023-07-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type AccountsUpdateInput = typeof AccountsUpdateInput.Type;
@@ -472,6 +475,7 @@ export const InstancesCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceUpdate/accounts/{accountName}/instances/{instanceName}",
     apiVersion: "2023-07-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type InstancesCreateInput = typeof InstancesCreateInput.Type;
@@ -514,6 +518,7 @@ export const InstancesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceUpdate/accounts/{accountName}/instances/{instanceName}",
     apiVersion: "2023-07-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type InstancesDeleteInput = typeof InstancesDeleteInput.Type;
@@ -813,6 +818,7 @@ export const PrivateEndpointConnectionProxiesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceUpdate/accounts/{accountName}/privateEndpointConnectionProxies/{privateEndpointConnectionProxyId}",
       apiVersion: "2023-07-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PrivateEndpointConnectionProxiesCreateOrUpdateInput =
@@ -916,6 +922,7 @@ export const PrivateEndpointConnectionProxiesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceUpdate/accounts/{accountName}/privateEndpointConnectionProxies/{privateEndpointConnectionProxyId}",
       apiVersion: "2023-07-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionProxiesDeleteInput =
@@ -1340,6 +1347,7 @@ export const PrivateEndpointConnectionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceUpdate/accounts/{accountName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2023-07-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PrivateEndpointConnectionsCreateOrUpdateInput =
@@ -1390,6 +1398,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceUpdate/accounts/{accountName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2023-07-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =

--- a/packages/azure/src/services/devopsinfrastructure.ts
+++ b/packages/azure/src/services/devopsinfrastructure.ts
@@ -237,6 +237,7 @@ export const PoolsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevOpsInfrastructure/pools/{poolName}",
       apiVersion: "2025-09-20",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PoolsCreateOrUpdateInput = typeof PoolsCreateOrUpdateInput.Type;
@@ -287,6 +288,7 @@ export const PoolsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevOpsInfrastructure/pools/{poolName}",
     apiVersion: "2025-09-20",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type PoolsDeleteInput = typeof PoolsDeleteInput.Type;
@@ -602,6 +604,7 @@ export const PoolsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevOpsInfrastructure/pools/{poolName}",
     apiVersion: "2025-09-20",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type PoolsUpdateInput = typeof PoolsUpdateInput.Type;

--- a/packages/azure/src/services/devspaces.ts
+++ b/packages/azure/src/services/devspaces.ts
@@ -77,6 +77,7 @@ export const ControllersCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevSpaces/controllers/{name}",
     apiVersion: "2019-04-01",
+    longRunning: {},
   }),
 );
 export type ControllersCreateInput = typeof ControllersCreateInput.Type;
@@ -108,6 +109,7 @@ export const ControllersDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevSpaces/controllers/{name}",
     apiVersion: "2019-04-01",
+    longRunning: {},
   }),
 );
 export type ControllersDeleteInput = typeof ControllersDeleteInput.Type;

--- a/packages/azure/src/services/devtestlabs.ts
+++ b/packages/azure/src/services/devtestlabs.ts
@@ -864,6 +864,7 @@ export const CustomImagesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{labName}/customimages/{name}",
       apiVersion: "2018-09-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CustomImagesCreateOrUpdateInput =
@@ -921,6 +922,7 @@ export const CustomImagesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{labName}/customimages/{name}",
       apiVersion: "2018-09-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CustomImagesDeleteInput = typeof CustomImagesDeleteInput.Type;
@@ -1137,6 +1139,7 @@ export const DisksAttachInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{labName}/users/{userName}/disks/{name}/attach",
     apiVersion: "2018-09-15",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type DisksAttachInput = typeof DisksAttachInput.Type;
@@ -1190,6 +1193,7 @@ export const DisksCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{labName}/users/{userName}/disks/{name}",
       apiVersion: "2018-09-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DisksCreateOrUpdateInput = typeof DisksCreateOrUpdateInput.Type;
@@ -1244,6 +1248,7 @@ export const DisksDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{labName}/users/{userName}/disks/{name}",
     apiVersion: "2018-09-15",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type DisksDeleteInput = typeof DisksDeleteInput.Type;
@@ -1280,6 +1285,7 @@ export const DisksDetachInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{labName}/users/{userName}/disks/{name}/detach",
     apiVersion: "2018-09-15",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type DisksDetachInput = typeof DisksDetachInput.Type;
@@ -1511,6 +1517,7 @@ export const EnvironmentsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{labName}/users/{userName}/environments/{name}",
       apiVersion: "2018-09-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type EnvironmentsCreateOrUpdateInput =
@@ -1570,6 +1577,7 @@ export const EnvironmentsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{labName}/users/{userName}/environments/{name}",
       apiVersion: "2018-09-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type EnvironmentsDeleteInput = typeof EnvironmentsDeleteInput.Type;
@@ -1970,6 +1978,7 @@ export const FormulasCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{labName}/formulas/{name}",
       apiVersion: "2018-09-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type FormulasCreateOrUpdateInput =
@@ -2427,6 +2436,7 @@ export const GlobalSchedulesExecuteInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/schedules/{name}/execute",
       apiVersion: "2018-09-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type GlobalSchedulesExecuteInput =
@@ -2667,6 +2677,7 @@ export const GlobalSchedulesRetargetInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/schedules/{name}/retarget",
       apiVersion: "2018-09-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type GlobalSchedulesRetargetInput =
@@ -2758,6 +2769,7 @@ export const LabsClaimAnyVmInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{name}/claimAnyVm",
     apiVersion: "2018-09-15",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type LabsClaimAnyVmInput = typeof LabsClaimAnyVmInput.Type;
@@ -2942,6 +2954,7 @@ export const LabsCreateEnvironmentInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{name}/createEnvironment",
       apiVersion: "2018-09-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LabsCreateEnvironmentInput = typeof LabsCreateEnvironmentInput.Type;
@@ -3029,6 +3042,7 @@ export const LabsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{name}",
       apiVersion: "2018-09-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LabsCreateOrUpdateInput = typeof LabsCreateOrUpdateInput.Type;
@@ -3079,6 +3093,7 @@ export const LabsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{name}",
     apiVersion: "2018-09-15",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type LabsDeleteInput = typeof LabsDeleteInput.Type;
@@ -3113,6 +3128,7 @@ export const LabsExportResourceUsageInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{name}/exportResourceUsage",
       apiVersion: "2018-09-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LabsExportResourceUsageInput =
@@ -3242,6 +3258,7 @@ export const LabsImportVirtualMachineInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{name}/importVirtualMachine",
       apiVersion: "2018-09-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LabsImportVirtualMachineInput =
@@ -4496,6 +4513,7 @@ export const SchedulesExecuteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{labName}/schedules/{name}/execute",
     apiVersion: "2018-09-15",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type SchedulesExecuteInput = typeof SchedulesExecuteInput.Type;
@@ -4777,6 +4795,7 @@ export const SecretsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{labName}/users/{userName}/secrets/{name}",
       apiVersion: "2018-09-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SecretsCreateOrUpdateInput = typeof SecretsCreateOrUpdateInput.Type;
@@ -5182,6 +5201,7 @@ export const ServiceFabricSchedulesExecuteInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{labName}/users/{userName}/servicefabrics/{serviceFabricName}/schedules/{name}/execute",
       apiVersion: "2018-09-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServiceFabricSchedulesExecuteInput =
@@ -5468,6 +5488,7 @@ export const ServiceFabricsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{labName}/users/{userName}/servicefabrics/{name}",
       apiVersion: "2018-09-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServiceFabricsCreateOrUpdateInput =
@@ -5526,6 +5547,7 @@ export const ServiceFabricsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{labName}/users/{userName}/servicefabrics/{name}",
       apiVersion: "2018-09-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServiceFabricsDeleteInput = typeof ServiceFabricsDeleteInput.Type;
@@ -5757,6 +5779,7 @@ export const ServiceFabricsStartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{labName}/users/{userName}/servicefabrics/{name}/start",
       apiVersion: "2018-09-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServiceFabricsStartInput = typeof ServiceFabricsStartInput.Type;
@@ -5794,6 +5817,7 @@ export const ServiceFabricsStopInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{labName}/users/{userName}/servicefabrics/{name}/stop",
       apiVersion: "2018-09-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServiceFabricsStopInput = typeof ServiceFabricsStopInput.Type;
@@ -6073,6 +6097,7 @@ export const UsersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{labName}/users/{name}",
       apiVersion: "2018-09-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type UsersCreateOrUpdateInput = typeof UsersCreateOrUpdateInput.Type;
@@ -6125,6 +6150,7 @@ export const UsersDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{labName}/users/{name}",
     apiVersion: "2018-09-15",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type UsersDeleteInput = typeof UsersDeleteInput.Type;
@@ -6339,6 +6365,7 @@ export const VirtualMachinesAddDataDiskInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{labName}/virtualmachines/{name}/addDataDisk",
       apiVersion: "2018-09-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesAddDataDiskInput =
@@ -6398,6 +6425,7 @@ export const VirtualMachinesApplyArtifactsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{labName}/virtualmachines/{name}/applyArtifacts",
       apiVersion: "2018-09-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesApplyArtifactsInput =
@@ -6571,6 +6599,7 @@ export const VirtualMachineSchedulesExecuteInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{labName}/virtualmachines/{virtualMachineName}/schedules/{name}/execute",
       apiVersion: "2018-09-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineSchedulesExecuteInput =
@@ -6810,6 +6839,7 @@ export const VirtualMachinesClaimInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{labName}/virtualmachines/{name}/claim",
       apiVersion: "2018-09-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesClaimInput = typeof VirtualMachinesClaimInput.Type;
@@ -7071,6 +7101,7 @@ export const VirtualMachinesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{labName}/virtualmachines/{name}",
       apiVersion: "2018-09-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesCreateOrUpdateInput =
@@ -7127,6 +7158,7 @@ export const VirtualMachinesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{labName}/virtualmachines/{name}",
       apiVersion: "2018-09-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesDeleteInput = typeof VirtualMachinesDeleteInput.Type;
@@ -7166,6 +7198,7 @@ export const VirtualMachinesDetachDataDiskInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{labName}/virtualmachines/{name}/detachDataDisk",
       apiVersion: "2018-09-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesDetachDataDiskInput =
@@ -7429,6 +7462,7 @@ export const VirtualMachinesRedeployInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{labName}/virtualmachines/{name}/redeploy",
       apiVersion: "2018-09-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesRedeployInput =
@@ -7469,6 +7503,7 @@ export const VirtualMachinesResizeInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{labName}/virtualmachines/{name}/resize",
       apiVersion: "2018-09-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesResizeInput = typeof VirtualMachinesResizeInput.Type;
@@ -7507,6 +7542,7 @@ export const VirtualMachinesRestartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{labName}/virtualmachines/{name}/restart",
       apiVersion: "2018-09-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesRestartInput =
@@ -7546,6 +7582,7 @@ export const VirtualMachinesStartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{labName}/virtualmachines/{name}/start",
       apiVersion: "2018-09-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesStartInput = typeof VirtualMachinesStartInput.Type;
@@ -7583,6 +7620,7 @@ export const VirtualMachinesStopInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{labName}/virtualmachines/{name}/stop",
       apiVersion: "2018-09-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesStopInput = typeof VirtualMachinesStopInput.Type;
@@ -7618,6 +7656,7 @@ export const VirtualMachinesTransferDisksInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{labName}/virtualmachines/{name}/transferDisks",
       apiVersion: "2018-09-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesTransferDisksInput =
@@ -7656,6 +7695,7 @@ export const VirtualMachinesUnClaimInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{labName}/virtualmachines/{name}/unClaim",
       apiVersion: "2018-09-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesUnClaimInput =
@@ -7809,6 +7849,7 @@ export const VirtualNetworksCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{labName}/virtualnetworks/{name}",
       apiVersion: "2018-09-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworksCreateOrUpdateInput =
@@ -7865,6 +7906,7 @@ export const VirtualNetworksDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DevTestLab/labs/{labName}/virtualnetworks/{name}",
       apiVersion: "2018-09-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworksDeleteInput = typeof VirtualNetworksDeleteInput.Type;

--- a/packages/azure/src/services/digitaltwins.ts
+++ b/packages/azure/src/services/digitaltwins.ts
@@ -200,6 +200,7 @@ export const DigitalTwinsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DigitalTwins/digitalTwinsInstances/{resourceName}",
       apiVersion: "2023-01-31",
+      longRunning: {},
     }),
   );
 export type DigitalTwinsCreateOrUpdateInput =
@@ -279,6 +280,7 @@ export const DigitalTwinsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DigitalTwins/digitalTwinsInstances/{resourceName}",
       apiVersion: "2023-01-31",
+      longRunning: {},
     }),
   );
 export type DigitalTwinsDeleteInput = typeof DigitalTwinsDeleteInput.Type;
@@ -411,6 +413,7 @@ export const DigitalTwinsEndpointCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DigitalTwins/digitalTwinsInstances/{resourceName}/endpoints/{endpointName}",
       apiVersion: "2023-01-31",
+      longRunning: {},
     }),
   );
 export type DigitalTwinsEndpointCreateOrUpdateInput =
@@ -460,6 +463,7 @@ export const DigitalTwinsEndpointDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DigitalTwins/digitalTwinsInstances/{resourceName}/endpoints/{endpointName}",
       apiVersion: "2023-01-31",
+      longRunning: {},
     }),
   );
 export type DigitalTwinsEndpointDeleteInput =
@@ -927,6 +931,7 @@ export const DigitalTwinsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DigitalTwins/digitalTwinsInstances/{resourceName}",
       apiVersion: "2023-01-31",
+      longRunning: {},
     }),
   );
 export type DigitalTwinsUpdateInput = typeof DigitalTwinsUpdateInput.Type;
@@ -1095,6 +1100,7 @@ export const PrivateEndpointConnectionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DigitalTwins/digitalTwinsInstances/{resourceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2023-01-31",
+      longRunning: {},
     }),
   );
 export type PrivateEndpointConnectionsCreateOrUpdateInput =
@@ -1169,6 +1175,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DigitalTwins/digitalTwinsInstances/{resourceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2023-01-31",
+      longRunning: {},
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =
@@ -1496,6 +1503,7 @@ export const TimeSeriesDatabaseConnectionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DigitalTwins/digitalTwinsInstances/{resourceName}/timeSeriesDatabaseConnections/{timeSeriesDatabaseConnectionName}",
       apiVersion: "2023-01-31",
+      longRunning: {},
     }),
   );
 export type TimeSeriesDatabaseConnectionsCreateOrUpdateInput =
@@ -1545,6 +1553,7 @@ export const TimeSeriesDatabaseConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DigitalTwins/digitalTwinsInstances/{resourceName}/timeSeriesDatabaseConnections/{timeSeriesDatabaseConnectionName}",
       apiVersion: "2023-01-31",
+      longRunning: {},
     }),
   );
 export type TimeSeriesDatabaseConnectionsDeleteInput =

--- a/packages/azure/src/services/dnc.ts
+++ b/packages/azure/src/services/dnc.ts
@@ -33,6 +33,7 @@ export const ControllerCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DelegatedNetwork/controller/{resourceName}",
     apiVersion: "2021-03-15",
+    longRunning: {},
   }),
 );
 export type ControllerCreateInput = typeof ControllerCreateInput.Type;
@@ -70,6 +71,7 @@ export const ControllerDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DelegatedNetwork/controller/{resourceName}",
     apiVersion: "2021-03-15",
+    longRunning: {},
   }),
 );
 export type ControllerDeleteInput = typeof ControllerDeleteInput.Type;
@@ -263,6 +265,7 @@ export const DelegatedSubnetServiceDeleteDetailsInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DelegatedNetwork/delegatedSubnets/{resourceName}",
       apiVersion: "2021-03-15",
+      longRunning: {},
     }),
   );
 export type DelegatedSubnetServiceDeleteDetailsInput =
@@ -426,6 +429,7 @@ export const DelegatedSubnetServicePatchDetailsInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DelegatedNetwork/delegatedSubnets/{resourceName}",
       apiVersion: "2021-03-15",
+      longRunning: {},
     }),
   );
 export type DelegatedSubnetServicePatchDetailsInput =
@@ -489,6 +493,7 @@ export const DelegatedSubnetServicePutDetailsInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DelegatedNetwork/delegatedSubnets/{resourceName}",
       apiVersion: "2021-03-15",
+      longRunning: {},
     }),
   );
 export type DelegatedSubnetServicePutDetailsInput =
@@ -606,6 +611,7 @@ export const OrchestratorInstanceServiceCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DelegatedNetwork/orchestrators/{resourceName}",
       apiVersion: "2021-03-15",
+      longRunning: {},
     }),
   );
 export type OrchestratorInstanceServiceCreateInput =
@@ -654,6 +660,7 @@ export const OrchestratorInstanceServiceDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DelegatedNetwork/orchestrators/{resourceName}",
       apiVersion: "2021-03-15",
+      longRunning: {},
     }),
   );
 export type OrchestratorInstanceServiceDeleteInput =

--- a/packages/azure/src/services/dns.ts
+++ b/packages/azure/src/services/dns.ts
@@ -1248,6 +1248,7 @@ export const ZonesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsZones/{zoneName}",
     apiVersion: "2018-05-01",
+    longRunning: {},
   }),
 );
 export type ZonesDeleteInput = typeof ZonesDeleteInput.Type;

--- a/packages/azure/src/services/dnsresolver.ts
+++ b/packages/azure/src/services/dnsresolver.ts
@@ -40,6 +40,7 @@ export const DnsForwardingRulesetsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsForwardingRulesets/{dnsForwardingRulesetName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DnsForwardingRulesetsCreateOrUpdateInput =
@@ -96,6 +97,7 @@ export const DnsForwardingRulesetsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsForwardingRulesets/{dnsForwardingRulesetName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DnsForwardingRulesetsDeleteInput =
@@ -388,6 +390,7 @@ export const DnsForwardingRulesetsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsForwardingRulesets/{dnsForwardingRulesetName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DnsForwardingRulesetsUpdateInput =
@@ -448,6 +451,7 @@ export const DnsResolverDomainListsBulkInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsResolverDomainLists/{dnsResolverDomainListName}/bulk",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DnsResolverDomainListsBulkInput =
@@ -525,6 +529,7 @@ export const DnsResolverDomainListsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsResolverDomainLists/{dnsResolverDomainListName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DnsResolverDomainListsCreateOrUpdateInput =
@@ -581,6 +586,7 @@ export const DnsResolverDomainListsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsResolverDomainLists/{dnsResolverDomainListName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DnsResolverDomainListsDeleteInput =
@@ -816,6 +822,7 @@ export const DnsResolverDomainListsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsResolverDomainLists/{dnsResolverDomainListName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DnsResolverDomainListsUpdateInput =
@@ -889,6 +896,7 @@ export const DnsResolverPoliciesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsResolverPolicies/{dnsResolverPolicyName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DnsResolverPoliciesCreateOrUpdateInput =
@@ -945,6 +953,7 @@ export const DnsResolverPoliciesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsResolverPolicies/{dnsResolverPolicyName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DnsResolverPoliciesDeleteInput =
@@ -1219,6 +1228,7 @@ export const DnsResolverPoliciesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsResolverPolicies/{dnsResolverPolicyName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DnsResolverPoliciesUpdateInput =
@@ -1294,6 +1304,7 @@ export const DnsResolverPolicyVirtualNetworkLinksCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsResolverPolicies/{dnsResolverPolicyName}/virtualNetworkLinks/{dnsResolverPolicyVirtualNetworkLinkName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DnsResolverPolicyVirtualNetworkLinksCreateOrUpdateInput =
@@ -1352,6 +1363,7 @@ export const DnsResolverPolicyVirtualNetworkLinksDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsResolverPolicies/{dnsResolverPolicyName}/virtualNetworkLinks/{dnsResolverPolicyVirtualNetworkLinkName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DnsResolverPolicyVirtualNetworkLinksDeleteInput =
@@ -1519,6 +1531,7 @@ export const DnsResolverPolicyVirtualNetworkLinksUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsResolverPolicies/{dnsResolverPolicyName}/virtualNetworkLinks/{dnsResolverPolicyVirtualNetworkLinkName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DnsResolverPolicyVirtualNetworkLinksUpdateInput =
@@ -1597,6 +1610,7 @@ export const DnsResolversCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsResolvers/{dnsResolverName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DnsResolversCreateOrUpdateInput =
@@ -1654,6 +1668,7 @@ export const DnsResolversDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsResolvers/{dnsResolverName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DnsResolversDeleteInput = typeof DnsResolversDeleteInput.Type;
@@ -1915,6 +1930,7 @@ export const DnsResolversUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsResolvers/{dnsResolverName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DnsResolversUpdateInput = typeof DnsResolversUpdateInput.Type;
@@ -1997,6 +2013,7 @@ export const DnsSecurityRulesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsResolverPolicies/{dnsResolverPolicyName}/dnsSecurityRules/{dnsSecurityRuleName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DnsSecurityRulesCreateOrUpdateInput =
@@ -2055,6 +2072,7 @@ export const DnsSecurityRulesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsResolverPolicies/{dnsResolverPolicyName}/dnsSecurityRules/{dnsSecurityRuleName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DnsSecurityRulesDeleteInput =
@@ -2241,6 +2259,7 @@ export const DnsSecurityRulesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsResolverPolicies/{dnsResolverPolicyName}/dnsSecurityRules/{dnsSecurityRuleName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DnsSecurityRulesUpdateInput =
@@ -2641,6 +2660,7 @@ export const InboundEndpointsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsResolvers/{dnsResolverName}/inboundEndpoints/{inboundEndpointName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type InboundEndpointsCreateOrUpdateInput =
@@ -2699,6 +2719,7 @@ export const InboundEndpointsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsResolvers/{dnsResolverName}/inboundEndpoints/{inboundEndpointName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type InboundEndpointsDeleteInput =
@@ -2863,6 +2884,7 @@ export const InboundEndpointsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsResolvers/{dnsResolverName}/inboundEndpoints/{inboundEndpointName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type InboundEndpointsUpdateInput =
@@ -2940,6 +2962,7 @@ export const OutboundEndpointsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsResolvers/{dnsResolverName}/outboundEndpoints/{outboundEndpointName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type OutboundEndpointsCreateOrUpdateInput =
@@ -2998,6 +3021,7 @@ export const OutboundEndpointsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsResolvers/{dnsResolverName}/outboundEndpoints/{outboundEndpointName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type OutboundEndpointsDeleteInput =
@@ -3165,6 +3189,7 @@ export const OutboundEndpointsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsResolvers/{dnsResolverName}/outboundEndpoints/{outboundEndpointName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type OutboundEndpointsUpdateInput =
@@ -3240,6 +3265,7 @@ export const VirtualNetworkLinksCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsForwardingRulesets/{dnsForwardingRulesetName}/virtualNetworkLinks/{virtualNetworkLinkName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkLinksCreateOrUpdateInput =
@@ -3298,6 +3324,7 @@ export const VirtualNetworkLinksDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsForwardingRulesets/{dnsForwardingRulesetName}/virtualNetworkLinks/{virtualNetworkLinkName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkLinksDeleteInput =
@@ -3472,6 +3499,7 @@ export const VirtualNetworkLinksUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsForwardingRulesets/{dnsForwardingRulesetName}/virtualNetworkLinks/{virtualNetworkLinkName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkLinksUpdateInput =

--- a/packages/azure/src/services/domainregistration.ts
+++ b/packages/azure/src/services/domainregistration.ts
@@ -340,6 +340,7 @@ export const DomainsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DomainRegistration/domains/{domainName}",
       apiVersion: "2024-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DomainsCreateOrUpdateInput = typeof DomainsCreateOrUpdateInput.Type;

--- a/packages/azure/src/services/domainservices.ts
+++ b/packages/azure/src/services/domainservices.ts
@@ -248,6 +248,7 @@ export const DomainServicesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AAD/domainServices/{domainServiceName}",
       apiVersion: "2022-12-01",
+      longRunning: {},
     }),
   );
 export type DomainServicesCreateOrUpdateInput =
@@ -298,6 +299,7 @@ export const DomainServicesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AAD/domainServices/{domainServiceName}",
       apiVersion: "2022-12-01",
+      longRunning: {},
     }),
   );
 export type DomainServicesDeleteInput = typeof DomainServicesDeleteInput.Type;
@@ -691,6 +693,7 @@ export const DomainServicesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AAD/domainServices/{domainServiceName}",
       apiVersion: "2022-12-01",
+      longRunning: {},
     }),
   );
 export type DomainServicesUpdateInput = typeof DomainServicesUpdateInput.Type;
@@ -745,6 +748,7 @@ export const OuContainerCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Aad/domainServices/{domainServiceName}/ouContainer/{ouContainerName}",
     apiVersion: "2022-12-01",
+    longRunning: {},
   }),
 );
 export type OuContainerCreateInput = typeof OuContainerCreateInput.Type;
@@ -793,6 +797,7 @@ export const OuContainerDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Aad/domainServices/{domainServiceName}/ouContainer/{ouContainerName}",
     apiVersion: "2022-12-01",
+    longRunning: {},
   }),
 );
 export type OuContainerDeleteInput = typeof OuContainerDeleteInput.Type;
@@ -980,6 +985,7 @@ export const OuContainerUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Aad/domainServices/{domainServiceName}/ouContainer/{ouContainerName}",
     apiVersion: "2022-12-01",
+    longRunning: {},
   }),
 );
 export type OuContainerUpdateInput = typeof OuContainerUpdateInput.Type;

--- a/packages/azure/src/services/durabletask.ts
+++ b/packages/azure/src/services/durabletask.ts
@@ -97,6 +97,7 @@ export const RetentionPoliciesCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DurableTask/schedulers/{schedulerName}/retentionPolicies/default",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type RetentionPoliciesCreateOrReplaceInput =
@@ -151,6 +152,7 @@ export const RetentionPoliciesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DurableTask/schedulers/{schedulerName}/retentionPolicies/default",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RetentionPoliciesDeleteInput =
@@ -340,6 +342,7 @@ export const RetentionPoliciesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DurableTask/schedulers/{schedulerName}/retentionPolicies/default",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RetentionPoliciesUpdateInput =
@@ -455,6 +458,7 @@ export const SchedulersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DurableTask/schedulers/{schedulerName}",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SchedulersCreateOrUpdateInput =
@@ -548,6 +552,7 @@ export const SchedulersCreateOrUpdatePrivateEndpointConnectionInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DurableTask/schedulers/{schedulerName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SchedulersCreateOrUpdatePrivateEndpointConnectionInput =
@@ -603,6 +608,7 @@ export const SchedulersDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DurableTask/schedulers/{schedulerName}",
     apiVersion: "2026-02-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type SchedulersDeleteInput = typeof SchedulersDeleteInput.Type;
@@ -636,6 +642,7 @@ export const SchedulersDeletePrivateEndpointConnectionInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DurableTask/schedulers/{schedulerName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SchedulersDeletePrivateEndpointConnectionInput =
@@ -1133,6 +1140,7 @@ export const SchedulersUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DurableTask/schedulers/{schedulerName}",
     apiVersion: "2026-02-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type SchedulersUpdateInput = typeof SchedulersUpdateInput.Type;
@@ -1204,6 +1212,7 @@ export const SchedulersUpdatePrivateEndpointConnectionInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DurableTask/schedulers/{schedulerName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SchedulersUpdatePrivateEndpointConnectionInput =
@@ -1276,6 +1285,7 @@ export const TaskHubsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DurableTask/schedulers/{schedulerName}/taskHubs/{taskHubName}",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type TaskHubsCreateOrUpdateInput =
@@ -1332,6 +1342,7 @@ export const TaskHubsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DurableTask/schedulers/{schedulerName}/taskHubs/{taskHubName}",
     apiVersion: "2026-02-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type TaskHubsDeleteInput = typeof TaskHubsDeleteInput.Type;

--- a/packages/azure/src/services/edge.ts
+++ b/packages/azure/src/services/edge.ts
@@ -214,6 +214,7 @@ export const ConfigTemplatesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/configTemplates/{configTemplateName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ConfigTemplatesCreateOrUpdateInput =
@@ -289,6 +290,7 @@ export const ConfigTemplatesCreateVersionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/configTemplates/{configTemplateName}/createVersion",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ConfigTemplatesCreateVersionInput =
@@ -343,6 +345,7 @@ export const ConfigTemplatesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/configTemplates/{configTemplateName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ConfigTemplatesDeleteInput = typeof ConfigTemplatesDeleteInput.Type;
@@ -1421,6 +1424,7 @@ export const ContextsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/contexts/{contextName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ContextsCreateOrUpdateInput =
@@ -1475,6 +1479,7 @@ export const ContextsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/contexts/{contextName}",
     apiVersion: "2025-08-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ContextsDeleteInput = typeof ContextsDeleteInput.Type;
@@ -1711,6 +1716,7 @@ export const ContextsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/contexts/{contextName}",
     apiVersion: "2025-08-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ContextsUpdateInput = typeof ContextsUpdateInput.Type;
@@ -1784,6 +1790,7 @@ export const DiagnosticsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/diagnostics/{diagnosticName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DiagnosticsCreateOrUpdateInput =
@@ -1840,6 +1847,7 @@ export const DiagnosticsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/diagnostics/{diagnosticName}",
     apiVersion: "2025-08-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type DiagnosticsDeleteInput = typeof DiagnosticsDeleteInput.Type;
@@ -2056,6 +2064,7 @@ export const DiagnosticsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/diagnostics/{diagnosticName}",
     apiVersion: "2025-08-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type DiagnosticsUpdateInput = typeof DiagnosticsUpdateInput.Type;
@@ -2154,6 +2163,7 @@ export const DisconnectedOperationsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/disconnectedOperations/{name}",
       apiVersion: "2026-03-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DisconnectedOperationsCreateOrUpdateInput =
@@ -2208,6 +2218,7 @@ export const DisconnectedOperationsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/disconnectedOperations/{name}",
       apiVersion: "2026-03-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DisconnectedOperationsDeleteInput =
@@ -2623,6 +2634,7 @@ export const DynamicConfigurationsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/configurations/{configurationName}/dynamicConfigurations/{dynamicConfigurationName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DynamicConfigurationsCreateOrUpdateInput =
@@ -2928,6 +2940,7 @@ export const DynamicConfigurationVersionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/configurations/{configurationName}/dynamicConfigurations/{dynamicConfigurationName}/versions/{dynamicConfigurationVersionName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DynamicConfigurationVersionsCreateOrUpdateInput =
@@ -3239,6 +3252,7 @@ export const DynamicSchemasCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/schemas/{schemaName}/dynamicSchemas/{dynamicSchemaName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DynamicSchemasCreateOrUpdateInput =
@@ -3295,6 +3309,7 @@ export const DynamicSchemasDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/schemas/{schemaName}/dynamicSchemas/{dynamicSchemaName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DynamicSchemasDeleteInput = typeof DynamicSchemasDeleteInput.Type;
@@ -3549,6 +3564,7 @@ export const DynamicSchemaVersionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/schemas/{schemaName}/dynamicSchemas/{dynamicSchemaName}/versions/{dynamicSchemaVersionName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DynamicSchemaVersionsCreateOrUpdateInput =
@@ -3607,6 +3623,7 @@ export const DynamicSchemaVersionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/schemas/{schemaName}/dynamicSchemas/{dynamicSchemaName}/versions/{dynamicSchemaVersionName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DynamicSchemaVersionsDeleteInput =
@@ -3895,6 +3912,7 @@ export const ExecutionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/contexts/{contextName}/workflows/{workflowName}/versions/{versionName}/executions/{executionName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ExecutionsCreateOrUpdateInput =
@@ -3955,6 +3973,7 @@ export const ExecutionsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/contexts/{contextName}/workflows/{workflowName}/versions/{versionName}/executions/{executionName}",
     apiVersion: "2025-08-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ExecutionsDeleteInput = typeof ExecutionsDeleteInput.Type;
@@ -4128,6 +4147,7 @@ export const ExecutionsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/contexts/{contextName}/workflows/{workflowName}/versions/{versionName}/executions/{executionName}",
     apiVersion: "2025-08-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ExecutionsUpdateInput = typeof ExecutionsUpdateInput.Type;
@@ -4200,6 +4220,7 @@ export const HardwareSettingsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/disconnectedOperations/{name}/hardwareSettings/{hardwareSettingName}",
       apiVersion: "2026-03-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type HardwareSettingsCreateOrUpdateInput =
@@ -4256,6 +4277,7 @@ export const HardwareSettingsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/disconnectedOperations/{name}/hardwareSettings/{hardwareSettingName}",
       apiVersion: "2026-03-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type HardwareSettingsDeleteInput =
@@ -4789,6 +4811,7 @@ export const InstancesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/targets/{targetName}/solutions/{solutionName}/instances/{instanceName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type InstancesCreateOrUpdateInput =
@@ -4847,6 +4870,7 @@ export const InstancesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/targets/{targetName}/solutions/{solutionName}/instances/{instanceName}",
     apiVersion: "2025-08-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type InstancesDeleteInput = typeof InstancesDeleteInput.Type;
@@ -5021,6 +5045,7 @@ export const InstancesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/targets/{targetName}/solutions/{solutionName}/instances/{instanceName}",
     apiVersion: "2025-08-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type InstancesUpdateInput = typeof InstancesUpdateInput.Type;
@@ -5241,6 +5266,7 @@ export const SchemaReferencesCreateOrUpdateInput =
       method: "PUT",
       path: "/{resourceUri}/providers/Microsoft.Edge/schemaReferences/{schemaReferenceName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SchemaReferencesCreateOrUpdateInput =
@@ -5291,6 +5317,7 @@ export const SchemaReferencesDeleteInput =
       method: "DELETE",
       path: "/{resourceUri}/providers/Microsoft.Edge/schemaReferences/{schemaReferenceName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SchemaReferencesDeleteInput =
@@ -5509,6 +5536,7 @@ export const SchemasCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/schemas/{schemaName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SchemasCreateOrUpdateInput = typeof SchemasCreateOrUpdateInput.Type;
@@ -5584,6 +5612,7 @@ export const SchemasCreateVersionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/schemas/{schemaName}/createVersion",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SchemasCreateVersionInput = typeof SchemasCreateVersionInput.Type;
@@ -5636,6 +5665,7 @@ export const SchemasDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/schemas/{schemaName}",
     apiVersion: "2025-08-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type SchemasDeleteInput = typeof SchemasDeleteInput.Type;
@@ -5957,6 +5987,7 @@ export const SchemaVersionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/schemas/{schemaName}/versions/{schemaVersionName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SchemaVersionsCreateOrUpdateInput =
@@ -6013,6 +6044,7 @@ export const SchemaVersionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/schemas/{schemaName}/versions/{schemaVersionName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SchemaVersionsDeleteInput = typeof SchemaVersionsDeleteInput.Type;
@@ -6249,6 +6281,7 @@ export const SiteReferencesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/contexts/{contextName}/siteReferences/{siteReferenceName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SiteReferencesCreateOrUpdateInput =
@@ -6305,6 +6338,7 @@ export const SiteReferencesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/contexts/{contextName}/siteReferences/{siteReferenceName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SiteReferencesDeleteInput = typeof SiteReferencesDeleteInput.Type;
@@ -6471,6 +6505,7 @@ export const SiteReferencesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/contexts/{contextName}/siteReferences/{siteReferenceName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SiteReferencesUpdateInput = typeof SiteReferencesUpdateInput.Type;
@@ -6544,6 +6579,7 @@ export const SitesByServiceGroupCreateOrUpdateInput =
       method: "PUT",
       path: "/providers/Microsoft.Management/serviceGroups/{servicegroupName}/providers/Microsoft.Edge/sites/{siteName}",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SitesByServiceGroupCreateOrUpdateInput =
@@ -6839,6 +6875,7 @@ export const SitesBySubscriptionCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.Edge/sites/{siteName}",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SitesBySubscriptionCreateOrUpdateInput =
@@ -7136,6 +7173,7 @@ export const SitesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/sites/{siteName}",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SitesCreateOrUpdateInput = typeof SitesCreateOrUpdateInput.Type;
@@ -7434,6 +7472,7 @@ export const SolutionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/targets/{targetName}/solutions/{solutionName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SolutionsCreateOrUpdateInput =
@@ -7490,6 +7529,7 @@ export const SolutionsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/targets/{targetName}/solutions/{solutionName}",
     apiVersion: "2025-08-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type SolutionsDeleteInput = typeof SolutionsDeleteInput.Type;
@@ -7644,6 +7684,7 @@ export const SolutionsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/targets/{targetName}/solutions/{solutionName}",
     apiVersion: "2025-08-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type SolutionsUpdateInput = typeof SolutionsUpdateInput.Type;
@@ -7718,6 +7759,7 @@ export const SolutionTemplatesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/solutionTemplates/{solutionTemplateName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SolutionTemplatesCreateOrUpdateInput =
@@ -7793,6 +7835,7 @@ export const SolutionTemplatesCreateVersionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/solutionTemplates/{solutionTemplateName}/createVersion",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SolutionTemplatesCreateVersionInput =
@@ -7847,6 +7890,7 @@ export const SolutionTemplatesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/solutionTemplates/{solutionTemplateName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SolutionTemplatesDeleteInput =
@@ -8070,6 +8114,7 @@ export const SolutionTemplatesRemoveVersionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/solutionTemplates/{solutionTemplateName}/removeVersion",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SolutionTemplatesRemoveVersionInput =
@@ -8176,6 +8221,7 @@ export const SolutionTemplateVersionsBulkDeploySolutionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/solutionTemplates/{solutionTemplateName}/versions/{solutionTemplateVersionName}/bulkDeploySolution",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SolutionTemplateVersionsBulkDeploySolutionInput =
@@ -8236,6 +8282,7 @@ export const SolutionTemplateVersionsBulkPublishSolutionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/solutionTemplates/{solutionTemplateName}/versions/{solutionTemplateVersionName}/bulkPublishSolution",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SolutionTemplateVersionsBulkPublishSolutionInput =
@@ -8295,6 +8342,7 @@ export const SolutionTemplateVersionsBulkReviewSolutionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/solutionTemplates/{solutionTemplateName}/versions/{solutionTemplateVersionName}/bulkReviewSolution",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SolutionTemplateVersionsBulkReviewSolutionInput =
@@ -8610,6 +8658,7 @@ export const SolutionVersionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/targets/{targetName}/solutions/{solutionName}/versions/{solutionVersionName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SolutionVersionsCreateOrUpdateInput =
@@ -8668,6 +8717,7 @@ export const SolutionVersionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/targets/{targetName}/solutions/{solutionName}/versions/{solutionVersionName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SolutionVersionsDeleteInput =
@@ -8842,6 +8892,7 @@ export const SolutionVersionsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/targets/{targetName}/solutions/{solutionName}/versions/{solutionVersionName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SolutionVersionsUpdateInput =
@@ -8957,6 +9008,7 @@ export const TargetsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/targets/{targetName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type TargetsCreateOrUpdateInput = typeof TargetsCreateOrUpdateInput.Type;
@@ -9010,6 +9062,7 @@ export const TargetsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/targets/{targetName}",
     apiVersion: "2025-08-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type TargetsDeleteInput = typeof TargetsDeleteInput.Type;
@@ -9092,6 +9145,7 @@ export const TargetsInstallSolutionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/targets/{targetName}/installSolution",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type TargetsInstallSolutionInput =
@@ -9264,6 +9318,7 @@ export const TargetsPublishSolutionVersionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/targets/{targetName}/publishSolutionVersion",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type TargetsPublishSolutionVersionInput =
@@ -9320,6 +9375,7 @@ export const TargetsRemoveRevisionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/targets/{targetName}/removeRevision",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type TargetsRemoveRevisionInput = typeof TargetsRemoveRevisionInput.Type;
@@ -9370,6 +9426,7 @@ export const TargetsResolveConfigurationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/targets/{targetName}/resolveConfiguration",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type TargetsResolveConfigurationInput =
@@ -9423,6 +9480,7 @@ export const TargetsReviewSolutionVersionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/targets/{targetName}/reviewSolutionVersion",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type TargetsReviewSolutionVersionInput =
@@ -9479,6 +9537,7 @@ export const TargetsUninstallSolutionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/targets/{targetName}/uninstallSolution",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type TargetsUninstallSolutionInput =
@@ -9517,6 +9576,7 @@ export const TargetsUnstageSolutionVersionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/targets/{targetName}/unstageSolutionVersion",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type TargetsUnstageSolutionVersionInput =
@@ -9585,6 +9645,7 @@ export const TargetsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/targets/{targetName}",
     apiVersion: "2025-08-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type TargetsUpdateInput = typeof TargetsUpdateInput.Type;
@@ -9671,6 +9732,7 @@ export const TargetsUpdateExternalValidationStatusInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/targets/{targetName}/updateExternalValidationStatus",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type TargetsUpdateExternalValidationStatusInput =
@@ -9748,6 +9810,7 @@ export const WorkflowsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/contexts/{contextName}/workflows/{workflowName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type WorkflowsCreateOrUpdateInput =
@@ -9804,6 +9867,7 @@ export const WorkflowsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/contexts/{contextName}/workflows/{workflowName}",
     apiVersion: "2025-08-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type WorkflowsDeleteInput = typeof WorkflowsDeleteInput.Type;
@@ -9973,6 +10037,7 @@ export const WorkflowsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/contexts/{contextName}/workflows/{workflowName}",
     apiVersion: "2025-08-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type WorkflowsUpdateInput = typeof WorkflowsUpdateInput.Type;
@@ -10103,6 +10168,7 @@ export const WorkflowVersionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/contexts/{contextName}/workflows/{workflowName}/versions/{versionName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type WorkflowVersionsCreateOrUpdateInput =
@@ -10161,6 +10227,7 @@ export const WorkflowVersionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/contexts/{contextName}/workflows/{workflowName}/versions/{versionName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkflowVersionsDeleteInput =
@@ -10371,6 +10438,7 @@ export const WorkflowVersionsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/contexts/{contextName}/workflows/{workflowName}/versions/{versionName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkflowVersionsUpdateInput =

--- a/packages/azure/src/services/edgemarketplace.ts
+++ b/packages/azure/src/services/edgemarketplace.ts
@@ -26,6 +26,7 @@ export const OffersGenerateAccessTokenInput =
       method: "POST",
       path: "/{resourceUri}/providers/Microsoft.EdgeMarketplace/offers/{offerId}/generateAccessToken",
       apiVersion: "2024-10-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type OffersGenerateAccessTokenInput =

--- a/packages/azure/src/services/edgeorder.ts
+++ b/packages/azure/src/services/edgeorder.ts
@@ -56,6 +56,7 @@ export const AddressesCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EdgeOrder/addresses/{addressName}",
     apiVersion: "2024-02-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type AddressesCreateInput = typeof AddressesCreateInput.Type;
@@ -106,6 +107,7 @@ export const AddressesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EdgeOrder/addresses/{addressName}",
     apiVersion: "2024-02-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type AddressesDeleteInput = typeof AddressesDeleteInput.Type;
@@ -361,6 +363,7 @@ export const AddressesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EdgeOrder/addresses/{addressName}",
     apiVersion: "2024-02-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type AddressesUpdateInput = typeof AddressesUpdateInput.Type;
@@ -984,6 +987,7 @@ export const OrderItemsCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EdgeOrder/orderItems/{orderItemName}",
     apiVersion: "2024-02-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type OrderItemsCreateInput = typeof OrderItemsCreateInput.Type;
@@ -1036,6 +1040,7 @@ export const OrderItemsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EdgeOrder/orderItems/{orderItemName}",
     apiVersion: "2024-02-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type OrderItemsDeleteInput = typeof OrderItemsDeleteInput.Type;
@@ -1307,6 +1312,7 @@ export const OrderItemsReturnInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EdgeOrder/orderItems/{orderItemName}/return",
     apiVersion: "2024-02-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type OrderItemsReturnInput = typeof OrderItemsReturnInput.Type;
@@ -1476,6 +1482,7 @@ export const OrderItemsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EdgeOrder/orderItems/{orderItemName}",
     apiVersion: "2024-02-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type OrderItemsUpdateInput = typeof OrderItemsUpdateInput.Type;

--- a/packages/azure/src/services/elastic.ts
+++ b/packages/azure/src/services/elastic.ts
@@ -83,6 +83,7 @@ export const AssociateTrafficFilterAssociateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Elastic/monitors/{monitorName}/associateTrafficFilter",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AssociateTrafficFilterAssociateInput =
@@ -228,6 +229,7 @@ export const CreateAndAssociateIPFilterCreateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Elastic/monitors/{monitorName}/createAndAssociateIPFilter",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CreateAndAssociateIPFilterCreateInput =
@@ -269,6 +271,7 @@ export const CreateAndAssociatePLFilterCreateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Elastic/monitors/{monitorName}/createAndAssociatePLFilter",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CreateAndAssociatePLFilterCreateInput =
@@ -405,6 +408,7 @@ export const DetachTrafficFilterUpdateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Elastic/monitors/{monitorName}/detachTrafficFilter",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DetachTrafficFilterUpdateInput =
@@ -710,6 +714,7 @@ export const MonitoredSubscriptionsCreateorUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Elastic/monitors/{monitorName}/monitoredSubscriptions/{configurationName}",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type MonitoredSubscriptionsCreateorUpdateInput =
@@ -764,6 +769,7 @@ export const MonitoredSubscriptionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Elastic/monitors/{monitorName}/monitoredSubscriptions/{configurationName}",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type MonitoredSubscriptionsDeleteInput =
@@ -1001,6 +1007,7 @@ export const MonitoredSubscriptionsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Elastic/monitors/{monitorName}/monitoredSubscriptions/{configurationName}",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type MonitoredSubscriptionsUpdateInput =
@@ -1167,6 +1174,7 @@ export const MonitorsCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Elastic/monitors/{monitorName}",
     apiVersion: "2025-06-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type MonitorsCreateInput = typeof MonitorsCreateInput.Type;
@@ -1215,6 +1223,7 @@ export const MonitorsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Elastic/monitors/{monitorName}",
     apiVersion: "2025-06-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type MonitorsDeleteInput = typeof MonitorsDeleteInput.Type;
@@ -1414,6 +1423,7 @@ export const MonitorsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Elastic/monitors/{monitorName}",
     apiVersion: "2025-06-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type MonitorsUpdateInput = typeof MonitorsUpdateInput.Type;
@@ -1463,6 +1473,7 @@ export const MonitorUpgradeInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Elastic/monitors/{monitorName}/upgrade",
     apiVersion: "2025-06-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type MonitorUpgradeInput = typeof MonitorUpgradeInput.Type;
@@ -1881,6 +1892,7 @@ export const OrganizationsResubscribeInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Elastic/monitors/{monitorName}/resubscribe",
       apiVersion: "2025-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type OrganizationsResubscribeInput =
@@ -2026,6 +2038,7 @@ export const TagRulesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Elastic/monitors/{monitorName}/tagRules/{ruleSetName}",
     apiVersion: "2025-06-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type TagRulesDeleteInput = typeof TagRulesDeleteInput.Type;

--- a/packages/azure/src/services/elasticsan.ts
+++ b/packages/azure/src/services/elasticsan.ts
@@ -100,6 +100,7 @@ export const ElasticSansCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ElasticSan/elasticSans/{elasticSanName}",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ElasticSansCreateInput = typeof ElasticSansCreateInput.Type;
@@ -152,6 +153,7 @@ export const ElasticSansDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ElasticSan/elasticSans/{elasticSanName}",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ElasticSansDeleteInput = typeof ElasticSansDeleteInput.Type;
@@ -390,6 +392,7 @@ export const ElasticSansUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ElasticSan/elasticSans/{elasticSanName}",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ElasticSansUpdateInput = typeof ElasticSansUpdateInput.Type;
@@ -519,6 +522,7 @@ export const PrivateEndpointConnectionsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ElasticSan/elasticSans/{elasticSanName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsCreateInput =
@@ -575,6 +579,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ElasticSan/elasticSans/{elasticSanName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =
@@ -970,6 +975,7 @@ export const VolumeGroupsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ElasticSan/elasticSans/{elasticSanName}/volumegroups/{volumeGroupName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VolumeGroupsCreateInput = typeof VolumeGroupsCreateInput.Type;
@@ -1023,6 +1029,7 @@ export const VolumeGroupsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ElasticSan/elasticSans/{elasticSanName}/volumegroups/{volumeGroupName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VolumeGroupsDeleteInput = typeof VolumeGroupsDeleteInput.Type;
@@ -1238,6 +1245,7 @@ export const VolumeGroupsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ElasticSan/elasticSans/{elasticSanName}/volumegroups/{volumeGroupName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VolumeGroupsUpdateInput = typeof VolumeGroupsUpdateInput.Type;
@@ -1361,6 +1369,7 @@ export const VolumesCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ElasticSan/elasticSans/{elasticSanName}/volumegroups/{volumeGroupName}/volumes/{volumeName}",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type VolumesCreateInput = typeof VolumesCreateInput.Type;
@@ -1414,6 +1423,7 @@ export const VolumesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ElasticSan/elasticSans/{elasticSanName}/volumegroups/{volumeGroupName}/volumes/{volumeName}",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type VolumesDeleteInput = typeof VolumesDeleteInput.Type;
@@ -1598,6 +1608,7 @@ export const VolumeSnapshotsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ElasticSan/elasticSans/{elasticSanName}/volumegroups/{volumeGroupName}/snapshots/{snapshotName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VolumeSnapshotsCreateInput = typeof VolumeSnapshotsCreateInput.Type;
@@ -1656,6 +1667,7 @@ export const VolumeSnapshotsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ElasticSan/elasticSans/{elasticSanName}/volumegroups/{volumeGroupName}/snapshots/{snapshotName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VolumeSnapshotsDeleteInput = typeof VolumeSnapshotsDeleteInput.Type;
@@ -1823,6 +1835,7 @@ export const VolumesPreBackupInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ElasticSan/elasticSans/{elasticSanName}/volumegroups/{volumeGroupName}/preBackup",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type VolumesPreBackupInput = typeof VolumesPreBackupInput.Type;
@@ -1863,6 +1876,7 @@ export const VolumesPreRestoreInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ElasticSan/elasticSans/{elasticSanName}/volumegroups/{volumeGroupName}/preRestore",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type VolumesPreRestoreInput = typeof VolumesPreRestoreInput.Type;
@@ -1910,6 +1924,7 @@ export const VolumesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ElasticSan/elasticSans/{elasticSanName}/volumegroups/{volumeGroupName}/volumes/{volumeName}",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type VolumesUpdateInput = typeof VolumesUpdateInput.Type;

--- a/packages/azure/src/services/eventgrid.ts
+++ b/packages/azure/src/services/eventgrid.ts
@@ -55,6 +55,7 @@ export const CaCertificatesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/caCertificates/{caCertificateName}",
       apiVersion: "2025-02-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CaCertificatesCreateOrUpdateInput =
@@ -96,6 +97,7 @@ export const CaCertificatesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/caCertificates/{caCertificateName}",
       apiVersion: "2025-02-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CaCertificatesDeleteInput = typeof CaCertificatesDeleteInput.Type;
@@ -320,6 +322,7 @@ export const ChannelsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerNamespaces/{partnerNamespaceName}/channels/{channelName}",
     apiVersion: "2025-02-15",
+    longRunning: {},
   }),
 );
 export type ChannelsDeleteInput = typeof ChannelsDeleteInput.Type;
@@ -562,6 +565,7 @@ export const ClientGroupsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/clientGroups/{clientGroupName}",
       apiVersion: "2025-02-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ClientGroupsCreateOrUpdateInput =
@@ -604,6 +608,7 @@ export const ClientGroupsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/clientGroups/{clientGroupName}",
       apiVersion: "2025-02-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ClientGroupsDeleteInput = typeof ClientGroupsDeleteInput.Type;
@@ -773,6 +778,7 @@ export const ClientsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/clients/{clientName}",
       apiVersion: "2025-02-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ClientsCreateOrUpdateInput = typeof ClientsCreateOrUpdateInput.Type;
@@ -813,6 +819,7 @@ export const ClientsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/clients/{clientName}",
     apiVersion: "2025-02-15",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ClientsDeleteInput = typeof ClientsDeleteInput.Type;
@@ -1078,6 +1085,7 @@ export const DomainEventSubscriptionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/eventSubscriptions/{eventSubscriptionName}",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type DomainEventSubscriptionsCreateOrUpdateInput =
@@ -1119,6 +1127,7 @@ export const DomainEventSubscriptionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/eventSubscriptions/{eventSubscriptionName}",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type DomainEventSubscriptionsDeleteInput =
@@ -1445,6 +1454,7 @@ export const DomainEventSubscriptionsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/eventSubscriptions/{eventSubscriptionName}",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type DomainEventSubscriptionsUpdateInput =
@@ -1597,6 +1607,7 @@ export const DomainsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type DomainsCreateOrUpdateInput = typeof DomainsCreateOrUpdateInput.Type;
@@ -1635,6 +1646,7 @@ export const DomainsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}",
     apiVersion: "2025-02-15",
+    longRunning: {},
   }),
 );
 export type DomainsDeleteInput = typeof DomainsDeleteInput.Type;
@@ -1926,6 +1938,7 @@ export const DomainsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}",
     apiVersion: "2025-02-15",
+    longRunning: {},
   }),
 );
 export type DomainsUpdateInput = typeof DomainsUpdateInput.Type;
@@ -2108,6 +2121,7 @@ export const DomainTopicEventSubscriptionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type DomainTopicEventSubscriptionsCreateOrUpdateInput =
@@ -2151,6 +2165,7 @@ export const DomainTopicEventSubscriptionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type DomainTopicEventSubscriptionsDeleteInput =
@@ -2486,6 +2501,7 @@ export const DomainTopicEventSubscriptionsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type DomainTopicEventSubscriptionsUpdateInput =
@@ -2528,6 +2544,7 @@ export const DomainTopicsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/topics/{domainTopicName}",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type DomainTopicsCreateOrUpdateInput =
@@ -2570,6 +2587,7 @@ export const DomainTopicsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/domains/{domainName}/topics/{domainTopicName}",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type DomainTopicsDeleteInput = typeof DomainTopicsDeleteInput.Type;
@@ -2834,6 +2852,7 @@ export const EventSubscriptionsCreateOrUpdateInput =
       method: "PUT",
       path: "/{scope}/providers/Microsoft.EventGrid/eventSubscriptions/{eventSubscriptionName}",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type EventSubscriptionsCreateOrUpdateInput =
@@ -2873,6 +2892,7 @@ export const EventSubscriptionsDeleteInput =
       method: "DELETE",
       path: "/{scope}/providers/Microsoft.EventGrid/eventSubscriptions/{eventSubscriptionName}",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type EventSubscriptionsDeleteInput =
@@ -3603,6 +3623,7 @@ export const EventSubscriptionsUpdateInput =
       method: "PATCH",
       path: "/{scope}/providers/Microsoft.EventGrid/eventSubscriptions/{eventSubscriptionName}",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type EventSubscriptionsUpdateInput =
@@ -3858,6 +3879,7 @@ export const NamespacesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}",
       apiVersion: "2025-02-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NamespacesCreateOrUpdateInput =
@@ -3897,6 +3919,7 @@ export const NamespacesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}",
     apiVersion: "2025-02-15",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type NamespacesDeleteInput = typeof NamespacesDeleteInput.Type;
@@ -4085,6 +4108,7 @@ export const NamespacesRegenerateKeyInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/regenerateKey",
       apiVersion: "2025-02-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NamespacesRegenerateKeyInput =
@@ -4260,6 +4284,7 @@ export const NamespacesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}",
     apiVersion: "2025-02-15",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type NamespacesUpdateInput = typeof NamespacesUpdateInput.Type;
@@ -4297,6 +4322,7 @@ export const NamespacesValidateCustomDomainOwnershipInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/validateCustomDomainOwnership",
       apiVersion: "2025-02-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NamespacesValidateCustomDomainOwnershipInput =
@@ -4552,6 +4578,7 @@ export const NamespaceTopicEventSubscriptionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}",
       apiVersion: "2025-02-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NamespaceTopicEventSubscriptionsCreateOrUpdateInput =
@@ -4595,6 +4622,7 @@ export const NamespaceTopicEventSubscriptionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}",
       apiVersion: "2025-02-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NamespaceTopicEventSubscriptionsDeleteInput =
@@ -4949,6 +4977,7 @@ export const NamespaceTopicEventSubscriptionsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}",
       apiVersion: "2025-02-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NamespaceTopicEventSubscriptionsUpdateInput =
@@ -5029,6 +5058,7 @@ export const NamespaceTopicsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/topics/{topicName}",
       apiVersion: "2025-02-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NamespaceTopicsCreateOrUpdateInput =
@@ -5070,6 +5100,7 @@ export const NamespaceTopicsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/topics/{topicName}",
       apiVersion: "2025-02-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NamespaceTopicsDeleteInput = typeof NamespaceTopicsDeleteInput.Type;
@@ -5232,6 +5263,7 @@ export const NamespaceTopicsRegenerateKeyInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/topics/{topicName}/regenerateKey",
       apiVersion: "2025-02-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NamespaceTopicsRegenerateKeyInput =
@@ -5277,6 +5309,7 @@ export const NamespaceTopicsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/topics/{topicName}",
       apiVersion: "2025-02-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NamespaceTopicsUpdateInput = typeof NamespaceTopicsUpdateInput.Type;
@@ -5452,6 +5485,7 @@ export const PartnerConfigurationsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerConfigurations/default",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type PartnerConfigurationsCreateOrUpdateInput =
@@ -5489,6 +5523,7 @@ export const PartnerConfigurationsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerConfigurations/default",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type PartnerConfigurationsDeleteInput =
@@ -5691,6 +5726,7 @@ export const PartnerConfigurationsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerConfigurations/default",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type PartnerConfigurationsUpdateInput =
@@ -5789,6 +5825,7 @@ export const PartnerNamespacesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerNamespaces/{partnerNamespaceName}",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type PartnerNamespacesCreateOrUpdateInput =
@@ -5828,6 +5865,7 @@ export const PartnerNamespacesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerNamespaces/{partnerNamespaceName}",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type PartnerNamespacesDeleteInput =
@@ -6083,6 +6121,7 @@ export const PartnerNamespacesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerNamespaces/{partnerNamespaceName}",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type PartnerNamespacesUpdateInput =
@@ -6150,6 +6189,7 @@ export const PartnerRegistrationsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerRegistrations/{partnerRegistrationName}",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type PartnerRegistrationsCreateOrUpdateInput =
@@ -6189,6 +6229,7 @@ export const PartnerRegistrationsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerRegistrations/{partnerRegistrationName}",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type PartnerRegistrationsDeleteInput =
@@ -6350,6 +6391,7 @@ export const PartnerRegistrationsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerRegistrations/{partnerRegistrationName}",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type PartnerRegistrationsUpdateInput =
@@ -6536,6 +6578,7 @@ export const PartnerTopicEventSubscriptionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerTopics/{partnerTopicName}/eventSubscriptions/{eventSubscriptionName}",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type PartnerTopicEventSubscriptionsCreateOrUpdateInput =
@@ -6577,6 +6620,7 @@ export const PartnerTopicEventSubscriptionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerTopics/{partnerTopicName}/eventSubscriptions/{eventSubscriptionName}",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type PartnerTopicEventSubscriptionsDeleteInput =
@@ -6902,6 +6946,7 @@ export const PartnerTopicEventSubscriptionsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerTopics/{partnerTopicName}/eventSubscriptions/{eventSubscriptionName}",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type PartnerTopicEventSubscriptionsUpdateInput =
@@ -7139,6 +7184,7 @@ export const PartnerTopicsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/partnerTopics/{partnerTopicName}",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type PartnerTopicsDeleteInput = typeof PartnerTopicsDeleteInput.Type;
@@ -7386,6 +7432,7 @@ export const PermissionBindingsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/permissionBindings/{permissionBindingName}",
       apiVersion: "2025-02-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PermissionBindingsCreateOrUpdateInput =
@@ -7427,6 +7474,7 @@ export const PermissionBindingsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/permissionBindings/{permissionBindingName}",
       apiVersion: "2025-02-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PermissionBindingsDeleteInput =
@@ -7558,6 +7606,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/{parentType}/{parentName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =
@@ -7740,6 +7789,7 @@ export const PrivateEndpointConnectionsUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/{parentType}/{parentName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type PrivateEndpointConnectionsUpdateInput =
@@ -8039,6 +8089,7 @@ export const SystemTopicEventSubscriptionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/systemTopics/{systemTopicName}/eventSubscriptions/{eventSubscriptionName}",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type SystemTopicEventSubscriptionsCreateOrUpdateInput =
@@ -8080,6 +8131,7 @@ export const SystemTopicEventSubscriptionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/systemTopics/{systemTopicName}/eventSubscriptions/{eventSubscriptionName}",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type SystemTopicEventSubscriptionsDeleteInput =
@@ -8405,6 +8457,7 @@ export const SystemTopicEventSubscriptionsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/systemTopics/{systemTopicName}/eventSubscriptions/{eventSubscriptionName}",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type SystemTopicEventSubscriptionsUpdateInput =
@@ -8501,6 +8554,7 @@ export const SystemTopicsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/systemTopics/{systemTopicName}",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type SystemTopicsCreateOrUpdateInput =
@@ -8541,6 +8595,7 @@ export const SystemTopicsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/systemTopics/{systemTopicName}",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type SystemTopicsDeleteInput = typeof SystemTopicsDeleteInput.Type;
@@ -8714,6 +8769,7 @@ export const SystemTopicsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/systemTopics/{systemTopicName}",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type SystemTopicsUpdateInput = typeof SystemTopicsUpdateInput.Type;
@@ -8900,6 +8956,7 @@ export const TopicEventSubscriptionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type TopicEventSubscriptionsCreateOrUpdateInput =
@@ -8941,6 +8998,7 @@ export const TopicEventSubscriptionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type TopicEventSubscriptionsDeleteInput =
@@ -9268,6 +9326,7 @@ export const TopicEventSubscriptionsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}/eventSubscriptions/{eventSubscriptionName}",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type TopicEventSubscriptionsUpdateInput =
@@ -9418,6 +9477,7 @@ export const TopicsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type TopicsCreateOrUpdateInput = typeof TopicsCreateOrUpdateInput.Type;
@@ -9455,6 +9515,7 @@ export const TopicsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}",
     apiVersion: "2025-02-15",
+    longRunning: {},
   }),
 );
 export type TopicsDeleteInput = typeof TopicsDeleteInput.Type;
@@ -9728,6 +9789,7 @@ export const TopicSpacesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/topicSpaces/{topicSpaceName}",
       apiVersion: "2025-02-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type TopicSpacesCreateOrUpdateInput =
@@ -9771,6 +9833,7 @@ export const TopicSpacesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/namespaces/{namespaceName}/topicSpaces/{topicSpaceName}",
     apiVersion: "2025-02-15",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type TopicSpacesDeleteInput = typeof TopicSpacesDeleteInput.Type;
@@ -9887,6 +9950,7 @@ export const TopicsRegenerateKeyInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}/regenerateKey",
       apiVersion: "2025-02-15",
+      longRunning: {},
     }),
   );
 export type TopicsRegenerateKeyInput = typeof TopicsRegenerateKeyInput.Type;
@@ -9983,6 +10047,7 @@ export const TopicsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventGrid/topics/{topicName}",
     apiVersion: "2025-02-15",
+    longRunning: {},
   }),
 );
 export type TopicsUpdateInput = typeof TopicsUpdateInput.Type;

--- a/packages/azure/src/services/eventhub.ts
+++ b/packages/azure/src/services/eventhub.ts
@@ -264,6 +264,7 @@ export const ClustersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/clusters/{clusterName}",
       apiVersion: "2024-01-01",
+      longRunning: {},
     }),
   );
 export type ClustersCreateOrUpdateInput =
@@ -304,6 +305,7 @@ export const ClustersDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/clusters/{clusterName}",
     apiVersion: "2024-01-01",
+    longRunning: {},
   }),
 );
 export type ClustersDeleteInput = typeof ClustersDeleteInput.Type;
@@ -588,6 +590,7 @@ export const ClustersUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/clusters/{clusterName}",
     apiVersion: "2024-01-01",
+    longRunning: {},
   }),
 );
 export type ClustersUpdateInput = typeof ClustersUpdateInput.Type;
@@ -2072,6 +2075,7 @@ export const NamespacesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}",
       apiVersion: "2024-01-01",
+      longRunning: {},
     }),
   );
 export type NamespacesCreateOrUpdateInput =
@@ -2266,6 +2270,7 @@ export const NamespacesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}",
     apiVersion: "2024-01-01",
+    longRunning: {},
   }),
 );
 export type NamespacesDeleteInput = typeof NamespacesDeleteInput.Type;
@@ -2911,6 +2916,7 @@ export const NetworkSecurityPerimeterConfigurationsCreateOrUpdateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/networkSecurityPerimeterConfigurations/{resourceAssociationName}/reconcile",
       apiVersion: "2024-01-01",
+      longRunning: {},
     }),
   );
 export type NetworkSecurityPerimeterConfigurationsCreateOrUpdateInput =
@@ -3133,6 +3139,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2024-01-01",
+      longRunning: {},
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =

--- a/packages/azure/src/services/extendedlocation.ts
+++ b/packages/azure/src/services/extendedlocation.ts
@@ -57,6 +57,7 @@ export const CustomLocationsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ExtendedLocation/customLocations/{resourceName}",
       apiVersion: "2021-08-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CustomLocationsCreateOrUpdateInput =
@@ -97,6 +98,7 @@ export const CustomLocationsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ExtendedLocation/customLocations/{resourceName}",
       apiVersion: "2021-08-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CustomLocationsDeleteInput = typeof CustomLocationsDeleteInput.Type;

--- a/packages/azure/src/services/fabric.ts
+++ b/packages/azure/src/services/fabric.ts
@@ -98,6 +98,7 @@ export const FabricCapacitiesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Fabric/capacities/{capacityName}",
       apiVersion: "2023-11-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type FabricCapacitiesCreateOrUpdateInput =
@@ -152,6 +153,7 @@ export const FabricCapacitiesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Fabric/capacities/{capacityName}",
       apiVersion: "2023-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type FabricCapacitiesDeleteInput =
@@ -461,6 +463,7 @@ export const FabricCapacitiesResumeInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Fabric/capacities/{capacityName}/resume",
       apiVersion: "2023-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type FabricCapacitiesResumeInput =
@@ -498,6 +501,7 @@ export const FabricCapacitiesSuspendInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Fabric/capacities/{capacityName}/suspend",
       apiVersion: "2023-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type FabricCapacitiesSuspendInput =
@@ -551,6 +555,7 @@ export const FabricCapacitiesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Fabric/capacities/{capacityName}",
       apiVersion: "2023-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type FabricCapacitiesUpdateInput =

--- a/packages/azure/src/services/fist.ts
+++ b/packages/azure/src/services/fist.ts
@@ -1150,6 +1150,7 @@ export const WorkspacesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.IoTFirmwareDefense/workspaces/{workspaceName}",
     apiVersion: "2025-08-02",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type WorkspacesDeleteInput = typeof WorkspacesDeleteInput.Type;

--- a/packages/azure/src/services/frontdoor.ts
+++ b/packages/azure/src/services/frontdoor.ts
@@ -20,6 +20,7 @@ export const EndpointsPurgeContentInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/frontDoors/{frontDoorName}/purge",
       apiVersion: "2025-11-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type EndpointsPurgeContentInput = typeof EndpointsPurgeContentInput.Type;
@@ -92,6 +93,7 @@ export const ExperimentsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/NetworkExperimentProfiles/{profileName}/Experiments/{experimentName}",
       apiVersion: "2025-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ExperimentsCreateOrUpdateInput =
@@ -138,6 +140,7 @@ export const ExperimentsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/NetworkExperimentProfiles/{profileName}/Experiments/{experimentName}",
     apiVersion: "2025-11-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ExperimentsDeleteInput = typeof ExperimentsDeleteInput.Type;
@@ -267,6 +270,7 @@ export const ExperimentsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/NetworkExperimentProfiles/{profileName}/Experiments/{experimentName}",
     apiVersion: "2025-11-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ExperimentsUpdateInput = typeof ExperimentsUpdateInput.Type;
@@ -449,6 +453,7 @@ export const FrontDoorsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/frontDoors/{frontDoorName}",
       apiVersion: "2025-11-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type FrontDoorsCreateOrUpdateInput =
@@ -491,6 +496,7 @@ export const FrontDoorsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/frontDoors/{frontDoorName}",
     apiVersion: "2025-11-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type FrontDoorsDeleteInput = typeof FrontDoorsDeleteInput.Type;
@@ -685,6 +691,7 @@ export const FrontendEndpointsDisableHttpsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/frontDoors/{frontDoorName}/frontendEndpoints/{frontendEndpointName}/disableHttps",
       apiVersion: "2025-11-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type FrontendEndpointsDisableHttpsInput =
@@ -742,6 +749,7 @@ export const FrontendEndpointsEnableHttpsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/frontDoors/{frontDoorName}/frontendEndpoints/{frontendEndpointName}/enableHttps",
       apiVersion: "2025-11-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type FrontendEndpointsEnableHttpsInput =
@@ -926,6 +934,7 @@ export const NetworkExperimentProfilesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/NetworkExperimentProfiles/{profileName}",
       apiVersion: "2025-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkExperimentProfilesCreateOrUpdateInput =
@@ -968,6 +977,7 @@ export const NetworkExperimentProfilesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/NetworkExperimentProfiles/{profileName}",
       apiVersion: "2025-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkExperimentProfilesDeleteInput =
@@ -1140,6 +1150,7 @@ export const NetworkExperimentProfilesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/NetworkExperimentProfiles/{profileName}",
       apiVersion: "2025-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkExperimentProfilesUpdateInput =
@@ -1528,6 +1539,7 @@ export const PoliciesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/FrontDoorWebApplicationFirewallPolicies/{policyName}",
       apiVersion: "2025-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PoliciesCreateOrUpdateInput =
@@ -1570,6 +1582,7 @@ export const PoliciesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/FrontDoorWebApplicationFirewallPolicies/{policyName}",
     apiVersion: "2025-11-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type PoliciesDeleteInput = typeof PoliciesDeleteInput.Type;
@@ -1723,6 +1736,7 @@ export const PoliciesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/FrontDoorWebApplicationFirewallPolicies/{policyName}",
     apiVersion: "2025-11-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type PoliciesUpdateInput = typeof PoliciesUpdateInput.Type;
@@ -2020,6 +2034,7 @@ export const RulesEnginesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/frontDoors/{frontDoorName}/rulesEngines/{rulesEngineName}",
       apiVersion: "2025-11-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type RulesEnginesCreateOrUpdateInput =
@@ -2063,6 +2078,7 @@ export const RulesEnginesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/frontDoors/{frontDoorName}/rulesEngines/{rulesEngineName}",
       apiVersion: "2025-11-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type RulesEnginesDeleteInput = typeof RulesEnginesDeleteInput.Type;

--- a/packages/azure/src/services/graphservicesprod.ts
+++ b/packages/azure/src/services/graphservicesprod.ts
@@ -42,6 +42,7 @@ export const AccountsCreateAndUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.GraphServices/accounts/{resourceName}",
       apiVersion: "2023-04-13",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AccountsCreateAndUpdateInput =

--- a/packages/azure/src/services/hardwaresecuritymodules.ts
+++ b/packages/azure/src/services/hardwaresecuritymodules.ts
@@ -188,6 +188,7 @@ export const CloudHsmClusterPrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HardwareSecurityModules/cloudHsmClusters/{cloudHsmClusterName}/privateEndpointConnections/{peConnectionName}",
       apiVersion: "2025-03-31",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CloudHsmClusterPrivateEndpointConnectionsDeleteInput =
@@ -438,6 +439,7 @@ export const CloudHsmClustersBackupInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HardwareSecurityModules/cloudHsmClusters/{cloudHsmClusterName}/backup",
       apiVersion: "2025-03-31",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CloudHsmClustersBackupInput =
@@ -625,6 +627,7 @@ export const CloudHsmClustersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HardwareSecurityModules/cloudHsmClusters/{cloudHsmClusterName}",
       apiVersion: "2025-03-31",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type CloudHsmClustersCreateOrUpdateInput =
@@ -679,6 +682,7 @@ export const CloudHsmClustersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HardwareSecurityModules/cloudHsmClusters/{cloudHsmClusterName}",
       apiVersion: "2025-03-31",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CloudHsmClustersDeleteInput =
@@ -906,6 +910,7 @@ export const CloudHsmClustersRestoreInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HardwareSecurityModules/cloudHsmClusters/{cloudHsmClusterName}/restore",
       apiVersion: "2025-03-31",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CloudHsmClustersRestoreInput =
@@ -1010,6 +1015,7 @@ export const CloudHsmClustersUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HardwareSecurityModules/cloudHsmClusters/{cloudHsmClusterName}",
       apiVersion: "2025-03-31",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CloudHsmClustersUpdateInput =
@@ -1067,6 +1073,7 @@ export const CloudHsmClustersValidateBackupPropertiesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HardwareSecurityModules/cloudHsmClusters/{cloudHsmClusterName}/validateBackupProperties",
       apiVersion: "2025-03-31",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CloudHsmClustersValidateBackupPropertiesInput =
@@ -1151,6 +1158,7 @@ export const CloudHsmClustersValidateRestorePropertiesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HardwareSecurityModules/cloudHsmClusters/{cloudHsmClusterName}/validateRestoreProperties",
       apiVersion: "2025-03-31",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CloudHsmClustersValidateRestorePropertiesInput =
@@ -1297,6 +1305,7 @@ export const DedicatedHsmCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HardwareSecurityModules/dedicatedHSMs/{name}",
       apiVersion: "2025-03-31",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DedicatedHsmCreateOrUpdateInput =
@@ -1352,6 +1361,7 @@ export const DedicatedHsmDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HardwareSecurityModules/dedicatedHSMs/{name}",
       apiVersion: "2025-03-31",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DedicatedHsmDeleteInput = typeof DedicatedHsmDeleteInput.Type;
@@ -1630,6 +1640,7 @@ export const DedicatedHsmUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HardwareSecurityModules/dedicatedHSMs/{name}",
       apiVersion: "2025-03-31",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DedicatedHsmUpdateInput = typeof DedicatedHsmUpdateInput.Type;

--- a/packages/azure/src/services/hdinsight.ts
+++ b/packages/azure/src/services/hdinsight.ts
@@ -258,6 +258,7 @@ export const ApplicationsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HDInsight/clusters/{clusterName}/applications/{applicationName}",
       apiVersion: "2021-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ApplicationsCreateInput = typeof ApplicationsCreateInput.Type;
@@ -286,6 +287,7 @@ export const ApplicationsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HDInsight/clusters/{clusterName}/applications/{applicationName}",
       apiVersion: "2021-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ApplicationsDeleteInput = typeof ApplicationsDeleteInput.Type;
@@ -699,6 +701,7 @@ export const ClustersCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HDInsight/clusters/{clusterName}",
     apiVersion: "2021-06-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ClustersCreateInput = typeof ClustersCreateInput.Type;
@@ -727,6 +730,7 @@ export const ClustersDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HDInsight/clusters/{clusterName}",
     apiVersion: "2021-06-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ClustersDeleteInput = typeof ClustersDeleteInput.Type;
@@ -763,6 +767,7 @@ export const ClustersExecuteScriptActionsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HDInsight/clusters/{clusterName}/executeScriptActions",
       apiVersion: "2021-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ClustersExecuteScriptActionsInput =
@@ -965,6 +970,7 @@ export const ClustersResizeInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HDInsight/clusters/{clusterName}/roles/{roleName}/resize",
     apiVersion: "2021-06-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ClustersResizeInput = typeof ClustersResizeInput.Type;
@@ -994,6 +1000,7 @@ export const ClustersRotateDiskEncryptionKeyInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HDInsight/clusters/{clusterName}/rotatediskencryptionkey",
       apiVersion: "2021-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ClustersRotateDiskEncryptionKeyInput =
@@ -1094,6 +1101,7 @@ export const ClustersUpdateAutoScaleConfigurationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HDInsight/clusters/{clusterName}/roles/{roleName}/autoscale",
       apiVersion: "2021-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ClustersUpdateAutoScaleConfigurationInput =
@@ -1127,6 +1135,7 @@ export const ClustersUpdateGatewaySettingsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HDInsight/clusters/{clusterName}/updateGatewaySettings",
       apiVersion: "2021-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ClustersUpdateGatewaySettingsInput =
@@ -1158,6 +1167,7 @@ export const ClustersUpdateIdentityCertificateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HDInsight/clusters/{clusterName}/updateClusterIdentityCertificate",
       apiVersion: "2021-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ClustersUpdateIdentityCertificateInput =
@@ -1240,6 +1250,7 @@ export const ExtensionsCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HDInsight/clusters/{clusterName}/extensions/{extensionName}",
     apiVersion: "2021-06-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ExtensionsCreateInput = typeof ExtensionsCreateInput.Type;
@@ -1264,6 +1275,7 @@ export const ExtensionsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HDInsight/clusters/{clusterName}/extensions/{extensionName}",
     apiVersion: "2021-06-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ExtensionsDeleteInput = typeof ExtensionsDeleteInput.Type;
@@ -1287,6 +1299,7 @@ export const ExtensionsDisableAzureMonitorInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HDInsight/clusters/{clusterName}/extensions/azureMonitor",
       apiVersion: "2021-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ExtensionsDisableAzureMonitorInput =
@@ -1314,6 +1327,7 @@ export const ExtensionsDisableMonitoringInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HDInsight/clusters/{clusterName}/extensions/clustermonitoring",
       apiVersion: "2021-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ExtensionsDisableMonitoringInput =
@@ -1360,6 +1374,7 @@ export const ExtensionsEnableAzureMonitorInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HDInsight/clusters/{clusterName}/extensions/azureMonitor",
       apiVersion: "2021-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ExtensionsEnableAzureMonitorInput =
@@ -1390,6 +1405,7 @@ export const ExtensionsEnableMonitoringInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HDInsight/clusters/{clusterName}/extensions/clustermonitoring",
       apiVersion: "2021-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ExtensionsEnableMonitoringInput =
@@ -2318,6 +2334,7 @@ export const PrivateEndpointConnectionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HDInsight/clusters/{clusterName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2021-06-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PrivateEndpointConnectionsCreateOrUpdateInput =
@@ -2349,6 +2366,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HDInsight/clusters/{clusterName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2021-06-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =
@@ -2787,6 +2805,7 @@ export const VirtualMachinesRestartHostsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HDInsight/clusters/{clusterName}/restartHosts",
       apiVersion: "2021-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesRestartHostsInput =

--- a/packages/azure/src/services/healthbot.ts
+++ b/packages/azure/src/services/healthbot.ts
@@ -61,6 +61,7 @@ export const BotsCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HealthBot/healthBots/{botName}",
     apiVersion: "2025-11-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type BotsCreateInput = typeof BotsCreateInput.Type;
@@ -110,6 +111,7 @@ export const BotsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HealthBot/healthBots/{botName}",
     apiVersion: "2025-11-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type BotsDeleteInput = typeof BotsDeleteInput.Type;
@@ -433,6 +435,7 @@ export const BotsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HealthBot/healthBots/{botName}",
     apiVersion: "2025-11-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type BotsUpdateInput = typeof BotsUpdateInput.Type;

--- a/packages/azure/src/services/healthcareapis.ts
+++ b/packages/azure/src/services/healthcareapis.ts
@@ -120,6 +120,7 @@ export const DicomServicesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HealthcareApis/workspaces/{workspaceName}/dicomservices/{dicomServiceName}",
       apiVersion: "2024-03-31",
+      longRunning: {},
     }),
   );
 export type DicomServicesCreateOrUpdateInput =
@@ -175,6 +176,7 @@ export const DicomServicesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HealthcareApis/workspaces/{workspaceName}/dicomservices/{dicomServiceName}",
       apiVersion: "2024-03-31",
+      longRunning: {},
     }),
   );
 export type DicomServicesDeleteInput = typeof DicomServicesDeleteInput.Type;
@@ -338,6 +340,7 @@ export const DicomServicesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HealthcareApis/workspaces/{workspaceName}/dicomservices/{dicomServiceName}",
       apiVersion: "2024-03-31",
+      longRunning: {},
     }),
   );
 export type DicomServicesUpdateInput = typeof DicomServicesUpdateInput.Type;
@@ -596,6 +599,7 @@ export const FhirServicesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HealthcareApis/workspaces/{workspaceName}/fhirservices/{fhirServiceName}",
       apiVersion: "2024-03-31",
+      longRunning: {},
     }),
   );
 export type FhirServicesCreateOrUpdateInput =
@@ -651,6 +655,7 @@ export const FhirServicesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HealthcareApis/workspaces/{workspaceName}/fhirservices/{fhirServiceName}",
       apiVersion: "2024-03-31",
+      longRunning: {},
     }),
   );
 export type FhirServicesDeleteInput = typeof FhirServicesDeleteInput.Type;
@@ -812,6 +817,7 @@ export const FhirServicesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HealthcareApis/workspaces/{workspaceName}/fhirservices/{fhirServiceName}",
       apiVersion: "2024-03-31",
+      longRunning: {},
     }),
   );
 export type FhirServicesUpdateInput = typeof FhirServicesUpdateInput.Type;
@@ -897,6 +903,7 @@ export const IotConnectorFhirDestinationCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HealthcareApis/workspaces/{workspaceName}/iotconnectors/{iotConnectorName}/fhirdestinations/{fhirDestinationName}",
       apiVersion: "2024-03-31",
+      longRunning: {},
     }),
   );
 export type IotConnectorFhirDestinationCreateOrUpdateInput =
@@ -934,6 +941,7 @@ export const IotConnectorFhirDestinationDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HealthcareApis/workspaces/{workspaceName}/iotconnectors/{iotConnectorName}/fhirdestinations/{fhirDestinationName}",
       apiVersion: "2024-03-31",
+      longRunning: {},
     }),
   );
 export type IotConnectorFhirDestinationDeleteInput =
@@ -1071,6 +1079,7 @@ export const IotConnectorsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HealthcareApis/workspaces/{workspaceName}/iotconnectors/{iotConnectorName}",
       apiVersion: "2024-03-31",
+      longRunning: {},
     }),
   );
 export type IotConnectorsCreateOrUpdateInput =
@@ -1126,6 +1135,7 @@ export const IotConnectorsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HealthcareApis/workspaces/{workspaceName}/iotconnectors/{iotConnectorName}",
       apiVersion: "2024-03-31",
+      longRunning: {},
     }),
   );
 export type IotConnectorsDeleteInput = typeof IotConnectorsDeleteInput.Type;
@@ -1289,6 +1299,7 @@ export const IotConnectorsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HealthcareApis/workspaces/{workspaceName}/iotconnectors/{iotConnectorName}",
       apiVersion: "2024-03-31",
+      longRunning: {},
     }),
   );
 export type IotConnectorsUpdateInput = typeof IotConnectorsUpdateInput.Type;
@@ -1508,6 +1519,7 @@ export const PrivateEndpointConnectionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HealthcareApis/services/{resourceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2024-03-31",
+      longRunning: {},
     }),
   );
 export type PrivateEndpointConnectionsCreateOrUpdateInput =
@@ -1547,6 +1559,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HealthcareApis/services/{resourceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2024-03-31",
+      longRunning: {},
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =
@@ -1896,6 +1909,7 @@ export const ServicesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HealthcareApis/services/{resourceName}",
       apiVersion: "2024-03-31",
+      longRunning: {},
     }),
   );
 export type ServicesCreateOrUpdateInput =
@@ -1943,6 +1957,7 @@ export const ServicesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HealthcareApis/services/{resourceName}",
     apiVersion: "2024-03-31",
+    longRunning: {},
   }),
 );
 export type ServicesDeleteInput = typeof ServicesDeleteInput.Type;
@@ -2126,6 +2141,7 @@ export const ServicesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HealthcareApis/services/{resourceName}",
     apiVersion: "2024-03-31",
+    longRunning: {},
   }),
 );
 export type ServicesUpdateInput = typeof ServicesUpdateInput.Type;
@@ -2203,6 +2219,7 @@ export const WorkspacePrivateEndpointConnectionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HealthcareApis/workspaces/{workspaceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2024-03-31",
+      longRunning: {},
     }),
   );
 export type WorkspacePrivateEndpointConnectionsCreateOrUpdateInput =
@@ -2241,6 +2258,7 @@ export const WorkspacePrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HealthcareApis/workspaces/{workspaceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2024-03-31",
+      longRunning: {},
     }),
   );
 export type WorkspacePrivateEndpointConnectionsDeleteInput =
@@ -2481,6 +2499,7 @@ export const WorkspacesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HealthcareApis/workspaces/{workspaceName}",
       apiVersion: "2024-03-31",
+      longRunning: {},
     }),
   );
 export type WorkspacesCreateOrUpdateInput =
@@ -2516,6 +2535,7 @@ export const WorkspacesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HealthcareApis/workspaces/{workspaceName}",
     apiVersion: "2024-03-31",
+    longRunning: {},
   }),
 );
 export type WorkspacesDeleteInput = typeof WorkspacesDeleteInput.Type;
@@ -2658,6 +2678,7 @@ export const WorkspacesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HealthcareApis/workspaces/{workspaceName}",
     apiVersion: "2024-03-31",
+    longRunning: {},
   }),
 );
 export type WorkspacesUpdateInput = typeof WorkspacesUpdateInput.Type;

--- a/packages/azure/src/services/healthdataaiservices.ts
+++ b/packages/azure/src/services/healthdataaiservices.ts
@@ -94,6 +94,7 @@ export const DeidServicesCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HealthDataAIServices/deidServices/{deidServiceName}",
       apiVersion: "2024-09-20",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DeidServicesCreateInput = typeof DeidServicesCreateInput.Type;
@@ -145,6 +146,7 @@ export const DeidServicesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HealthDataAIServices/deidServices/{deidServiceName}",
       apiVersion: "2024-09-20",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeidServicesDeleteInput = typeof DeidServicesDeleteInput.Type;
@@ -387,6 +389,7 @@ export const DeidServicesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HealthDataAIServices/deidServices/{deidServiceName}",
       apiVersion: "2024-09-20",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeidServicesUpdateInput = typeof DeidServicesUpdateInput.Type;
@@ -507,6 +510,7 @@ export const PrivateEndpointConnectionsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HealthDataAIServices/deidServices/{deidServiceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2024-09-20",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PrivateEndpointConnectionsCreateInput =
@@ -563,6 +567,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HealthDataAIServices/deidServices/{deidServiceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2024-09-20",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =

--- a/packages/azure/src/services/help.ts
+++ b/packages/azure/src/services/help.ts
@@ -115,6 +115,7 @@ export const DiagnosticsCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "PUT",
     path: "/{scope}/providers/Microsoft.Help/diagnostics/{diagnosticsResourceName}",
     apiVersion: "2023-06-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type DiagnosticsCreateInput = typeof DiagnosticsCreateInput.Type;

--- a/packages/azure/src/services/hybridaks.ts
+++ b/packages/azure/src/services/hybridaks.ts
@@ -82,6 +82,7 @@ export const AgentPoolCreateOrUpdateInput =
       method: "PUT",
       path: "/{connectedClusterResourceUri}/providers/Microsoft.HybridContainerService/provisionedClusterInstances/default/agentPools/{agentPoolName}",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AgentPoolCreateOrUpdateInput =
@@ -131,6 +132,7 @@ export const AgentPoolDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/{connectedClusterResourceUri}/providers/Microsoft.HybridContainerService/provisionedClusterInstances/default/agentPools/{agentPoolName}",
     apiVersion: "2024-01-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type AgentPoolDeleteInput = typeof AgentPoolDeleteInput.Type;
@@ -264,6 +266,7 @@ export const DeleteKubernetesVersionsInput =
       method: "DELETE",
       path: "/{customLocationResourceUri}/providers/Microsoft.HybridContainerService/kubernetesVersions/default",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DeleteKubernetesVersionsInput =
@@ -297,6 +300,7 @@ export const DeleteVMSkusInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/{customLocationResourceUri}/providers/Microsoft.HybridContainerService/skus/default",
     apiVersion: "2024-01-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type DeleteVMSkusInput = typeof DeleteVMSkusInput.Type;
@@ -417,6 +421,7 @@ export const HybridIdentityMetadataDeleteInput =
       method: "DELETE",
       path: "/{connectedClusterResourceUri}/providers/Microsoft.HybridContainerService/provisionedClusterInstances/default/hybridIdentityMetadata/default",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type HybridIdentityMetadataDeleteInput =
@@ -945,6 +950,7 @@ export const ProvisionedClusterInstancesCreateOrUpdateInput =
       method: "PUT",
       path: "/{connectedClusterResourceUri}/providers/Microsoft.HybridContainerService/provisionedClusterInstances/default",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ProvisionedClusterInstancesCreateOrUpdateInput =
@@ -992,6 +998,7 @@ export const ProvisionedClusterInstancesDeleteInput =
       method: "DELETE",
       path: "/{connectedClusterResourceUri}/providers/Microsoft.HybridContainerService/provisionedClusterInstances/default",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ProvisionedClusterInstancesDeleteInput =
@@ -1179,6 +1186,7 @@ export const ProvisionedClusterInstancesListAdminKubeconfigInput =
       method: "POST",
       path: "/{connectedClusterResourceUri}/providers/Microsoft.HybridContainerService/provisionedClusterInstances/default/listAdminKubeconfig",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ProvisionedClusterInstancesListAdminKubeconfigInput =
@@ -1243,6 +1251,7 @@ export const ProvisionedClusterInstancesListUserKubeconfigInput =
       method: "POST",
       path: "/{connectedClusterResourceUri}/providers/Microsoft.HybridContainerService/provisionedClusterInstances/default/listUserKubeconfig",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ProvisionedClusterInstancesListUserKubeconfigInput =
@@ -1365,6 +1374,7 @@ export const PutKubernetesVersionsInput =
       method: "PUT",
       path: "/{customLocationResourceUri}/providers/Microsoft.HybridContainerService/kubernetesVersions/default",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PutKubernetesVersionsInput = typeof PutKubernetesVersionsInput.Type;
@@ -1453,6 +1463,7 @@ export const PutVMSkusInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/{customLocationResourceUri}/providers/Microsoft.HybridContainerService/skus/default",
     apiVersion: "2024-01-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type PutVMSkusInput = typeof PutVMSkusInput.Type;
@@ -1570,6 +1581,7 @@ export const VirtualNetworksCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridContainerService/virtualNetworks/{virtualNetworkName}",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualNetworksCreateOrUpdateInput =
@@ -1622,6 +1634,7 @@ export const VirtualNetworksDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridContainerService/virtualNetworks/{virtualNetworkName}",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualNetworksDeleteInput = typeof VirtualNetworksDeleteInput.Type;
@@ -1846,6 +1859,7 @@ export const VirtualNetworksUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridContainerService/virtualNetworks/{virtualNetworkName}",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualNetworksUpdateInput = typeof VirtualNetworksUpdateInput.Type;

--- a/packages/azure/src/services/hybridcompute.ts
+++ b/packages/azure/src/services/hybridcompute.ts
@@ -457,6 +457,7 @@ export const GatewaysCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridCompute/gateways/{gatewayName}",
       apiVersion: "2025-01-13",
+      longRunning: {},
     }),
   );
 export type GatewaysCreateOrUpdateInput =
@@ -509,6 +510,7 @@ export const GatewaysDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridCompute/gateways/{gatewayName}",
     apiVersion: "2025-01-13",
+    longRunning: {},
   }),
 );
 export type GatewaysDeleteInput = typeof GatewaysDeleteInput.Type;
@@ -1049,6 +1051,7 @@ export const LicenseProfilesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridCompute/machines/{machineName}/licenseProfiles/{licenseProfileName}",
       apiVersion: "2025-01-13",
+      longRunning: {},
     }),
   );
 export type LicenseProfilesCreateOrUpdateInput =
@@ -1101,6 +1104,7 @@ export const LicenseProfilesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridCompute/machines/{machineName}/licenseProfiles/{licenseProfileName}",
       apiVersion: "2025-01-13",
+      longRunning: {},
     }),
   );
 export type LicenseProfilesDeleteInput = typeof LicenseProfilesDeleteInput.Type;
@@ -1285,6 +1289,7 @@ export const LicenseProfilesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridCompute/machines/{machineName}/licenseProfiles/{licenseProfileName}",
       apiVersion: "2025-01-13",
+      longRunning: {},
     }),
   );
 export type LicenseProfilesUpdateInput = typeof LicenseProfilesUpdateInput.Type;
@@ -1387,6 +1392,7 @@ export const LicensesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridCompute/licenses/{licenseName}",
       apiVersion: "2025-01-13",
+      longRunning: {},
     }),
   );
 export type LicensesCreateOrUpdateInput =
@@ -1439,6 +1445,7 @@ export const LicensesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridCompute/licenses/{licenseName}",
     apiVersion: "2025-01-13",
+    longRunning: {},
   }),
 );
 export type LicensesDeleteInput = typeof LicensesDeleteInput.Type;
@@ -1666,6 +1673,7 @@ export const LicensesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridCompute/licenses/{licenseName}",
     apiVersion: "2025-01-13",
+    longRunning: {},
   }),
 );
 export type LicensesUpdateInput = typeof LicensesUpdateInput.Type;
@@ -1763,6 +1771,7 @@ export const LicensesValidateLicenseInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.HybridCompute/validateLicense",
       apiVersion: "2025-01-13",
+      longRunning: {},
     }),
   );
 export type LicensesValidateLicenseInput =
@@ -1852,6 +1861,7 @@ export const MachineExtensionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridCompute/machines/{machineName}/extensions/{extensionName}",
       apiVersion: "2025-01-13",
+      longRunning: {},
     }),
   );
 export type MachineExtensionsCreateOrUpdateInput =
@@ -1908,6 +1918,7 @@ export const MachineExtensionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridCompute/machines/{machineName}/extensions/{extensionName}",
       apiVersion: "2025-01-13",
+      longRunning: {},
     }),
   );
 export type MachineExtensionsDeleteInput =
@@ -2090,6 +2101,7 @@ export const MachineExtensionsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridCompute/machines/{machineName}/extensions/{extensionName}",
       apiVersion: "2025-01-13",
+      longRunning: {},
     }),
   );
 export type MachineExtensionsUpdateInput =
@@ -2233,6 +2245,7 @@ export const MachineRunCommandsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridCompute/machines/{machineName}/runCommands/{runCommandName}",
       apiVersion: "2025-01-13",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type MachineRunCommandsCreateOrUpdateInput =
@@ -2285,6 +2298,7 @@ export const MachineRunCommandsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridCompute/machines/{machineName}/runCommands/{runCommandName}",
       apiVersion: "2025-01-13",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type MachineRunCommandsDeleteInput =
@@ -2445,6 +2459,7 @@ export const MachineRunCommandsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridCompute/machines/{machineName}/runCommands/{runCommandName}",
       apiVersion: "2025-01-13",
+      longRunning: {},
     }),
   );
 export type MachineRunCommandsUpdateInput =
@@ -2499,6 +2514,7 @@ export const MachinesAssessPatchesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridCompute/machines/{name}/assessPatches",
       apiVersion: "2025-01-13",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type MachinesAssessPatchesInput = typeof MachinesAssessPatchesInput.Type;
@@ -3207,6 +3223,7 @@ export const MachinesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridCompute/machines/{machineName}",
     apiVersion: "2025-01-13",
+    longRunning: {},
   }),
 );
 export type MachinesDeleteInput = typeof MachinesDeleteInput.Type;
@@ -3323,6 +3340,7 @@ export const MachinesInstallPatchesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridCompute/machines/{name}/installPatches",
       apiVersion: "2025-01-13",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type MachinesInstallPatchesInput =
@@ -4329,6 +4347,7 @@ export const NetworkSecurityPerimeterConfigurationsReconcileForPrivateLinkScopeI
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridCompute/privateLinkScopes/{scopeName}/networkSecurityPerimeterConfigurations/{perimeterName}/reconcile",
       apiVersion: "2025-01-13",
+      longRunning: {},
     }),
   );
 export type NetworkSecurityPerimeterConfigurationsReconcileForPrivateLinkScopeInput =
@@ -4444,6 +4463,7 @@ export const PrivateEndpointConnectionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridCompute/privateLinkScopes/{scopeName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-01-13",
+      longRunning: {},
     }),
   );
 export type PrivateEndpointConnectionsCreateOrUpdateInput =
@@ -4498,6 +4518,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridCompute/privateLinkScopes/{scopeName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-01-13",
+      longRunning: {},
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =
@@ -4873,6 +4894,7 @@ export const PrivateLinkScopesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridCompute/privateLinkScopes/{scopeName}",
       apiVersion: "2025-01-13",
+      longRunning: {},
     }),
   );
 export type PrivateLinkScopesDeleteInput =
@@ -5371,6 +5393,7 @@ export const SetupExtensionsInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridCompute/machines/{machineName}/addExtensions",
     apiVersion: "2025-01-13",
+    longRunning: {},
   }),
 );
 export type SetupExtensionsInput = typeof SetupExtensionsInput.Type;
@@ -5448,6 +5471,7 @@ export const UpgradeExtensionsInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridCompute/machines/{machineName}/upgradeExtensions",
     apiVersion: "2025-01-13",
+    longRunning: {},
   }),
 );
 export type UpgradeExtensionsInput = typeof UpgradeExtensionsInput.Type;

--- a/packages/azure/src/services/hybridconnectivity.ts
+++ b/packages/azure/src/services/hybridconnectivity.ts
@@ -610,6 +610,7 @@ export const PublicCloudConnectorsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridConnectivity/publicCloudConnectors/{publicCloudConnector}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PublicCloudConnectorsCreateOrUpdateInput =
@@ -888,6 +889,7 @@ export const PublicCloudConnectorsTestPermissionsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridConnectivity/publicCloudConnectors/{publicCloudConnector}/testPermissions",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PublicCloudConnectorsTestPermissionsInput =
@@ -1534,6 +1536,7 @@ export const SolutionConfigurationsSyncNowInput =
       method: "POST",
       path: "/{resourceUri}/providers/Microsoft.HybridConnectivity/solutionConfigurations/{solutionConfiguration}/syncNow",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SolutionConfigurationsSyncNowInput =

--- a/packages/azure/src/services/hybridkubernetes.ts
+++ b/packages/azure/src/services/hybridkubernetes.ts
@@ -92,6 +92,7 @@ export const ConnectedClusterCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Kubernetes/connectedClusters/{clusterName}",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ConnectedClusterCreateInput =
@@ -133,6 +134,7 @@ export const ConnectedClusterDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Kubernetes/connectedClusters/{clusterName}",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ConnectedClusterDeleteInput =

--- a/packages/azure/src/services/hybridnetwork.ts
+++ b/packages/azure/src/services/hybridnetwork.ts
@@ -66,6 +66,7 @@ export const ArtifactManifestsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridNetwork/publishers/{publisherName}/artifactStores/{artifactStoreName}/artifactManifests/{artifactManifestName}",
       apiVersion: "2024-04-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ArtifactManifestsCreateOrUpdateInput =
@@ -124,6 +125,7 @@ export const ArtifactManifestsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridNetwork/publishers/{publisherName}/artifactStores/{artifactStoreName}/artifactManifests/{artifactManifestName}",
       apiVersion: "2024-04-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ArtifactManifestsDeleteInput =
@@ -412,6 +414,7 @@ export const ArtifactManifestsUpdateStateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridNetwork/publishers/{publisherName}/artifactStores/{artifactStoreName}/artifactManifests/{artifactManifestName}/updateState",
       apiVersion: "2024-04-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ArtifactManifestsUpdateStateInput =
@@ -469,6 +472,7 @@ export const ArtifactStoresAddNetworkFabricControllerEndPointsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridNetwork/publishers/{publisherName}/artifactStores/{artifactStoreName}/addNetworkFabricControllerEndPoints",
       apiVersion: "2024-04-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ArtifactStoresAddNetworkFabricControllerEndPointsInput =
@@ -514,6 +518,7 @@ export const ArtifactStoresApprovePrivateEndPointsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridNetwork/publishers/{publisherName}/artifactStores/{artifactStoreName}/approvePrivateEndPoints",
       apiVersion: "2024-04-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ArtifactStoresApprovePrivateEndPointsInput =
@@ -590,6 +595,7 @@ export const ArtifactStoresCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridNetwork/publishers/{publisherName}/artifactStores/{artifactStoreName}",
       apiVersion: "2024-04-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ArtifactStoresCreateOrUpdateInput =
@@ -646,6 +652,7 @@ export const ArtifactStoresDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridNetwork/publishers/{publisherName}/artifactStores/{artifactStoreName}",
       apiVersion: "2024-04-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ArtifactStoresDeleteInput = typeof ArtifactStoresDeleteInput.Type;
@@ -690,6 +697,7 @@ export const ArtifactStoresDeleteNetworkFabricControllerEndPointsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridNetwork/publishers/{publisherName}/artifactStores/{artifactStoreName}/deleteNetworkFabricControllerEndPoints",
       apiVersion: "2024-04-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ArtifactStoresDeleteNetworkFabricControllerEndPointsInput =
@@ -853,6 +861,7 @@ export const ArtifactStoresListNetworkFabricControllerPrivateEndPointsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridNetwork/publishers/{publisherName}/artifactStores/{artifactStoreName}/listNetworkFabricControllerPrivateEndPoints",
       apiVersion: "2024-04-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ArtifactStoresListNetworkFabricControllerPrivateEndPointsInput =
@@ -907,6 +916,7 @@ export const ArtifactStoresListPrivateEndPointsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridNetwork/publishers/{publisherName}/artifactStores/{artifactStoreName}/listPrivateEndPoints",
       apiVersion: "2024-04-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ArtifactStoresListPrivateEndPointsInput =
@@ -967,6 +977,7 @@ export const ArtifactStoresRemovePrivateEndPointsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridNetwork/publishers/{publisherName}/artifactStores/{artifactStoreName}/removePrivateEndPoints",
       apiVersion: "2024-04-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ArtifactStoresRemovePrivateEndPointsInput =
@@ -1207,6 +1218,7 @@ export const ConfigurationGroupSchemasCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridNetwork/publishers/{publisherName}/configurationGroupSchemas/{configurationGroupSchemaName}",
       apiVersion: "2024-04-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ConfigurationGroupSchemasCreateOrUpdateInput =
@@ -1263,6 +1275,7 @@ export const ConfigurationGroupSchemasDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridNetwork/publishers/{publisherName}/configurationGroupSchemas/{configurationGroupSchemaName}",
       apiVersion: "2024-04-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ConfigurationGroupSchemasDeleteInput =
@@ -1489,6 +1502,7 @@ export const ConfigurationGroupSchemasUpdateStateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridNetwork/publishers/{publisherName}/configurationGroupSchemas/{configurationGroupSchemaName}/updateState",
       apiVersion: "2024-04-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ConfigurationGroupSchemasUpdateStateInput =
@@ -1562,6 +1576,7 @@ export const ConfigurationGroupValuesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridNetwork/configurationGroupValues/{configurationGroupValueName}",
       apiVersion: "2024-04-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ConfigurationGroupValuesCreateOrUpdateInput =
@@ -1616,6 +1631,7 @@ export const ConfigurationGroupValuesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridNetwork/configurationGroupValues/{configurationGroupValueName}",
       apiVersion: "2024-04-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ConfigurationGroupValuesDeleteInput =
@@ -1919,6 +1935,7 @@ export const NetworkFunctionDefinitionGroupsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridNetwork/publishers/{publisherName}/networkFunctionDefinitionGroups/{networkFunctionDefinitionGroupName}",
       apiVersion: "2024-04-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NetworkFunctionDefinitionGroupsCreateOrUpdateInput =
@@ -1975,6 +1992,7 @@ export const NetworkFunctionDefinitionGroupsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridNetwork/publishers/{publisherName}/networkFunctionDefinitionGroups/{networkFunctionDefinitionGroupName}",
       apiVersion: "2024-04-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkFunctionDefinitionGroupsDeleteInput =
@@ -2234,6 +2252,7 @@ export const NetworkFunctionDefinitionVersionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridNetwork/publishers/{publisherName}/networkFunctionDefinitionGroups/{networkFunctionDefinitionGroupName}/networkFunctionDefinitionVersions/{networkFunctionDefinitionVersionName}",
       apiVersion: "2024-04-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NetworkFunctionDefinitionVersionsCreateOrUpdateInput =
@@ -2292,6 +2311,7 @@ export const NetworkFunctionDefinitionVersionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridNetwork/publishers/{publisherName}/networkFunctionDefinitionGroups/{networkFunctionDefinitionGroupName}/networkFunctionDefinitionVersions/{networkFunctionDefinitionVersionName}",
       apiVersion: "2024-04-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkFunctionDefinitionVersionsDeleteInput =
@@ -2535,6 +2555,7 @@ export const NetworkFunctionDefinitionVersionsUpdateStateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridNetwork/publishers/{publisherName}/networkFunctionDefinitionGroups/{networkFunctionDefinitionGroupName}/networkFunctionDefinitionVersions/{networkFunctionDefinitionVersionName}/updateState",
       apiVersion: "2024-04-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkFunctionDefinitionVersionsUpdateStateInput =
@@ -2652,6 +2673,7 @@ export const NetworkFunctionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridNetwork/networkFunctions/{networkFunctionName}",
       apiVersion: "2024-04-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NetworkFunctionsCreateOrUpdateInput =
@@ -2706,6 +2728,7 @@ export const NetworkFunctionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridNetwork/networkFunctions/{networkFunctionName}",
       apiVersion: "2024-04-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkFunctionsDeleteInput =
@@ -2757,6 +2780,7 @@ export const NetworkFunctionsExecuteRequestInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridNetwork/networkFunctions/{networkFunctionName}/executeRequest",
       apiVersion: "2024-04-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkFunctionsExecuteRequestInput =
@@ -3057,6 +3081,7 @@ export const NetworkServiceDesignGroupsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridNetwork/publishers/{publisherName}/networkServiceDesignGroups/{networkServiceDesignGroupName}",
       apiVersion: "2024-04-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NetworkServiceDesignGroupsCreateOrUpdateInput =
@@ -3113,6 +3138,7 @@ export const NetworkServiceDesignGroupsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridNetwork/publishers/{publisherName}/networkServiceDesignGroups/{networkServiceDesignGroupName}",
       apiVersion: "2024-04-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkServiceDesignGroupsDeleteInput =
@@ -3399,6 +3425,7 @@ export const NetworkServiceDesignVersionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridNetwork/publishers/{publisherName}/networkServiceDesignGroups/{networkServiceDesignGroupName}/networkServiceDesignVersions/{networkServiceDesignVersionName}",
       apiVersion: "2024-04-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NetworkServiceDesignVersionsCreateOrUpdateInput =
@@ -3457,6 +3484,7 @@ export const NetworkServiceDesignVersionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridNetwork/publishers/{publisherName}/networkServiceDesignGroups/{networkServiceDesignGroupName}/networkServiceDesignVersions/{networkServiceDesignVersionName}",
       apiVersion: "2024-04-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkServiceDesignVersionsDeleteInput =
@@ -3693,6 +3721,7 @@ export const NetworkServiceDesignVersionsUpdateStateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridNetwork/publishers/{publisherName}/networkServiceDesignGroups/{networkServiceDesignGroupName}/networkServiceDesignVersions/{networkServiceDesignVersionName}/updateState",
       apiVersion: "2024-04-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkServiceDesignVersionsUpdateStateInput =
@@ -3936,6 +3965,7 @@ export const ProxyArtifactUpdateStateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridNetwork/publishers/{publisherName}/artifactStores/{artifactStoreName}/artifactVersions/{artifactVersionName}",
       apiVersion: "2024-04-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ProxyArtifactUpdateStateInput =
@@ -4036,6 +4066,7 @@ export const PublishersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridNetwork/publishers/{publisherName}",
       apiVersion: "2024-04-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PublishersCreateOrUpdateInput =
@@ -4090,6 +4121,7 @@ export const PublishersDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridNetwork/publishers/{publisherName}",
     apiVersion: "2024-04-15",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type PublishersDeleteInput = typeof PublishersDeleteInput.Type;
@@ -4451,6 +4483,7 @@ export const SiteNetworkServicesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridNetwork/siteNetworkServices/{siteNetworkServiceName}",
       apiVersion: "2024-04-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SiteNetworkServicesCreateOrUpdateInput =
@@ -4505,6 +4538,7 @@ export const SiteNetworkServicesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridNetwork/siteNetworkServices/{siteNetworkServiceName}",
       apiVersion: "2024-04-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SiteNetworkServicesDeleteInput =
@@ -4827,6 +4861,7 @@ export const SitesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridNetwork/sites/{siteName}",
       apiVersion: "2024-04-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SitesCreateOrUpdateInput = typeof SitesCreateOrUpdateInput.Type;
@@ -4877,6 +4912,7 @@ export const SitesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HybridNetwork/sites/{siteName}",
     apiVersion: "2024-04-15",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type SitesDeleteInput = typeof SitesDeleteInput.Type;

--- a/packages/azure/src/services/imagebuilder.ts
+++ b/packages/azure/src/services/imagebuilder.ts
@@ -86,6 +86,7 @@ export const TriggersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.VirtualMachineImages/imageTemplates/{imageTemplateName}/triggers/{triggerName}",
       apiVersion: "2025-10-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type TriggersCreateOrUpdateInput =
@@ -138,6 +139,7 @@ export const TriggersDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.VirtualMachineImages/imageTemplates/{imageTemplateName}/triggers/{triggerName}",
     apiVersion: "2025-10-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type TriggersDeleteInput = typeof TriggersDeleteInput.Type;
@@ -283,6 +285,7 @@ export const VirtualMachineImageTemplatesCancelInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.VirtualMachineImages/imageTemplates/{imageTemplateName}/cancel",
       apiVersion: "2025-10-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualMachineImageTemplatesCancelInput =
@@ -494,6 +497,7 @@ export const VirtualMachineImageTemplatesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.VirtualMachineImages/imageTemplates/{imageTemplateName}",
       apiVersion: "2025-10-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualMachineImageTemplatesCreateOrUpdateInput =
@@ -546,6 +550,7 @@ export const VirtualMachineImageTemplatesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.VirtualMachineImages/imageTemplates/{imageTemplateName}",
       apiVersion: "2025-10-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineImageTemplatesDeleteInput =
@@ -889,6 +894,7 @@ export const VirtualMachineImageTemplatesRunInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.VirtualMachineImages/imageTemplates/{imageTemplateName}/run",
       apiVersion: "2025-10-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualMachineImageTemplatesRunInput =
@@ -969,6 +975,7 @@ export const VirtualMachineImageTemplatesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.VirtualMachineImages/imageTemplates/{imageTemplateName}",
       apiVersion: "2025-10-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualMachineImageTemplatesUpdateInput =

--- a/packages/azure/src/services/iotcentral.ts
+++ b/packages/azure/src/services/iotcentral.ts
@@ -109,6 +109,7 @@ export const AppsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.IoTCentral/iotApps/{resourceName}",
       apiVersion: "2021-06-01",
+      longRunning: {},
     }),
   );
 export type AppsCreateOrUpdateInput = typeof AppsCreateOrUpdateInput.Type;
@@ -140,6 +141,7 @@ export const AppsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.IoTCentral/iotApps/{resourceName}",
     apiVersion: "2021-06-01",
+    longRunning: {},
   }),
 );
 export type AppsDeleteInput = typeof AppsDeleteInput.Type;
@@ -343,6 +345,7 @@ export const AppsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.IoTCentral/iotApps/{resourceName}",
     apiVersion: "2021-06-01",
+    longRunning: {},
   }),
 );
 export type AppsUpdateInput = typeof AppsUpdateInput.Type;

--- a/packages/azure/src/services/iothub.ts
+++ b/packages/azure/src/services/iothub.ts
@@ -299,6 +299,7 @@ export const IotHubManualFailoverInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/IotHubs/{iotHubName}/failover",
       apiVersion: "2023-06-30",
+      longRunning: {},
     }),
   );
 export type IotHubManualFailoverInput = typeof IotHubManualFailoverInput.Type;
@@ -774,6 +775,7 @@ export const IotHubResourceCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/IotHubs/{resourceName}",
       apiVersion: "2023-06-30",
+      longRunning: {},
     }),
   );
 export type IotHubResourceCreateOrUpdateInput =
@@ -811,6 +813,7 @@ export const IotHubResourceDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/IotHubs/{resourceName}",
       apiVersion: "2023-06-30",
+      longRunning: {},
     }),
   );
 export type IotHubResourceDeleteInput = typeof IotHubResourceDeleteInput.Type;
@@ -1859,6 +1862,7 @@ export const IotHubResourceUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/IotHubs/{resourceName}",
       apiVersion: "2023-06-30",
+      longRunning: {},
     }),
   );
 export type IotHubResourceUpdateInput = typeof IotHubResourceUpdateInput.Type;
@@ -1937,6 +1941,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/iotHubs/{resourceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2023-06-30",
+      longRunning: {},
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =
@@ -2110,6 +2115,7 @@ export const PrivateEndpointConnectionsUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/iotHubs/{resourceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2023-06-30",
+      longRunning: {},
     }),
   );
 export type PrivateEndpointConnectionsUpdateInput =

--- a/packages/azure/src/services/iotoperations.ts
+++ b/packages/azure/src/services/iotoperations.ts
@@ -73,6 +73,7 @@ export const AkriConnectorCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.IoTOperations/instances/{instanceName}/akriConnectorTemplates/{akriConnectorTemplateName}/connectors/{connectorName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AkriConnectorCreateOrUpdateInput =
@@ -132,6 +133,7 @@ export const AkriConnectorDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.IoTOperations/instances/{instanceName}/akriConnectorTemplates/{akriConnectorTemplateName}/connectors/{connectorName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AkriConnectorDeleteInput = typeof AkriConnectorDeleteInput.Type;
@@ -365,6 +367,7 @@ export const AkriConnectorTemplateCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.IoTOperations/instances/{instanceName}/akriConnectorTemplates/{akriConnectorTemplateName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AkriConnectorTemplateCreateOrUpdateInput =
@@ -421,6 +424,7 @@ export const AkriConnectorTemplateDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.IoTOperations/instances/{instanceName}/akriConnectorTemplates/{akriConnectorTemplateName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AkriConnectorTemplateDeleteInput =
@@ -627,6 +631,7 @@ export const AkriServiceCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.IoTOperations/instances/{instanceName}/akriServices/{akriServiceName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AkriServiceCreateOrUpdateInput =
@@ -685,6 +690,7 @@ export const AkriServiceDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.IoTOperations/instances/{instanceName}/akriServices/{akriServiceName}",
     apiVersion: "2026-03-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type AkriServiceDeleteInput = typeof AkriServiceDeleteInput.Type;
@@ -907,6 +913,7 @@ export const BrokerAuthenticationCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.IoTOperations/instances/{instanceName}/brokers/{brokerName}/authentications/{authenticationName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type BrokerAuthenticationCreateOrUpdateInput =
@@ -965,6 +972,7 @@ export const BrokerAuthenticationDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.IoTOperations/instances/{instanceName}/brokers/{brokerName}/authentications/{authenticationName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BrokerAuthenticationDeleteInput =
@@ -1196,6 +1204,7 @@ export const BrokerAuthorizationCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.IoTOperations/instances/{instanceName}/brokers/{brokerName}/authorizations/{authorizationName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type BrokerAuthorizationCreateOrUpdateInput =
@@ -1254,6 +1263,7 @@ export const BrokerAuthorizationDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.IoTOperations/instances/{instanceName}/brokers/{brokerName}/authorizations/{authorizationName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BrokerAuthorizationDeleteInput =
@@ -1780,6 +1790,7 @@ export const BrokerCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.IoTOperations/instances/{instanceName}/brokers/{brokerName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type BrokerCreateOrUpdateInput = typeof BrokerCreateOrUpdateInput.Type;
@@ -1834,6 +1845,7 @@ export const BrokerDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.IoTOperations/instances/{instanceName}/brokers/{brokerName}",
     apiVersion: "2026-03-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type BrokerDeleteInput = typeof BrokerDeleteInput.Type;
@@ -2069,6 +2081,7 @@ export const BrokerListenerCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.IoTOperations/instances/{instanceName}/brokers/{brokerName}/listeners/{listenerName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type BrokerListenerCreateOrUpdateInput =
@@ -2127,6 +2140,7 @@ export const BrokerListenerDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.IoTOperations/instances/{instanceName}/brokers/{brokerName}/listeners/{listenerName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BrokerListenerDeleteInput = typeof BrokerListenerDeleteInput.Type;
@@ -2425,6 +2439,7 @@ export const DataflowCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.IoTOperations/instances/{instanceName}/dataflowProfiles/{dataflowProfileName}/dataflows/{dataflowName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DataflowCreateOrUpdateInput =
@@ -2483,6 +2498,7 @@ export const DataflowDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.IoTOperations/instances/{instanceName}/dataflowProfiles/{dataflowProfileName}/dataflows/{dataflowName}",
     apiVersion: "2026-03-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type DataflowDeleteInput = typeof DataflowDeleteInput.Type;
@@ -2816,6 +2832,7 @@ export const DataflowEndpointCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.IoTOperations/instances/{instanceName}/dataflowEndpoints/{dataflowEndpointName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DataflowEndpointCreateOrUpdateInput =
@@ -2872,6 +2889,7 @@ export const DataflowEndpointDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.IoTOperations/instances/{instanceName}/dataflowEndpoints/{dataflowEndpointName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DataflowEndpointDeleteInput =
@@ -3159,6 +3177,7 @@ export const DataflowGraphCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.IoTOperations/instances/{instanceName}/dataflowProfiles/{dataflowProfileName}/dataflowGraphs/{dataflowGraphName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DataflowGraphCreateOrUpdateInput =
@@ -3218,6 +3237,7 @@ export const DataflowGraphDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.IoTOperations/instances/{instanceName}/dataflowProfiles/{dataflowProfileName}/dataflowGraphs/{dataflowGraphName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DataflowGraphDeleteInput = typeof DataflowGraphDeleteInput.Type;
@@ -3510,6 +3530,7 @@ export const DataflowProfileCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.IoTOperations/instances/{instanceName}/dataflowProfiles/{dataflowProfileName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DataflowProfileCreateOrUpdateInput =
@@ -3566,6 +3587,7 @@ export const DataflowProfileDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.IoTOperations/instances/{instanceName}/dataflowProfiles/{dataflowProfileName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DataflowProfileDeleteInput = typeof DataflowProfileDeleteInput.Type;
@@ -3801,6 +3823,7 @@ export const InstanceCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.IoTOperations/instances/{instanceName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type InstanceCreateOrUpdateInput =
@@ -3855,6 +3878,7 @@ export const InstanceDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.IoTOperations/instances/{instanceName}",
     apiVersion: "2026-03-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type InstanceDeleteInput = typeof InstanceDeleteInput.Type;
@@ -4230,6 +4254,7 @@ export const RegistryEndpointCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.IoTOperations/instances/{instanceName}/registryEndpoints/{registryEndpointName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type RegistryEndpointCreateOrUpdateInput =
@@ -4286,6 +4311,7 @@ export const RegistryEndpointDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.IoTOperations/instances/{instanceName}/registryEndpoints/{registryEndpointName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RegistryEndpointDeleteInput =

--- a/packages/azure/src/services/keyvault.ts
+++ b/packages/azure/src/services/keyvault.ts
@@ -961,6 +961,7 @@ export const ManagedHsmsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/managedHSMs/{name}",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedHsmsCreateOrUpdateInput =
@@ -1017,6 +1018,7 @@ export const ManagedHsmsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/managedHSMs/{name}",
     apiVersion: "2026-02-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ManagedHsmsDeleteInput = typeof ManagedHsmsDeleteInput.Type;
@@ -1354,6 +1356,7 @@ export const ManagedHsmsPurgeDeletedInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.KeyVault/locations/{location}/deletedManagedHSMs/{name}/purge",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedHsmsPurgeDeletedInput =
@@ -1551,6 +1554,7 @@ export const ManagedHsmsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/managedHSMs/{name}",
     apiVersion: "2026-02-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ManagedHsmsUpdateInput = typeof ManagedHsmsUpdateInput.Type;
@@ -1603,6 +1607,7 @@ export const MHSMPrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/managedHSMs/{name}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type MHSMPrivateEndpointConnectionsDeleteInput =
@@ -2125,6 +2130,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/{vaultName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =
@@ -2938,6 +2944,7 @@ export const VaultsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/{vaultName}",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VaultsCreateOrUpdateInput = typeof VaultsCreateOrUpdateInput.Type;
@@ -3377,6 +3384,7 @@ export const VaultsPurgeDeletedInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.KeyVault/locations/{location}/deletedVaults/{vaultName}/purge",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VaultsPurgeDeletedInput = typeof VaultsPurgeDeletedInput.Type;

--- a/packages/azure/src/services/kubernetesconfiguration.ts
+++ b/packages/azure/src/services/kubernetesconfiguration.ts
@@ -154,6 +154,7 @@ export const ExtensionsCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{clusterRp}/{clusterResourceName}/{clusterName}/providers/Microsoft.KubernetesConfiguration/extensions/{extensionName}",
     apiVersion: "2023-05-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type ExtensionsCreateInput = typeof ExtensionsCreateInput.Type;
@@ -196,6 +197,7 @@ export const ExtensionsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{clusterRp}/{clusterResourceName}/{clusterName}/providers/Microsoft.KubernetesConfiguration/extensions/{extensionName}",
     apiVersion: "2023-05-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type ExtensionsDeleteInput = typeof ExtensionsDeleteInput.Type;
@@ -330,6 +332,7 @@ export const ExtensionsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{clusterRp}/{clusterResourceName}/{clusterName}/providers/Microsoft.KubernetesConfiguration/extensions/{extensionName}",
     apiVersion: "2023-05-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type ExtensionsUpdateInput = typeof ExtensionsUpdateInput.Type;
@@ -708,6 +711,7 @@ export const FluxConfigurationsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{clusterRp}/{clusterResourceName}/{clusterName}/providers/Microsoft.KubernetesConfiguration/fluxConfigurations/{fluxConfigurationName}",
       apiVersion: "2023-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type FluxConfigurationsCreateOrUpdateInput =
@@ -753,6 +757,7 @@ export const FluxConfigurationsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{clusterRp}/{clusterResourceName}/{clusterName}/providers/Microsoft.KubernetesConfiguration/fluxConfigurations/{fluxConfigurationName}",
       apiVersion: "2023-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type FluxConfigurationsDeleteInput =
@@ -1031,6 +1036,7 @@ export const FluxConfigurationsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{clusterRp}/{clusterResourceName}/{clusterName}/providers/Microsoft.KubernetesConfiguration/fluxConfigurations/{fluxConfigurationName}",
       apiVersion: "2023-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type FluxConfigurationsUpdateInput =
@@ -1393,6 +1399,7 @@ export const SourceControlConfigurationsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{clusterRp}/{clusterResourceName}/{clusterName}/providers/Microsoft.KubernetesConfiguration/sourceControlConfigurations/{sourceControlConfigurationName}",
       apiVersion: "2023-05-01",
+      longRunning: {},
     }),
   );
 export type SourceControlConfigurationsDeleteInput =

--- a/packages/azure/src/services/kubernetesruntime.ts
+++ b/packages/azure/src/services/kubernetesruntime.ts
@@ -36,6 +36,7 @@ export const BgpPeersCreateOrUpdateInput =
       method: "PUT",
       path: "/{resourceUri}/providers/Microsoft.KubernetesRuntime/bgpPeers/{bgpPeerName}",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type BgpPeersCreateOrUpdateInput =
@@ -229,6 +230,7 @@ export const LoadBalancersCreateOrUpdateInput =
       method: "PUT",
       path: "/{resourceUri}/providers/Microsoft.KubernetesRuntime/loadBalancers/{loadBalancerName}",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type LoadBalancersCreateOrUpdateInput =
@@ -698,6 +700,7 @@ export const StorageClassCreateOrUpdateInput =
       method: "PUT",
       path: "/{resourceUri}/providers/Microsoft.KubernetesRuntime/storageClasses/{storageClassName}",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type StorageClassCreateOrUpdateInput =
@@ -749,6 +752,7 @@ export const StorageClassDeleteInput =
       method: "DELETE",
       path: "/{resourceUri}/providers/Microsoft.KubernetesRuntime/storageClasses/{storageClassName}",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StorageClassDeleteInput = typeof StorageClassDeleteInput.Type;
@@ -927,6 +931,7 @@ export const StorageClassUpdateInput =
       method: "PATCH",
       path: "/{resourceUri}/providers/Microsoft.KubernetesRuntime/storageClasses/{storageClassName}",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StorageClassUpdateInput = typeof StorageClassUpdateInput.Type;

--- a/packages/azure/src/services/labservices.ts
+++ b/packages/azure/src/services/labservices.ts
@@ -241,6 +241,7 @@ export const LabPlansCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.LabServices/labPlans/{labPlanName}",
       apiVersion: "2023-06-07",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type LabPlansCreateOrUpdateInput =
@@ -276,6 +277,7 @@ export const LabPlansDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.LabServices/labPlans/{labPlanName}",
     apiVersion: "2023-06-07",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type LabPlansDeleteInput = typeof LabPlansDeleteInput.Type;
@@ -417,6 +419,7 @@ export const LabPlansSaveImageInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.LabServices/labPlans/{labPlanName}/saveImage",
     apiVersion: "2023-06-07",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type LabPlansSaveImageInput = typeof LabPlansSaveImageInput.Type;
@@ -502,6 +505,7 @@ export const LabPlansUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.LabServices/labPlans/{labPlanName}",
     apiVersion: "2023-06-07",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type LabPlansUpdateInput = typeof LabPlansUpdateInput.Type;
@@ -644,6 +648,7 @@ export const LabsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.LabServices/labs/{labName}",
       apiVersion: "2023-06-07",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type LabsCreateOrUpdateInput = typeof LabsCreateOrUpdateInput.Type;
@@ -675,6 +680,7 @@ export const LabsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.LabServices/labs/{labName}",
     apiVersion: "2023-06-07",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type LabsDeleteInput = typeof LabsDeleteInput.Type;
@@ -811,6 +817,7 @@ export const LabsPublishInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.LabServices/labs/{labName}/publish",
     apiVersion: "2023-06-07",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type LabsPublishInput = typeof LabsPublishInput.Type;
@@ -837,6 +844,7 @@ export const LabsSyncGroupInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.LabServices/labs/{labName}/syncGroup",
     apiVersion: "2023-06-07",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type LabsSyncGroupInput = typeof LabsSyncGroupInput.Type;
@@ -961,6 +969,7 @@ export const LabsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.LabServices/labs/{labName}",
     apiVersion: "2023-06-07",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type LabsUpdateInput = typeof LabsUpdateInput.Type;
@@ -1186,6 +1195,7 @@ export const SchedulesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.LabServices/labs/{labName}/schedules/{scheduleName}",
     apiVersion: "2023-06-07",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type SchedulesDeleteInput = typeof SchedulesDeleteInput.Type;
@@ -1476,6 +1486,7 @@ export const UsersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.LabServices/labs/{labName}/users/{userName}",
       apiVersion: "2023-06-07",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type UsersCreateOrUpdateInput = typeof UsersCreateOrUpdateInput.Type;
@@ -1507,6 +1518,7 @@ export const UsersDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.LabServices/labs/{labName}/users/{userName}",
     apiVersion: "2023-06-07",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type UsersDeleteInput = typeof UsersDeleteInput.Type;
@@ -1561,6 +1573,7 @@ export const UsersInviteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.LabServices/labs/{labName}/users/{userName}/invite",
     apiVersion: "2023-06-07",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type UsersInviteInput = typeof UsersInviteInput.Type;
@@ -1628,6 +1641,7 @@ export const UsersUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.LabServices/labs/{labName}/users/{userName}",
     apiVersion: "2023-06-07",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type UsersUpdateInput = typeof UsersUpdateInput.Type;
@@ -1728,6 +1742,7 @@ export const VirtualMachinesRedeployInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.LabServices/labs/{labName}/virtualMachines/{virtualMachineName}/redeploy",
       apiVersion: "2023-06-07",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesRedeployInput =
@@ -1758,6 +1773,7 @@ export const VirtualMachinesReimageInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.LabServices/labs/{labName}/virtualMachines/{virtualMachineName}/reimage",
       apiVersion: "2023-06-07",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesReimageInput =
@@ -1791,6 +1807,7 @@ export const VirtualMachinesResetPasswordInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.LabServices/labs/{labName}/virtualMachines/{virtualMachineName}/resetPassword",
       apiVersion: "2023-06-07",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesResetPasswordInput =
@@ -1820,6 +1837,7 @@ export const VirtualMachinesStartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.LabServices/labs/{labName}/virtualMachines/{virtualMachineName}/start",
       apiVersion: "2023-06-07",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesStartInput = typeof VirtualMachinesStartInput.Type;
@@ -1848,6 +1866,7 @@ export const VirtualMachinesStopInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.LabServices/labs/{labName}/virtualMachines/{virtualMachineName}/stop",
       apiVersion: "2023-06-07",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesStopInput = typeof VirtualMachinesStopInput.Type;

--- a/packages/azure/src/services/liftrweightsandbiases.ts
+++ b/packages/azure/src/services/liftrweightsandbiases.ts
@@ -97,6 +97,7 @@ export const InstancesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.WeightsAndBiases/instances/{instancename}",
       apiVersion: "2024-09-18",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type InstancesCreateOrUpdateInput =
@@ -151,6 +152,7 @@ export const InstancesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.WeightsAndBiases/instances/{instancename}",
     apiVersion: "2024-09-18",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type InstancesDeleteInput = typeof InstancesDeleteInput.Type;

--- a/packages/azure/src/services/loadtestservice.ts
+++ b/packages/azure/src/services/loadtestservice.ts
@@ -64,6 +64,7 @@ export const LoadTestsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.LoadTestService/loadTests/{loadTestName}",
       apiVersion: "2022-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type LoadTestsCreateOrUpdateInput =
@@ -118,6 +119,7 @@ export const LoadTestsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.LoadTestService/loadTests/{loadTestName}",
     apiVersion: "2022-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type LoadTestsDeleteInput = typeof LoadTestsDeleteInput.Type;
@@ -429,6 +431,7 @@ export const LoadTestsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.LoadTestService/loadTests/{loadTestName}",
     apiVersion: "2022-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type LoadTestsUpdateInput = typeof LoadTestsUpdateInput.Type;
@@ -834,6 +837,7 @@ export const PlaywrightWorkspacesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.LoadTestService/playwrightWorkspaces/{playwrightWorkspaceName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PlaywrightWorkspacesCreateOrUpdateInput =
@@ -888,6 +892,7 @@ export const PlaywrightWorkspacesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.LoadTestService/playwrightWorkspaces/{playwrightWorkspaceName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PlaywrightWorkspacesDeleteInput =

--- a/packages/azure/src/services/logic.ts
+++ b/packages/azure/src/services/logic.ts
@@ -3500,6 +3500,7 @@ export const IntegrationServiceEnvironmentManagedApisDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Logic/integrationServiceEnvironments/{integrationServiceEnvironmentName}/managedApis/{apiName}",
       apiVersion: "2019-05-01",
+      longRunning: {},
     }),
   );
 export type IntegrationServiceEnvironmentManagedApisDeleteInput =
@@ -3792,6 +3793,7 @@ export const IntegrationServiceEnvironmentManagedApisPutInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Logic/integrationServiceEnvironments/{integrationServiceEnvironmentName}/managedApis/{apiName}",
       apiVersion: "2019-05-01",
+      longRunning: {},
     }),
   );
 export type IntegrationServiceEnvironmentManagedApisPutInput =
@@ -4087,6 +4089,7 @@ export const IntegrationServiceEnvironmentsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Logic/integrationServiceEnvironments/{integrationServiceEnvironmentName}",
       apiVersion: "2019-05-01",
+      longRunning: {},
     }),
   );
 export type IntegrationServiceEnvironmentsCreateOrUpdateInput =
@@ -4529,6 +4532,7 @@ export const IntegrationServiceEnvironmentsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Logic/integrationServiceEnvironments/{integrationServiceEnvironmentName}",
       apiVersion: "2019-05-01",
+      longRunning: {},
     }),
   );
 export type IntegrationServiceEnvironmentsUpdateInput =
@@ -5999,6 +6003,7 @@ export const WorkflowsMoveInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Logic/workflows/{workflowName}/move",
     apiVersion: "2019-05-01",
+    longRunning: {},
   }),
 );
 export type WorkflowsMoveInput = typeof WorkflowsMoveInput.Type;

--- a/packages/azure/src/services/machinelearningservices.ts
+++ b/packages/azure/src/services/machinelearningservices.ts
@@ -82,6 +82,7 @@ export const BatchDeploymentsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/batchEndpoints/{endpointName}/deployments/{deploymentName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type BatchDeploymentsCreateOrUpdateInput =
@@ -140,6 +141,7 @@ export const BatchDeploymentsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/batchEndpoints/{endpointName}/deployments/{deploymentName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BatchDeploymentsDeleteInput =
@@ -322,6 +324,7 @@ export const BatchDeploymentsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/batchEndpoints/{endpointName}/deployments/{deploymentName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BatchDeploymentsUpdateInput =
@@ -434,6 +437,7 @@ export const BatchEndpointsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/batchEndpoints/{endpointName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type BatchEndpointsCreateOrUpdateInput =
@@ -492,6 +496,7 @@ export const BatchEndpointsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/batchEndpoints/{endpointName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BatchEndpointsDeleteInput = typeof BatchEndpointsDeleteInput.Type;
@@ -715,6 +720,7 @@ export const BatchEndpointsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/batchEndpoints/{endpointName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BatchEndpointsUpdateInput = typeof BatchEndpointsUpdateInput.Type;
@@ -783,6 +789,7 @@ export const CapabilityHostsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/capabilityHosts/{name}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type CapabilityHostsCreateOrUpdateInput =
@@ -839,6 +846,7 @@ export const CapabilityHostsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/capabilityHosts/{name}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CapabilityHostsDeleteInput = typeof CapabilityHostsDeleteInput.Type;
@@ -1463,6 +1471,7 @@ export const CodeVersionsPublishInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/codes/{name}/versions/{version}/publish",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CodeVersionsPublishInput = typeof CodeVersionsPublishInput.Type;
@@ -1994,6 +2003,7 @@ export const ComponentVersionsPublishInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/components/{name}/versions/{version}/publish",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ComponentVersionsPublishInput =
@@ -2130,6 +2140,7 @@ export const ComputeCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/computes/{computeName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ComputeCreateOrUpdateInput = typeof ComputeCreateOrUpdateInput.Type;
@@ -2186,6 +2197,7 @@ export const ComputeDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/computes/{computeName}",
     apiVersion: "2025-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ComputeDeleteInput = typeof ComputeDeleteInput.Type;
@@ -2431,6 +2443,7 @@ export const ComputeRestartInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/computes/{computeName}/restart",
     apiVersion: "2025-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ComputeRestartInput = typeof ComputeRestartInput.Type;
@@ -2464,6 +2477,7 @@ export const ComputeStartInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/computes/{computeName}/start",
     apiVersion: "2025-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ComputeStartInput = typeof ComputeStartInput.Type;
@@ -2497,6 +2511,7 @@ export const ComputeStopInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/computes/{computeName}/stop",
     apiVersion: "2025-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ComputeStopInput = typeof ComputeStopInput.Type;
@@ -2545,6 +2560,7 @@ export const ComputeUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/computes/{computeName}",
     apiVersion: "2025-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ComputeUpdateInput = typeof ComputeUpdateInput.Type;
@@ -3346,6 +3362,7 @@ export const DataVersionsPublishInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/data/{name}/versions/{version}/publish",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DataVersionsPublishInput = typeof DataVersionsPublishInput.Type;
@@ -3880,6 +3897,7 @@ export const EnvironmentVersionsPublishInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/environments/{name}/versions/{version}/publish",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type EnvironmentVersionsPublishInput =
@@ -3933,6 +3951,7 @@ export const FeaturesetContainersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/featuresets/{name}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type FeaturesetContainersCreateOrUpdateInput =
@@ -3989,6 +4008,7 @@ export const FeaturesetContainersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/featuresets/{name}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type FeaturesetContainersDeleteInput =
@@ -4199,6 +4219,7 @@ export const FeaturesetVersionsBackfillInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/featuresets/{name}/versions/{version}/backfill",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type FeaturesetVersionsBackfillInput =
@@ -4255,6 +4276,7 @@ export const FeaturesetVersionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/featuresets/{name}/versions/{version}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type FeaturesetVersionsCreateOrUpdateInput =
@@ -4313,6 +4335,7 @@ export const FeaturesetVersionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/featuresets/{name}/versions/{version}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type FeaturesetVersionsDeleteInput =
@@ -4643,6 +4666,7 @@ export const FeaturestoreEntityContainersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/featurestoreEntities/{name}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type FeaturestoreEntityContainersCreateOrUpdateInput =
@@ -4699,6 +4723,7 @@ export const FeaturestoreEntityContainersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/featurestoreEntities/{name}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type FeaturestoreEntityContainersDeleteInput =
@@ -4892,6 +4917,7 @@ export const FeaturestoreEntityVersionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/featurestoreEntities/{name}/versions/{version}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type FeaturestoreEntityVersionsCreateOrUpdateInput =
@@ -4950,6 +4976,7 @@ export const FeaturestoreEntityVersionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/featurestoreEntities/{name}/versions/{version}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type FeaturestoreEntityVersionsDeleteInput =
@@ -5137,6 +5164,7 @@ export const JobsCancelInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/jobs/{id}/cancel",
     apiVersion: "2025-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type JobsCancelInput = typeof JobsCancelInput.Type;
@@ -5240,6 +5268,7 @@ export const JobsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/jobs/{id}",
     apiVersion: "2025-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type JobsDeleteInput = typeof JobsDeleteInput.Type;
@@ -5391,6 +5420,7 @@ export const ManagedNetworkProvisionsProvisionManagedNetworkInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/provisionManagedNetwork",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedNetworkProvisionsProvisionManagedNetworkInput =
@@ -5453,6 +5483,7 @@ export const ManagedNetworkSettingsRuleCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/outboundRules/{ruleName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedNetworkSettingsRuleCreateOrUpdateInput =
@@ -5509,6 +5540,7 @@ export const ManagedNetworkSettingsRuleDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/outboundRules/{ruleName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedNetworkSettingsRuleDeleteInput =
@@ -5695,6 +5727,7 @@ export const MarketplaceSubscriptionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/marketplaceSubscriptions/{name}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type MarketplaceSubscriptionsCreateOrUpdateInput =
@@ -5751,6 +5784,7 @@ export const MarketplaceSubscriptionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/marketplaceSubscriptions/{name}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type MarketplaceSubscriptionsDeleteInput =
@@ -6410,6 +6444,7 @@ export const ModelVersionsPublishInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/models/{name}/versions/{version}/publish",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ModelVersionsPublishInput = typeof ModelVersionsPublishInput.Type;
@@ -6506,6 +6541,7 @@ export const OnlineDeploymentsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/onlineEndpoints/{endpointName}/deployments/{deploymentName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type OnlineDeploymentsCreateOrUpdateInput =
@@ -6564,6 +6600,7 @@ export const OnlineDeploymentsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/onlineEndpoints/{endpointName}/deployments/{deploymentName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type OnlineDeploymentsDeleteInput =
@@ -6870,6 +6907,7 @@ export const OnlineDeploymentsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/onlineEndpoints/{endpointName}/deployments/{deploymentName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type OnlineDeploymentsUpdateInput =
@@ -6982,6 +7020,7 @@ export const OnlineEndpointsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/onlineEndpoints/{endpointName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type OnlineEndpointsCreateOrUpdateInput =
@@ -7038,6 +7077,7 @@ export const OnlineEndpointsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/onlineEndpoints/{endpointName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type OnlineEndpointsDeleteInput = typeof OnlineEndpointsDeleteInput.Type;
@@ -7306,6 +7346,7 @@ export const OnlineEndpointsRegenerateKeysInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/onlineEndpoints/{endpointName}/regenerateKeys",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type OnlineEndpointsRegenerateKeysInput =
@@ -7362,6 +7403,7 @@ export const OnlineEndpointsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/onlineEndpoints/{endpointName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type OnlineEndpointsUpdateInput = typeof OnlineEndpointsUpdateInput.Type;
@@ -8116,6 +8158,7 @@ export const RegistriesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/registries/{registryName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type RegistriesCreateOrUpdateInput =
@@ -8170,6 +8213,7 @@ export const RegistriesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/registries/{registryName}",
     apiVersion: "2025-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type RegistriesDeleteInput = typeof RegistriesDeleteInput.Type;
@@ -8540,6 +8584,7 @@ export const RegistriesRemoveRegionsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/registries/{registryName}/removeRegions",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RegistriesRemoveRegionsInput =
@@ -8697,6 +8742,7 @@ export const RegistryCodeContainersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/registries/{registryName}/codes/{codeName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type RegistryCodeContainersCreateOrUpdateInput =
@@ -8753,6 +8799,7 @@ export const RegistryCodeContainersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/registries/{registryName}/codes/{codeName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RegistryCodeContainersDeleteInput =
@@ -8994,6 +9041,7 @@ export const RegistryCodeVersionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/registries/{registryName}/codes/{codeName}/versions/{version}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type RegistryCodeVersionsCreateOrUpdateInput =
@@ -9052,6 +9100,7 @@ export const RegistryCodeVersionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/registries/{registryName}/codes/{codeName}/versions/{version}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RegistryCodeVersionsDeleteInput =
@@ -9242,6 +9291,7 @@ export const RegistryComponentContainersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/registries/{registryName}/components/{componentName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type RegistryComponentContainersCreateOrUpdateInput =
@@ -9298,6 +9348,7 @@ export const RegistryComponentContainersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/registries/{registryName}/components/{componentName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RegistryComponentContainersDeleteInput =
@@ -9477,6 +9528,7 @@ export const RegistryComponentVersionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/registries/{registryName}/components/{componentName}/versions/{version}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type RegistryComponentVersionsCreateOrUpdateInput =
@@ -9535,6 +9587,7 @@ export const RegistryComponentVersionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/registries/{registryName}/components/{componentName}/versions/{version}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RegistryComponentVersionsDeleteInput =
@@ -9722,6 +9775,7 @@ export const RegistryDataContainersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/registries/{registryName}/data/{name}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type RegistryDataContainersCreateOrUpdateInput =
@@ -9778,6 +9832,7 @@ export const RegistryDataContainersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/registries/{registryName}/data/{name}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RegistryDataContainersDeleteInput =
@@ -10082,6 +10137,7 @@ export const RegistryDataVersionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/registries/{registryName}/data/{name}/versions/{version}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type RegistryDataVersionsCreateOrUpdateInput =
@@ -10140,6 +10196,7 @@ export const RegistryDataVersionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/registries/{registryName}/data/{name}/versions/{version}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RegistryDataVersionsDeleteInput =
@@ -10337,6 +10394,7 @@ export const RegistryEnvironmentContainersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/registries/{registryName}/environments/{environmentName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type RegistryEnvironmentContainersCreateOrUpdateInput =
@@ -10393,6 +10451,7 @@ export const RegistryEnvironmentContainersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/registries/{registryName}/environments/{environmentName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RegistryEnvironmentContainersDeleteInput =
@@ -10576,6 +10635,7 @@ export const RegistryEnvironmentVersionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/registries/{registryName}/environments/{environmentName}/versions/{version}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type RegistryEnvironmentVersionsCreateOrUpdateInput =
@@ -10634,6 +10694,7 @@ export const RegistryEnvironmentVersionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/registries/{registryName}/environments/{environmentName}/versions/{version}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RegistryEnvironmentVersionsDeleteInput =
@@ -10825,6 +10886,7 @@ export const RegistryModelContainersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/registries/{registryName}/models/{modelName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type RegistryModelContainersCreateOrUpdateInput =
@@ -10881,6 +10943,7 @@ export const RegistryModelContainersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/registries/{registryName}/models/{modelName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RegistryModelContainersDeleteInput =
@@ -11126,6 +11189,7 @@ export const RegistryModelVersionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/registries/{registryName}/models/{modelName}/versions/{version}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type RegistryModelVersionsCreateOrUpdateInput =
@@ -11184,6 +11248,7 @@ export const RegistryModelVersionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/registries/{registryName}/models/{modelName}/versions/{version}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RegistryModelVersionsDeleteInput =
@@ -11386,6 +11451,7 @@ export const SchedulesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/schedules/{name}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type SchedulesCreateOrUpdateInput =
@@ -11442,6 +11508,7 @@ export const SchedulesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/schedules/{name}",
     apiVersion: "2025-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type SchedulesDeleteInput = typeof SchedulesDeleteInput.Type;
@@ -11671,6 +11738,7 @@ export const ServerlessEndpointsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/serverlessEndpoints/{name}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type ServerlessEndpointsCreateOrUpdateInput =
@@ -11727,6 +11795,7 @@ export const ServerlessEndpointsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/serverlessEndpoints/{name}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServerlessEndpointsDeleteInput =
@@ -11939,6 +12008,7 @@ export const ServerlessEndpointsRegenerateKeysInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/serverlessEndpoints/{name}/regenerateKeys",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServerlessEndpointsRegenerateKeysInput =
@@ -12009,6 +12079,7 @@ export const ServerlessEndpointsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/serverlessEndpoints/{name}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServerlessEndpointsUpdateInput =
@@ -13165,6 +13236,7 @@ export const WorkspacesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkspacesCreateOrUpdateInput =
@@ -13220,6 +13292,7 @@ export const WorkspacesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}",
     apiVersion: "2025-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type WorkspacesDeleteInput = typeof WorkspacesDeleteInput.Type;
@@ -13279,6 +13352,7 @@ export const WorkspacesDiagnoseInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/diagnose",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkspacesDiagnoseInput = typeof WorkspacesDiagnoseInput.Type;
@@ -13849,6 +13923,7 @@ export const WorkspacesPrepareNotebookInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/prepareNotebook",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkspacesPrepareNotebookInput =
@@ -13896,6 +13971,7 @@ export const WorkspacesResyncKeysInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/resyncKeys",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkspacesResyncKeysInput = typeof WorkspacesResyncKeysInput.Type;
@@ -14073,6 +14149,7 @@ export const WorkspacesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}",
     apiVersion: "2025-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type WorkspacesUpdateInput = typeof WorkspacesUpdateInput.Type;

--- a/packages/azure/src/services/managednetworkfabric.ts
+++ b/packages/azure/src/services/managednetworkfabric.ts
@@ -301,6 +301,7 @@ export const AccessControlListsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/accessControlLists/{accessControlListName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AccessControlListsCreateInput =
@@ -356,6 +357,7 @@ export const AccessControlListsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/accessControlLists/{accessControlListName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AccessControlListsDeleteInput =
@@ -579,6 +581,7 @@ export const AccessControlListsResyncInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/accessControlLists/{accessControlListName}/resync",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AccessControlListsResyncInput =
@@ -873,6 +876,7 @@ export const AccessControlListsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/accessControlLists/{accessControlListName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AccessControlListsUpdateInput =
@@ -932,6 +936,7 @@ export const AccessControlListsUpdateAdministrativeStateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/accessControlLists/{accessControlListName}/updateAdministrativeState",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AccessControlListsUpdateAdministrativeStateInput =
@@ -1074,6 +1079,7 @@ export const AccessControlListsValidateConfigurationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/accessControlLists/{accessControlListName}/validateConfiguration",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AccessControlListsValidateConfigurationInput =
@@ -1301,6 +1307,7 @@ export const ExternalNetworksCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/l3IsolationDomains/{l3IsolationDomainName}/externalNetworks/{externalNetworkName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ExternalNetworksCreateInput =
@@ -1358,6 +1365,7 @@ export const ExternalNetworksDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/l3IsolationDomains/{l3IsolationDomainName}/externalNetworks/{externalNetworkName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ExternalNetworksDeleteInput =
@@ -1651,6 +1659,7 @@ export const ExternalNetworksUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/l3IsolationDomains/{l3IsolationDomainName}/externalNetworks/{externalNetworkName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ExternalNetworksUpdateInput =
@@ -1712,6 +1721,7 @@ export const ExternalNetworksUpdateAdministrativeStateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/l3IsolationDomains/{l3IsolationDomainName}/externalNetworks/{externalNetworkName}/updateAdministrativeState",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ExternalNetworksUpdateAdministrativeStateInput =
@@ -1860,6 +1870,7 @@ export const ExternalNetworksUpdateBfdAdministrativeStateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/l3IsolationDomains/{l3IsolationDomainName}/externalNetworks/{externalNetworkName}/updateBfdAdministrativeState",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ExternalNetworksUpdateBfdAdministrativeStateInput =
@@ -2010,6 +2021,7 @@ export const ExternalNetworksUpdateStaticRouteBfdAdministrativeStateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/l3IsolationDomains/{l3IsolationDomainName}/externalNetworks/{externalNetworkName}/updateStaticRouteBfdAdministrativeState",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ExternalNetworksUpdateStaticRouteBfdAdministrativeStateInput =
@@ -2293,6 +2305,7 @@ export const InternalNetworksCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/l3IsolationDomains/{l3IsolationDomainName}/internalNetworks/{internalNetworkName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type InternalNetworksCreateInput =
@@ -2350,6 +2363,7 @@ export const InternalNetworksDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/l3IsolationDomains/{l3IsolationDomainName}/internalNetworks/{internalNetworkName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type InternalNetworksDeleteInput =
@@ -2608,6 +2622,7 @@ export const InternalNetworksUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/l3IsolationDomains/{l3IsolationDomainName}/internalNetworks/{internalNetworkName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type InternalNetworksUpdateInput =
@@ -2669,6 +2684,7 @@ export const InternalNetworksUpdateAdministrativeStateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/l3IsolationDomains/{l3IsolationDomainName}/internalNetworks/{internalNetworkName}/updateAdministrativeState",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type InternalNetworksUpdateAdministrativeStateInput =
@@ -2818,6 +2834,7 @@ export const InternalNetworksUpdateBfdAdministrativeStateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/l3IsolationDomains/{l3IsolationDomainName}/internalNetworks/{internalNetworkName}/updateBfdAdministrativeState",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type InternalNetworksUpdateBfdAdministrativeStateInput =
@@ -2975,6 +2992,7 @@ export const InternalNetworksUpdateBgpAdministrativeStateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/l3IsolationDomains/{l3IsolationDomainName}/internalNetworks/{internalNetworkName}/updateBgpAdministrativeState",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type InternalNetworksUpdateBgpAdministrativeStateInput =
@@ -3132,6 +3150,7 @@ export const InternalNetworksUpdateStaticRouteBfdAdministrativeStateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/l3IsolationDomains/{l3IsolationDomainName}/internalNetworks/{internalNetworkName}/updateStaticRouteBfdAdministrativeState",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type InternalNetworksUpdateStaticRouteBfdAdministrativeStateInput =
@@ -3280,6 +3299,7 @@ export const InternetGatewayRulesCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/internetGatewayRules/{internetGatewayRuleName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type InternetGatewayRulesCreateInput =
@@ -3335,6 +3355,7 @@ export const InternetGatewayRulesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/internetGatewayRules/{internetGatewayRuleName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type InternetGatewayRulesDeleteInput =
@@ -3560,6 +3581,7 @@ export const InternetGatewayRulesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/internetGatewayRules/{internetGatewayRuleName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type InternetGatewayRulesUpdateInput =
@@ -3643,6 +3665,7 @@ export const InternetGatewaysCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/internetGateways/{internetGatewayName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type InternetGatewaysCreateInput =
@@ -3698,6 +3721,7 @@ export const InternetGatewaysDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/internetGateways/{internetGatewayName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type InternetGatewaysDeleteInput =
@@ -3924,6 +3948,7 @@ export const InternetGatewaysUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/internetGateways/{internetGatewayName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type InternetGatewaysUpdateInput =
@@ -4045,6 +4070,7 @@ export const IpCommunitiesCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/ipCommunities/{ipCommunityName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type IpCommunitiesCreateInput = typeof IpCommunitiesCreateInput.Type;
@@ -4096,6 +4122,7 @@ export const IpCommunitiesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/ipCommunities/{ipCommunityName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type IpCommunitiesDeleteInput = typeof IpCommunitiesDeleteInput.Type;
@@ -4337,6 +4364,7 @@ export const IpCommunitiesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/ipCommunities/{ipCommunityName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type IpCommunitiesUpdateInput = typeof IpCommunitiesUpdateInput.Type;
@@ -4443,6 +4471,7 @@ export const IpExtendedCommunitiesCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/ipExtendedCommunities/{ipExtendedCommunityName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type IpExtendedCommunitiesCreateInput =
@@ -4498,6 +4527,7 @@ export const IpExtendedCommunitiesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/ipExtendedCommunities/{ipExtendedCommunityName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type IpExtendedCommunitiesDeleteInput =
@@ -4737,6 +4767,7 @@ export const IpExtendedCommunitiesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/ipExtendedCommunities/{ipExtendedCommunityName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type IpExtendedCommunitiesUpdateInput =
@@ -4855,6 +4886,7 @@ export const IpPrefixesCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/ipPrefixes/{ipPrefixName}",
     apiVersion: "2025-07-15",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type IpPrefixesCreateInput = typeof IpPrefixesCreateInput.Type;
@@ -4906,6 +4938,7 @@ export const IpPrefixesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/ipPrefixes/{ipPrefixName}",
     apiVersion: "2025-07-15",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type IpPrefixesDeleteInput = typeof IpPrefixesDeleteInput.Type;
@@ -5142,6 +5175,7 @@ export const IpPrefixesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/ipPrefixes/{ipPrefixName}",
     apiVersion: "2025-07-15",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type IpPrefixesUpdateInput = typeof IpPrefixesUpdateInput.Type;
@@ -5194,6 +5228,7 @@ export const L2IsolationDomainsCommitConfigurationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/l2IsolationDomains/{l2IsolationDomainName}/commitConfiguration",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type L2IsolationDomainsCommitConfigurationInput =
@@ -5273,6 +5308,7 @@ export const L2IsolationDomainsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/l2IsolationDomains/{l2IsolationDomainName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type L2IsolationDomainsCreateInput =
@@ -5328,6 +5364,7 @@ export const L2IsolationDomainsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/l2IsolationDomains/{l2IsolationDomainName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type L2IsolationDomainsDeleteInput =
@@ -5578,6 +5615,7 @@ export const L2IsolationDomainsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/l2IsolationDomains/{l2IsolationDomainName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type L2IsolationDomainsUpdateInput =
@@ -5637,6 +5675,7 @@ export const L2IsolationDomainsUpdateAdministrativeStateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/l2IsolationDomains/{l2IsolationDomainName}/updateAdministrativeState",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type L2IsolationDomainsUpdateAdministrativeStateInput =
@@ -5779,6 +5818,7 @@ export const L2IsolationDomainsValidateConfigurationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/l2IsolationDomains/{l2IsolationDomainName}/validateConfiguration",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type L2IsolationDomainsValidateConfigurationInput =
@@ -5832,6 +5872,7 @@ export const L3IsolationDomainsCommitConfigurationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/l3IsolationDomains/{l3IsolationDomainName}/commitConfiguration",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type L3IsolationDomainsCommitConfigurationInput =
@@ -6024,6 +6065,7 @@ export const L3IsolationDomainsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/l3IsolationDomains/{l3IsolationDomainName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type L3IsolationDomainsCreateInput =
@@ -6079,6 +6121,7 @@ export const L3IsolationDomainsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/l3IsolationDomains/{l3IsolationDomainName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type L3IsolationDomainsDeleteInput =
@@ -6399,6 +6442,7 @@ export const L3IsolationDomainsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/l3IsolationDomains/{l3IsolationDomainName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type L3IsolationDomainsUpdateInput =
@@ -6458,6 +6502,7 @@ export const L3IsolationDomainsUpdateAdministrativeStateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/l3IsolationDomains/{l3IsolationDomainName}/updateAdministrativeState",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type L3IsolationDomainsUpdateAdministrativeStateInput =
@@ -6600,6 +6645,7 @@ export const L3IsolationDomainsValidateConfigurationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/l3IsolationDomains/{l3IsolationDomainName}/validateConfiguration",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type L3IsolationDomainsValidateConfigurationInput =
@@ -6718,6 +6764,7 @@ export const NeighborGroupsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/neighborGroups/{neighborGroupName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NeighborGroupsCreateInput = typeof NeighborGroupsCreateInput.Type;
@@ -6771,6 +6818,7 @@ export const NeighborGroupsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/neighborGroups/{neighborGroupName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NeighborGroupsDeleteInput = typeof NeighborGroupsDeleteInput.Type;
@@ -6990,6 +7038,7 @@ export const NeighborGroupsResyncInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/neighborGroups/{neighborGroupName}/resync",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NeighborGroupsResyncInput = typeof NeighborGroupsResyncInput.Type;
@@ -7158,6 +7207,7 @@ export const NeighborGroupsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/neighborGroups/{neighborGroupName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NeighborGroupsUpdateInput = typeof NeighborGroupsUpdateInput.Type;
@@ -7284,6 +7334,7 @@ export const NetworkBootstrapDevicesCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkBootstrapDevices/{networkBootstrapDeviceName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NetworkBootstrapDevicesCreateInput =
@@ -7338,6 +7389,7 @@ export const NetworkBootstrapDevicesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkBootstrapDevices/{networkBootstrapDeviceName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkBootstrapDevicesDeleteInput =
@@ -7561,6 +7613,7 @@ export const NetworkBootstrapDevicesRebootInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkBootstrapDevices/{networkBootstrapDeviceName}/reboot",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkBootstrapDevicesRebootInput =
@@ -7697,6 +7750,7 @@ export const NetworkBootstrapDevicesRefreshConfigurationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkBootstrapDevices/{networkBootstrapDeviceName}/refreshConfiguration",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkBootstrapDevicesRefreshConfigurationInput =
@@ -7833,6 +7887,7 @@ export const NetworkBootstrapDevicesResyncPasswordsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkBootstrapDevices/{networkBootstrapDeviceName}/resyncPasswords",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkBootstrapDevicesResyncPasswordsInput =
@@ -8000,6 +8055,7 @@ export const NetworkBootstrapDevicesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkBootstrapDevices/{networkBootstrapDeviceName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkBootstrapDevicesUpdateInput =
@@ -8068,6 +8124,7 @@ export const NetworkBootstrapDevicesUpdateAdministrativeStateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkBootstrapDevices/{networkBootstrapDeviceName}/updateAdministrativeState",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkBootstrapDevicesUpdateAdministrativeStateInput =
@@ -8205,6 +8262,7 @@ export const NetworkBootstrapDevicesUpgradeInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkBootstrapDevices/{networkBootstrapDeviceName}/upgrade",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkBootstrapDevicesUpgradeInput =
@@ -8345,6 +8403,7 @@ export const NetworkBootstrapInterfacesCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkBootstrapDevices/{networkBootstrapDeviceName}/networkBootstrapInterfaces/{networkBootstrapInterfaceName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NetworkBootstrapInterfacesCreateInput =
@@ -8401,6 +8460,7 @@ export const NetworkBootstrapInterfacesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkBootstrapDevices/{networkBootstrapDeviceName}/networkBootstrapInterfaces/{networkBootstrapInterfaceName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkBootstrapInterfacesDeleteInput =
@@ -8569,6 +8629,7 @@ export const NetworkBootstrapInterfacesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkBootstrapDevices/{networkBootstrapDeviceName}/networkBootstrapInterfaces/{networkBootstrapInterfaceName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkBootstrapInterfacesUpdateInput =
@@ -8629,6 +8690,7 @@ export const NetworkBootstrapInterfacesUpdateAdministrativeStateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkBootstrapDevices/{networkBootstrapDeviceName}/networkBootstrapInterfaces/{networkBootstrapInterfaceName}/updateAdministrativeState",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkBootstrapInterfacesUpdateAdministrativeStateInput =
@@ -8811,6 +8873,7 @@ export const NetworkDevicesCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkDevices/{networkDeviceName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NetworkDevicesCreateInput = typeof NetworkDevicesCreateInput.Type;
@@ -8864,6 +8927,7 @@ export const NetworkDevicesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkDevices/{networkDeviceName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkDevicesDeleteInput = typeof NetworkDevicesDeleteInput.Type;
@@ -9207,6 +9271,7 @@ export const NetworkDevicesRebootInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkDevices/{networkDeviceName}/reboot",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkDevicesRebootInput = typeof NetworkDevicesRebootInput.Type;
@@ -9296,6 +9361,7 @@ export const NetworkDevicesRefreshConfigurationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkDevices/{networkDeviceName}/refreshConfiguration",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkDevicesRefreshConfigurationInput =
@@ -9432,6 +9498,7 @@ export const NetworkDevicesResyncCertificatesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkDevices/{networkDeviceName}/resyncCertificates",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkDevicesResyncCertificatesInput =
@@ -9570,6 +9637,7 @@ export const NetworkDevicesResyncPasswordsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkDevices/{networkDeviceName}/resyncPasswords",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkDevicesResyncPasswordsInput =
@@ -9709,6 +9777,7 @@ export const NetworkDevicesRunRoCommandInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkDevices/{networkDeviceName}/runRoCommand",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkDevicesRunRoCommandInput =
@@ -9765,6 +9834,7 @@ export const NetworkDevicesRunRwCommandInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkDevices/{networkDeviceName}/runRwCommand",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkDevicesRunRwCommandInput =
@@ -9964,6 +10034,7 @@ export const NetworkDevicesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkDevices/{networkDeviceName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkDevicesUpdateInput = typeof NetworkDevicesUpdateInput.Type;
@@ -10031,6 +10102,7 @@ export const NetworkDevicesUpdateAdministrativeStateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkDevices/{networkDeviceName}/updateAdministrativeState",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkDevicesUpdateAdministrativeStateInput =
@@ -10169,6 +10241,7 @@ export const NetworkDevicesUpgradeInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkDevices/{networkDeviceName}/upgrade",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkDevicesUpgradeInput = typeof NetworkDevicesUpgradeInput.Type;
@@ -10390,6 +10463,7 @@ export const NetworkFabricControllersCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkFabricControllers/{networkFabricControllerName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NetworkFabricControllersCreateInput =
@@ -10444,6 +10518,7 @@ export const NetworkFabricControllersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkFabricControllers/{networkFabricControllerName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkFabricControllersDeleteInput =
@@ -10709,6 +10784,7 @@ export const NetworkFabricControllersUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkFabricControllers/{networkFabricControllerName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkFabricControllersUpdateInput =
@@ -10763,6 +10839,7 @@ export const NetworkFabricsArmConfigurationDiffInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkFabrics/{networkFabricName}/armConfigurationDiff",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkFabricsArmConfigurationDiffInput =
@@ -10905,6 +10982,7 @@ export const NetworkFabricsCommitBatchStatusInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkFabrics/{networkFabricName}/commitBatchStatus",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkFabricsCommitBatchStatusInput =
@@ -11059,6 +11137,7 @@ export const NetworkFabricsCommitConfigurationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkFabrics/{networkFabricName}/commitConfiguration",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkFabricsCommitConfigurationInput =
@@ -11221,6 +11300,7 @@ export const NetworkFabricsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkFabrics/{networkFabricName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NetworkFabricsCreateInput = typeof NetworkFabricsCreateInput.Type;
@@ -11274,6 +11354,7 @@ export const NetworkFabricsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkFabrics/{networkFabricName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkFabricsDeleteInput = typeof NetworkFabricsDeleteInput.Type;
@@ -11309,6 +11390,7 @@ export const NetworkFabricsDeprovisionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkFabrics/{networkFabricName}/deprovision",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkFabricsDeprovisionInput =
@@ -11401,6 +11483,7 @@ export const NetworkFabricsDiscardCommitBatchInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkFabrics/{networkFabricName}/discardCommitBatch",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkFabricsDiscardCommitBatchInput =
@@ -11594,6 +11677,7 @@ export const NetworkFabricsGetTopologyInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkFabrics/{networkFabricName}/getTopology",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkFabricsGetTopologyInput =
@@ -11988,6 +12072,7 @@ export const NetworkFabricsLockFabricInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkFabrics/{networkFabricName}/lockFabric",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkFabricsLockFabricInput =
@@ -12079,6 +12164,7 @@ export const NetworkFabricsProvisionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkFabrics/{networkFabricName}/provision",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkFabricsProvisionInput =
@@ -12170,6 +12256,7 @@ export const NetworkFabricsRefreshConfigurationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkFabrics/{networkFabricName}/refreshConfiguration",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkFabricsRefreshConfigurationInput =
@@ -12260,6 +12347,7 @@ export const NetworkFabricsResyncCertificatesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkFabrics/{networkFabricName}/resyncCertificates",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkFabricsResyncCertificatesInput =
@@ -12398,6 +12486,7 @@ export const NetworkFabricsResyncPasswordsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkFabrics/{networkFabricName}/resyncPasswords",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkFabricsResyncPasswordsInput =
@@ -12537,6 +12626,7 @@ export const NetworkFabricsRotateCertificatesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkFabrics/{networkFabricName}/rotateCertificates",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkFabricsRotateCertificatesInput =
@@ -12675,6 +12765,7 @@ export const NetworkFabricsRotatePasswordsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkFabrics/{networkFabricName}/rotatePasswords",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkFabricsRotatePasswordsInput =
@@ -12997,6 +13088,7 @@ export const NetworkFabricsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkFabrics/{networkFabricName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkFabricsUpdateInput = typeof NetworkFabricsUpdateInput.Type;
@@ -13054,6 +13146,7 @@ export const NetworkFabricsUpdateInfraManagementBfdConfigurationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkFabrics/{networkFabricName}/updateInfraManagementBfdConfiguration",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkFabricsUpdateInfraManagementBfdConfigurationInput =
@@ -13200,6 +13293,7 @@ export const NetworkFabricsUpdateWorkloadManagementBfdConfigurationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkFabrics/{networkFabricName}/updateWorkloadManagementBfdConfiguration",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkFabricsUpdateWorkloadManagementBfdConfigurationInput =
@@ -13344,6 +13438,7 @@ export const NetworkFabricsUpgradeInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkFabrics/{networkFabricName}/upgrade",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkFabricsUpgradeInput = typeof NetworkFabricsUpgradeInput.Type;
@@ -13437,6 +13532,7 @@ export const NetworkFabricsValidateConfigurationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkFabrics/{networkFabricName}/validateConfiguration",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkFabricsValidateConfigurationInput =
@@ -13490,6 +13586,7 @@ export const NetworkFabricsViewDeviceConfigurationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkFabrics/{networkFabricName}/viewDeviceConfiguration",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkFabricsViewDeviceConfigurationInput =
@@ -13656,6 +13753,7 @@ export const NetworkInterfacesCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkDevices/{networkDeviceName}/networkInterfaces/{networkInterfaceName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NetworkInterfacesCreateInput =
@@ -13713,6 +13811,7 @@ export const NetworkInterfacesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkDevices/{networkDeviceName}/networkInterfaces/{networkInterfaceName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkInterfacesDeleteInput =
@@ -13902,6 +14001,7 @@ export const NetworkInterfacesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkDevices/{networkDeviceName}/networkInterfaces/{networkInterfaceName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkInterfacesUpdateInput =
@@ -13963,6 +14063,7 @@ export const NetworkInterfacesUpdateAdministrativeStateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkDevices/{networkDeviceName}/networkInterfaces/{networkInterfaceName}/updateAdministrativeState",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkInterfacesUpdateAdministrativeStateInput =
@@ -14111,6 +14212,7 @@ export const NetworkMonitorsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkMonitors/{networkMonitorName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NetworkMonitorsCreateInput = typeof NetworkMonitorsCreateInput.Type;
@@ -14165,6 +14267,7 @@ export const NetworkMonitorsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkMonitors/{networkMonitorName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkMonitorsDeleteInput = typeof NetworkMonitorsDeleteInput.Type;
@@ -14440,6 +14543,7 @@ export const NetworkMonitorsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkMonitors/{networkMonitorName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkMonitorsUpdateInput = typeof NetworkMonitorsUpdateInput.Type;
@@ -14498,6 +14602,7 @@ export const NetworkMonitorsUpdateAdministrativeStateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkMonitors/{networkMonitorName}/updateAdministrativeState",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkMonitorsUpdateAdministrativeStateInput =
@@ -14613,6 +14718,7 @@ export const NetworkPacketBrokersCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkPacketBrokers/{networkPacketBrokerName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NetworkPacketBrokersCreateInput =
@@ -14668,6 +14774,7 @@ export const NetworkPacketBrokersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkPacketBrokers/{networkPacketBrokerName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkPacketBrokersDeleteInput =
@@ -14914,6 +15021,7 @@ export const NetworkPacketBrokersUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkPacketBrokers/{networkPacketBrokerName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkPacketBrokersUpdateInput =
@@ -14974,6 +15082,7 @@ export const NetworkRacksCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkRacks/{networkRackName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NetworkRacksCreateInput = typeof NetworkRacksCreateInput.Type;
@@ -15025,6 +15134,7 @@ export const NetworkRacksDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkRacks/{networkRackName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkRacksDeleteInput = typeof NetworkRacksDeleteInput.Type;
@@ -15239,6 +15349,7 @@ export const NetworkRacksUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkRacks/{networkRackName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkRacksUpdateInput = typeof NetworkRacksUpdateInput.Type;
@@ -15481,6 +15592,7 @@ export const NetworkTapRulesCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkTapRules/{networkTapRuleName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NetworkTapRulesCreateInput = typeof NetworkTapRulesCreateInput.Type;
@@ -15535,6 +15647,7 @@ export const NetworkTapRulesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkTapRules/{networkTapRuleName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkTapRulesDeleteInput = typeof NetworkTapRulesDeleteInput.Type;
@@ -15754,6 +15867,7 @@ export const NetworkTapRulesResyncInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkTapRules/{networkTapRuleName}/resync",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkTapRulesResyncInput = typeof NetworkTapRulesResyncInput.Type;
@@ -16039,6 +16153,7 @@ export const NetworkTapRulesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkTapRules/{networkTapRuleName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkTapRulesUpdateInput = typeof NetworkTapRulesUpdateInput.Type;
@@ -16097,6 +16212,7 @@ export const NetworkTapRulesUpdateAdministrativeStateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkTapRules/{networkTapRuleName}/updateAdministrativeState",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkTapRulesUpdateAdministrativeStateInput =
@@ -16150,6 +16266,7 @@ export const NetworkTapRulesValidateConfigurationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkTapRules/{networkTapRuleName}/validateConfiguration",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkTapRulesValidateConfigurationInput =
@@ -16230,6 +16347,7 @@ export const NetworkTapsCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkTaps/{networkTapName}",
     apiVersion: "2025-07-15",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type NetworkTapsCreateInput = typeof NetworkTapsCreateInput.Type;
@@ -16282,6 +16400,7 @@ export const NetworkTapsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkTaps/{networkTapName}",
     apiVersion: "2025-07-15",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type NetworkTapsDeleteInput = typeof NetworkTapsDeleteInput.Type;
@@ -16496,6 +16615,7 @@ export const NetworkTapsResyncInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkTaps/{networkTapName}/resync",
     apiVersion: "2025-07-15",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type NetworkTapsResyncInput = typeof NetworkTapsResyncInput.Type;
@@ -16657,6 +16777,7 @@ export const NetworkTapsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkTaps/{networkTapName}",
     apiVersion: "2025-07-15",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type NetworkTapsUpdateInput = typeof NetworkTapsUpdateInput.Type;
@@ -16712,6 +16833,7 @@ export const NetworkTapsUpdateAdministrativeStateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkTaps/{networkTapName}/updateAdministrativeState",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkTapsUpdateAdministrativeStateInput =
@@ -17009,6 +17131,7 @@ export const NetworkToNetworkInterconnectsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkFabrics/{networkFabricName}/networkToNetworkInterconnects/{networkToNetworkInterconnectName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NetworkToNetworkInterconnectsCreateInput =
@@ -17065,6 +17188,7 @@ export const NetworkToNetworkInterconnectsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkFabrics/{networkFabricName}/networkToNetworkInterconnects/{networkToNetworkInterconnectName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkToNetworkInterconnectsDeleteInput =
@@ -17337,6 +17461,7 @@ export const NetworkToNetworkInterconnectsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkFabrics/{networkFabricName}/networkToNetworkInterconnects/{networkToNetworkInterconnectName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkToNetworkInterconnectsUpdateInput =
@@ -17397,6 +17522,7 @@ export const NetworkToNetworkInterconnectsUpdateAdministrativeStateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkFabrics/{networkFabricName}/networkToNetworkInterconnects/{networkToNetworkInterconnectName}/updateAdministrativeState",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkToNetworkInterconnectsUpdateAdministrativeStateInput =
@@ -17545,6 +17671,7 @@ export const NetworkToNetworkInterconnectsUpdateBfdAdministrativeStateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkFabrics/{networkFabricName}/networkToNetworkInterconnects/{networkToNetworkInterconnectName}/updateBfdAdministrativeState",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkToNetworkInterconnectsUpdateBfdAdministrativeStateInput =
@@ -17696,6 +17823,7 @@ export const NetworkToNetworkInterconnectsUpdateNpbStaticRouteBfdAdministrativeS
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/networkFabrics/{networkFabricName}/networkToNetworkInterconnects/{networkToNetworkInterconnectName}/updateNpbStaticRouteBfdAdministrativeState",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkToNetworkInterconnectsUpdateNpbStaticRouteBfdAdministrativeStateInput =
@@ -17889,6 +18017,7 @@ export const RoutePoliciesCommitConfigurationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/routePolicies/{routePolicyName}/commitConfiguration",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RoutePoliciesCommitConfigurationInput =
@@ -17997,6 +18126,7 @@ export const RoutePoliciesCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/routePolicies/{routePolicyName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type RoutePoliciesCreateInput = typeof RoutePoliciesCreateInput.Type;
@@ -18048,6 +18178,7 @@ export const RoutePoliciesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/routePolicies/{routePolicyName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RoutePoliciesDeleteInput = typeof RoutePoliciesDeleteInput.Type;
@@ -18277,6 +18408,7 @@ export const RoutePoliciesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/routePolicies/{routePolicyName}",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RoutePoliciesUpdateInput = typeof RoutePoliciesUpdateInput.Type;
@@ -18332,6 +18464,7 @@ export const RoutePoliciesUpdateAdministrativeStateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/routePolicies/{routePolicyName}/updateAdministrativeState",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RoutePoliciesUpdateAdministrativeStateInput =
@@ -18474,6 +18607,7 @@ export const RoutePoliciesValidateConfigurationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedNetworkFabric/routePolicies/{routePolicyName}/validateConfiguration",
       apiVersion: "2025-07-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RoutePoliciesValidateConfigurationInput =

--- a/packages/azure/src/services/managedservices.ts
+++ b/packages/azure/src/services/managedservices.ts
@@ -593,6 +593,7 @@ export const RegistrationAssignmentsCreateOrUpdateInput =
       method: "PUT",
       path: "/{scope}/providers/Microsoft.ManagedServices/registrationAssignments/{registrationAssignmentId}",
       apiVersion: "2022-10-01",
+      longRunning: {},
     }),
   );
 export type RegistrationAssignmentsCreateOrUpdateInput =
@@ -766,6 +767,7 @@ export const RegistrationAssignmentsDeleteInput =
       method: "DELETE",
       path: "/{scope}/providers/Microsoft.ManagedServices/registrationAssignments/{registrationAssignmentId}",
       apiVersion: "2022-10-01",
+      longRunning: {},
     }),
   );
 export type RegistrationAssignmentsDeleteInput =
@@ -1249,6 +1251,7 @@ export const RegistrationDefinitionsCreateOrUpdateInput =
       method: "PUT",
       path: "/{scope}/providers/Microsoft.ManagedServices/registrationDefinitions/{registrationDefinitionId}",
       apiVersion: "2022-10-01",
+      longRunning: {},
     }),
   );
 export type RegistrationDefinitionsCreateOrUpdateInput =

--- a/packages/azure/src/services/management.ts
+++ b/packages/azure/src/services/management.ts
@@ -442,6 +442,7 @@ export const ManagementGroupsCreateOrUpdateInput =
       method: "PUT",
       path: "/providers/Microsoft.Management/managementGroups/{groupId}",
       apiVersion: "2023-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ManagementGroupsCreateOrUpdateInput =
@@ -494,6 +495,7 @@ export const ManagementGroupsDeleteInput =
       method: "DELETE",
       path: "/providers/Microsoft.Management/managementGroups/{groupId}",
       apiVersion: "2023-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ManagementGroupsDeleteInput =

--- a/packages/azure/src/services/manufacturingplatform.ts
+++ b/packages/azure/src/services/manufacturingplatform.ts
@@ -175,6 +175,7 @@ export const ManufacturingDataServicesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManufacturingPlatform/manufacturingDataServices/{mdsResourceName}",
       apiVersion: "2025-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ManufacturingDataServicesCreateOrUpdateInput =
@@ -229,6 +230,7 @@ export const ManufacturingDataServicesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManufacturingPlatform/manufacturingDataServices/{mdsResourceName}",
       apiVersion: "2025-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManufacturingDataServicesDeleteInput =
@@ -572,6 +574,7 @@ export const ManufacturingDataServicesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManufacturingPlatform/manufacturingDataServices/{mdsResourceName}",
       apiVersion: "2025-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManufacturingDataServicesUpdateInput =

--- a/packages/azure/src/services/mariadb.ts
+++ b/packages/azure/src/services/mariadb.ts
@@ -17,6 +17,7 @@ export const ServersStartInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforMariaDB/servers/{serverName}/start",
     apiVersion: "2020-01-01",
+    longRunning: {},
   }),
 );
 export type ServersStartInput = typeof ServersStartInput.Type;
@@ -46,6 +47,7 @@ export const ServersStopInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforMariaDB/servers/{serverName}/stop",
     apiVersion: "2020-01-01",
+    longRunning: {},
   }),
 );
 export type ServersStopInput = typeof ServersStopInput.Type;

--- a/packages/azure/src/services/migrate.ts
+++ b/packages/azure/src/services/migrate.ts
@@ -34,6 +34,7 @@ export const AksAssessmentOperationsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Migrate/assessmentProjects/{projectName}/aksAssessments/{assessmentName}",
       apiVersion: "2024-01-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AksAssessmentOperationsCreateInput =
@@ -128,6 +129,7 @@ export const AksAssessmentOperationsDownloadUrlInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Migrate/assessmentProjects/{projectName}/aksAssessments/{assessmentName}/downloadUrl",
       apiVersion: "2024-01-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AksAssessmentOperationsDownloadUrlInput =
@@ -1890,6 +1892,7 @@ export const AssessmentProjectsOperationsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Migrate/assessmentProjects/{projectName}",
       apiVersion: "2024-01-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AssessmentProjectsOperationsCreateInput =
@@ -2188,6 +2191,7 @@ export const AssessmentProjectsOperationsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Migrate/assessmentProjects/{projectName}",
       apiVersion: "2024-01-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AssessmentProjectsOperationsUpdateInput =
@@ -2385,6 +2389,7 @@ export const AssessmentsOperationsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Migrate/assessmentProjects/{projectName}/groups/{groupName}/assessments/{assessmentName}",
       apiVersion: "2024-01-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AssessmentsOperationsCreateInput =
@@ -2485,6 +2490,7 @@ export const AssessmentsOperationsDownloadUrlInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Migrate/assessmentProjects/{projectName}/groups/{groupName}/assessments/{assessmentName}/downloadUrl",
       apiVersion: "2024-01-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AssessmentsOperationsDownloadUrlInput =
@@ -2941,6 +2947,7 @@ export const AvsAssessmentsOperationsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Migrate/assessmentProjects/{projectName}/groups/{groupName}/avsAssessments/{assessmentName}",
       apiVersion: "2024-01-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AvsAssessmentsOperationsCreateInput =
@@ -3039,6 +3046,7 @@ export const AvsAssessmentsOperationsDownloadUrlInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Migrate/assessmentProjects/{projectName}/groups/{groupName}/avsAssessments/{assessmentName}/downloadUrl",
       apiVersion: "2024-01-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AvsAssessmentsOperationsDownloadUrlInput =
@@ -3513,6 +3521,7 @@ export const DependencyMapControllerClientGroupMembersInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/vmwareSites/{siteName}/clientGroupMembers",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DependencyMapControllerClientGroupMembersInput =
@@ -3551,6 +3560,7 @@ export const DependencyMapControllerExportDependenciesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/vmwareSites/{siteName}/exportDependencies",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DependencyMapControllerExportDependenciesInput =
@@ -3595,6 +3605,7 @@ export const DependencyMapControllerGenerateCoarseMapInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/vmwareSites/{siteName}/generateCoarseMap",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DependencyMapControllerGenerateCoarseMapInput =
@@ -3640,6 +3651,7 @@ export const DependencyMapControllerGenerateDetailedMapInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/vmwareSites/{siteName}/generateDetailedMap",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DependencyMapControllerGenerateDetailedMapInput =
@@ -3685,6 +3697,7 @@ export const DependencyMapControllerServerGroupMembersInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/vmwareSites/{siteName}/serverGroupMembers",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DependencyMapControllerServerGroupMembersInput =
@@ -3881,6 +3894,7 @@ export const GroupsOperationsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Migrate/assessmentProjects/{projectName}/groups/{groupName}",
       apiVersion: "2024-01-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type GroupsOperationsCreateInput =
@@ -4106,6 +4120,7 @@ export const GroupsOperationsUpdateMachinesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Migrate/assessmentProjects/{projectName}/groups/{groupName}/updateMachines",
       apiVersion: "2024-01-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type GroupsOperationsUpdateMachinesInput =
@@ -4221,6 +4236,7 @@ export const HypervClusterControllerCreateClusterInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/hypervSites/{siteName}/clusters/{clusterName}",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type HypervClusterControllerCreateClusterInput =
@@ -4457,6 +4473,7 @@ export const HypervCollectorsOperationsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Migrate/assessmentProjects/{projectName}/hypervcollectors/{hypervCollectorName}",
       apiVersion: "2024-01-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type HypervCollectorsOperationsCreateInput =
@@ -4686,6 +4703,7 @@ export const HypervDependencyMapControllerClientGroupMembersInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/hypervSites/{siteName}/clientGroupMembers",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type HypervDependencyMapControllerClientGroupMembersInput =
@@ -4724,6 +4742,7 @@ export const HypervDependencyMapControllerExportDependenciesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/hypervSites/{siteName}/exportDependencies",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type HypervDependencyMapControllerExportDependenciesInput =
@@ -4768,6 +4787,7 @@ export const HypervDependencyMapControllerGenerateCoarseMapInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/hypervSites/{siteName}/generateCoarseMap",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type HypervDependencyMapControllerGenerateCoarseMapInput =
@@ -4813,6 +4833,7 @@ export const HypervDependencyMapControllerGenerateDetailedMapInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/hypervSites/{siteName}/generateDetailedMap",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type HypervDependencyMapControllerGenerateDetailedMapInput =
@@ -4858,6 +4879,7 @@ export const HypervDependencyMapControllerServerGroupMembersInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/hypervSites/{siteName}/serverGroupMembers",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type HypervDependencyMapControllerServerGroupMembersInput =
@@ -4902,6 +4924,7 @@ export const HypervDependencyMapControllerUpdateDependencyMapStatusInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/hypervSites/{siteName}/updateDependencyMapStatus",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type HypervDependencyMapControllerUpdateDependencyMapStatusInput =
@@ -4995,6 +5018,7 @@ export const HypervHostControllerCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/hypervSites/{siteName}/hosts/{hostName}",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type HypervHostControllerCreateInput =
@@ -5052,6 +5076,7 @@ export const HypervHostControllerDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/hypervSites/{siteName}/hosts/{hostName}",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type HypervHostControllerDeleteInput =
@@ -5702,6 +5727,7 @@ export const HypervMachinesControllerUpdatePropertiesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/hypervSites/{siteName}/updateProperties",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type HypervMachinesControllerUpdatePropertiesInput =
@@ -6142,6 +6168,7 @@ export const HypervSitesControllerExportApplicationsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/hypervSites/{siteName}/exportApplications",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type HypervSitesControllerExportApplicationsInput =
@@ -6191,6 +6218,7 @@ export const HypervSitesControllerExportMachineErrorsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/hypervSites/{siteName}/exportMachineErrors",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type HypervSitesControllerExportMachineErrorsInput =
@@ -7099,6 +7127,7 @@ export const ImportCollectorsOperationsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Migrate/assessmentProjects/{projectName}/importcollectors/{importCollectorName}",
       apiVersion: "2024-01-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ImportCollectorsOperationsCreateInput =
@@ -8873,6 +8902,7 @@ export const MachinesControllerStartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/vmwareSites/{siteName}/machines/{machineName}/start",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type MachinesControllerStartInput =
@@ -8912,6 +8942,7 @@ export const MachinesControllerStopInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/vmwareSites/{siteName}/machines/{machineName}/stop",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type MachinesControllerStopInput =
@@ -9237,6 +9268,7 @@ export const MasterSitesControllerCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/masterSites/{siteName}",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type MasterSitesControllerCreateInput =
@@ -9583,6 +9615,7 @@ export const MasterSitesControllerUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/masterSites/{siteName}",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type MasterSitesControllerUpdateInput =
@@ -11569,6 +11602,7 @@ export const PrivateEndpointConnectionOperationsUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Migrate/assessmentProjects/{projectName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2024-01-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PrivateEndpointConnectionOperationsUpdateInput =
@@ -13471,6 +13505,7 @@ export const ServerCollectorsOperationsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Migrate/assessmentProjects/{projectName}/servercollectors/{serverCollectorName}",
       apiVersion: "2024-01-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ServerCollectorsOperationsCreateInput =
@@ -13700,6 +13735,7 @@ export const ServerDependencyMapControllerClientGroupMembersInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/serverSites/{siteName}/clientGroupMembers",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServerDependencyMapControllerClientGroupMembersInput =
@@ -13738,6 +13774,7 @@ export const ServerDependencyMapControllerExportDependenciesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/serverSites/{siteName}/exportDependencies",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServerDependencyMapControllerExportDependenciesInput =
@@ -13782,6 +13819,7 @@ export const ServerDependencyMapControllerGenerateCoarseMapInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/serverSites/{siteName}/generateCoarseMap",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServerDependencyMapControllerGenerateCoarseMapInput =
@@ -13827,6 +13865,7 @@ export const ServerDependencyMapControllerGenerateDetailedMapInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/serverSites/{siteName}/generateDetailedMap",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServerDependencyMapControllerGenerateDetailedMapInput =
@@ -13872,6 +13911,7 @@ export const ServerDependencyMapControllerServerGroupMembersInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/serverSites/{siteName}/serverGroupMembers",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServerDependencyMapControllerServerGroupMembersInput =
@@ -14650,6 +14690,7 @@ export const ServerSitesControllerCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/serverSites/{siteName}",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServerSitesControllerCreateInput =
@@ -14742,6 +14783,7 @@ export const ServerSitesControllerExportApplicationsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/serverSites/{siteName}/exportApplications",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServerSitesControllerExportApplicationsInput =
@@ -14791,6 +14833,7 @@ export const ServerSitesControllerExportMachineErrorsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/serverSites/{siteName}/exportMachineErrors",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServerSitesControllerExportMachineErrorsInput =
@@ -15077,6 +15120,7 @@ export const ServerSitesControllerRefreshSiteInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/serverSites/{siteName}/refreshSite",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServerSitesControllerRefreshSiteInput =
@@ -15241,6 +15285,7 @@ export const ServerSitesControllerUpdateDependencyMapStatusInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/serverSites/{siteName}/updateDependencyMapStatus",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServerSitesControllerUpdateDependencyMapStatusInput =
@@ -15285,6 +15330,7 @@ export const ServerSitesControllerUpdatePropertiesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/serverSites/{siteName}/updateProperties",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServerSitesControllerUpdatePropertiesInput =
@@ -15673,6 +15719,7 @@ export const SitesControllerExportApplicationsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/vmwareSites/{siteName}/exportApplications",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SitesControllerExportApplicationsInput =
@@ -15722,6 +15769,7 @@ export const SitesControllerExportMachineErrorsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/vmwareSites/{siteName}/exportMachineErrors",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SitesControllerExportMachineErrorsInput =
@@ -15760,6 +15808,7 @@ export const SitesControllerExportMachinesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/vmwareSites/{siteName}/exportMachines",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SitesControllerExportMachinesInput =
@@ -17015,6 +17064,7 @@ export const SqlAssessmentV2OperationsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Migrate/assessmentProjects/{projectName}/groups/{groupName}/sqlAssessments/{assessmentName}",
       apiVersion: "2024-01-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SqlAssessmentV2OperationsCreateInput =
@@ -17113,6 +17163,7 @@ export const SqlAssessmentV2OperationsDownloadUrlInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Migrate/assessmentProjects/{projectName}/groups/{groupName}/sqlAssessments/{assessmentName}/downloadUrl",
       apiVersion: "2024-01-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SqlAssessmentV2OperationsDownloadUrlInput =
@@ -17571,6 +17622,7 @@ export const SqlCollectorOperationsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Migrate/assessmentProjects/{projectName}/sqlcollectors/{collectorName}",
       apiVersion: "2024-01-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SqlCollectorOperationsCreateInput =
@@ -17946,6 +17998,7 @@ export const SqlDiscoverySiteDataSourceControllerCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/masterSites/{siteName}/sqlSites/{sqlSiteName}/discoverySiteDataSources/{discoverySiteDataSourceName}",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SqlDiscoverySiteDataSourceControllerCreateInput =
@@ -18971,6 +19024,7 @@ export const SqlSitesControllerExportSqlServerErrorsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/masterSites/{siteName}/sqlSites/{sqlSiteName}/exportSqlServerErrors",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SqlSitesControllerExportSqlServerErrorsInput =
@@ -19011,6 +19065,7 @@ export const SqlSitesControllerExportSqlServersInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/masterSites/{siteName}/sqlSites/{sqlSiteName}/exportSqlServers",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SqlSitesControllerExportSqlServersInput =
@@ -19175,6 +19230,7 @@ export const SqlSitesControllerRefreshInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/masterSites/{siteName}/sqlSites/{sqlSiteName}/refresh",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SqlSitesControllerRefreshInput =
@@ -19288,6 +19344,7 @@ export const SqlSitesControllerUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/masterSites/{siteName}/sqlSites/{sqlSiteName}",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SqlSitesControllerUpdateInput =
@@ -19736,6 +19793,7 @@ export const VcenterControllerCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/vmwareSites/{siteName}/vcenters/{vcenterName}",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VcenterControllerCreateInput =
@@ -20140,6 +20198,7 @@ export const VmwareCollectorsOperationsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Migrate/assessmentProjects/{projectName}/vmwarecollectors/{vmWareCollectorName}",
       apiVersion: "2024-01-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VmwareCollectorsOperationsCreateInput =
@@ -20547,6 +20606,7 @@ export const VmwarePropertiesControllerUpdateDependencyMapStatusInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/vmwareSites/{siteName}/updateDependencyMapStatus",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VmwarePropertiesControllerUpdateDependencyMapStatusInput =
@@ -20592,6 +20652,7 @@ export const VmwarePropertiesControllerUpdatePropertiesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/vmwareSites/{siteName}/updateProperties",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VmwarePropertiesControllerUpdatePropertiesInput =
@@ -20636,6 +20697,7 @@ export const VmwarePropertiesControllerUpdateRunAsAccountInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/vmwareSites/{siteName}/updateRunAsAccount",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VmwarePropertiesControllerUpdateRunAsAccountInput =
@@ -20681,6 +20743,7 @@ export const VmwarePropertiesControllerUpdateTagsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/vmwareSites/{siteName}/updateTags",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VmwarePropertiesControllerUpdateTagsInput =
@@ -20993,6 +21056,7 @@ export const WebAppAssessmentV2OperationsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Migrate/assessmentProjects/{projectName}/groups/{groupName}/webAppAssessments/{assessmentName}",
       apiVersion: "2024-01-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type WebAppAssessmentV2OperationsCreateInput =
@@ -21091,6 +21155,7 @@ export const WebAppAssessmentV2OperationsDownloadUrlInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Migrate/assessmentProjects/{projectName}/groups/{groupName}/webAppAssessments/{assessmentName}/downloadUrl",
       apiVersion: "2024-01-15",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppAssessmentV2OperationsDownloadUrlInput =
@@ -21414,6 +21479,7 @@ export const WebAppCollectorOperationsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Migrate/assessmentProjects/{projectName}/webAppCollectors/{collectorName}",
       apiVersion: "2024-01-15",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type WebAppCollectorOperationsCreateInput =
@@ -21650,6 +21716,7 @@ export const WebAppDiscoverySiteDataSourcesControllerCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/masterSites/{siteName}/webAppSites/{webAppSiteName}/discoverySiteDataSources/{discoverySiteDataSourceName}",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppDiscoverySiteDataSourcesControllerCreateInput =
@@ -21708,6 +21775,7 @@ export const WebAppDiscoverySiteDataSourcesControllerDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/masterSites/{siteName}/webAppSites/{webAppSiteName}/discoverySiteDataSources/{discoverySiteDataSourceName}",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppDiscoverySiteDataSourcesControllerDeleteInput =
@@ -22101,6 +22169,7 @@ export const WebAppPropertiesControllerUpdatePropertiesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/masterSites/{siteName}/webAppSites/{webAppSiteName}/updateProperties",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppPropertiesControllerUpdatePropertiesInput =
@@ -22510,6 +22579,7 @@ export const WebAppSitesControllerDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/masterSites/{siteName}/webAppSites/{webAppSiteName}",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppSitesControllerDeleteInput =
@@ -22602,6 +22672,7 @@ export const WebAppSitesControllerExportInventoryInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/masterSites/{siteName}/webAppSites/{webAppSiteName}/exportInventory",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppSitesControllerExportInventoryInput =
@@ -22767,6 +22838,7 @@ export const WebAppSitesControllerRefreshInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/masterSites/{siteName}/webAppSites/{webAppSiteName}/refresh",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppSitesControllerRefreshInput =
@@ -22878,6 +22950,7 @@ export const WebAppSitesControllerUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OffAzure/masterSites/{siteName}/webAppSites/{webAppSiteName}",
       apiVersion: "2023-06-06",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppSitesControllerUpdateInput =

--- a/packages/azure/src/services/mongocluster.ts
+++ b/packages/azure/src/services/mongocluster.ts
@@ -37,6 +37,7 @@ export const FirewallRulesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/mongoClusters/{mongoClusterName}/firewallRules/{firewallRuleName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type FirewallRulesCreateOrUpdateInput =
@@ -94,6 +95,7 @@ export const FirewallRulesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/mongoClusters/{mongoClusterName}/firewallRules/{firewallRuleName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type FirewallRulesDeleteInput = typeof FirewallRulesDeleteInput.Type;
@@ -491,6 +493,7 @@ export const MongoClustersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/mongoClusters/{mongoClusterName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type MongoClustersCreateOrUpdateInput =
@@ -546,6 +549,7 @@ export const MongoClustersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/mongoClusters/{mongoClusterName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type MongoClustersDeleteInput = typeof MongoClustersDeleteInput.Type;
@@ -808,6 +812,7 @@ export const MongoClustersPromoteInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/mongoClusters/{mongoClusterName}/promote",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type MongoClustersPromoteInput = typeof MongoClustersPromoteInput.Type;
@@ -947,6 +952,7 @@ export const MongoClustersUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/mongoClusters/{mongoClusterName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type MongoClustersUpdateInput = typeof MongoClustersUpdateInput.Type;
@@ -1067,6 +1073,7 @@ export const PrivateEndpointConnectionsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/mongoClusters/{mongoClusterName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PrivateEndpointConnectionsCreateInput =
@@ -1123,6 +1130,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/mongoClusters/{mongoClusterName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =
@@ -1450,6 +1458,7 @@ export const UsersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/mongoClusters/{mongoClusterName}/users/{userName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type UsersCreateOrUpdateInput = typeof UsersCreateOrUpdateInput.Type;
@@ -1502,6 +1511,7 @@ export const UsersDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/mongoClusters/{mongoClusterName}/users/{userName}",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type UsersDeleteInput = typeof UsersDeleteInput.Type;

--- a/packages/azure/src/services/monitor.ts
+++ b/packages/azure/src/services/monitor.ts
@@ -265,6 +265,7 @@ export const PipelineGroupsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Monitor/pipelineGroups/{pipelineGroupName}",
       apiVersion: "2026-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PipelineGroupsCreateOrUpdateInput =
@@ -319,6 +320,7 @@ export const PipelineGroupsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Monitor/pipelineGroups/{pipelineGroupName}",
       apiVersion: "2026-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PipelineGroupsDeleteInput = typeof PipelineGroupsDeleteInput.Type;
@@ -730,6 +732,7 @@ export const PipelineGroupsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Monitor/pipelineGroups/{pipelineGroupName}",
       apiVersion: "2026-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PipelineGroupsUpdateInput = typeof PipelineGroupsUpdateInput.Type;

--- a/packages/azure/src/services/monitoringservice.ts
+++ b/packages/azure/src/services/monitoringservice.ts
@@ -135,6 +135,7 @@ export const AzureMonitorWorkspacesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Monitor/accounts/{azureMonitorWorkspaceName}",
       apiVersion: "2023-04-03",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AzureMonitorWorkspacesDeleteInput =

--- a/packages/azure/src/services/mysql.ts
+++ b/packages/azure/src/services/mysql.ts
@@ -157,6 +157,7 @@ export const AdvancedThreatProtectionSettingsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforMySQL/flexibleServers/{serverName}/advancedThreatProtectionSettings/{advancedThreatProtectionName}",
       apiVersion: "2024-12-30",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AdvancedThreatProtectionSettingsUpdateInput =
@@ -224,6 +225,7 @@ export const AdvancedThreatProtectionSettingsUpdatePutInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforMySQL/flexibleServers/{serverName}/advancedThreatProtectionSettings/{advancedThreatProtectionName}",
       apiVersion: "2024-12-30",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AdvancedThreatProtectionSettingsUpdatePutInput =
@@ -291,6 +293,7 @@ export const AzureADAdministratorsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforMySQL/flexibleServers/{serverName}/administrators/{administratorName}",
       apiVersion: "2024-12-30",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type AzureADAdministratorsCreateOrUpdateInput =
@@ -347,6 +350,7 @@ export const AzureADAdministratorsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforMySQL/flexibleServers/{serverName}/administrators/{administratorName}",
       apiVersion: "2024-12-30",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AzureADAdministratorsDeleteInput =
@@ -520,6 +524,7 @@ export const BackupAndExportCreateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforMySQL/flexibleServers/{serverName}/backupAndExport",
       apiVersion: "2024-12-30",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BackupAndExportCreateInput = typeof BackupAndExportCreateInput.Type;
@@ -920,6 +925,7 @@ export const ConfigurationsBatchUpdateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforMySQL/flexibleServers/{serverName}/updateConfigurations",
       apiVersion: "2024-12-30",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ConfigurationsBatchUpdateInput =
@@ -1012,6 +1018,7 @@ export const ConfigurationsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforMySQL/flexibleServers/{serverName}/configurations/{configurationName}",
       apiVersion: "2024-12-30",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type ConfigurationsCreateOrUpdateInput =
@@ -1221,6 +1228,7 @@ export const ConfigurationsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforMySQL/flexibleServers/{serverName}/configurations/{configurationName}",
       apiVersion: "2024-12-30",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type ConfigurationsUpdateInput = typeof ConfigurationsUpdateInput.Type;
@@ -1282,6 +1290,7 @@ export const DatabasesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforMySQL/flexibleServers/{serverName}/databases/{databaseName}",
       apiVersion: "2024-12-30",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type DatabasesCreateOrUpdateInput =
@@ -1338,6 +1347,7 @@ export const DatabasesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforMySQL/flexibleServers/{serverName}/databases/{databaseName}",
     apiVersion: "2024-12-30",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type DatabasesDeleteInput = typeof DatabasesDeleteInput.Type;
@@ -1498,6 +1508,7 @@ export const FirewallRulesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforMySQL/flexibleServers/{serverName}/firewallRules/{firewallRuleName}",
       apiVersion: "2024-12-30",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type FirewallRulesCreateOrUpdateInput =
@@ -1555,6 +1566,7 @@ export const FirewallRulesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforMySQL/flexibleServers/{serverName}/firewallRules/{firewallRuleName}",
       apiVersion: "2024-12-30",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type FirewallRulesDeleteInput = typeof FirewallRulesDeleteInput.Type;
@@ -2036,6 +2048,7 @@ export const LongRunningBackupCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforMySQL/flexibleServers/{serverName}/backupsV2/{backupName}",
       apiVersion: "2024-12-30",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type LongRunningBackupCreateInput =
@@ -2347,6 +2360,7 @@ export const MaintenancesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforMySQL/flexibleServers/{serverName}/maintenances/{maintenanceName}",
       apiVersion: "2024-12-30",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type MaintenancesUpdateInput = typeof MaintenancesUpdateInput.Type;
@@ -2658,6 +2672,7 @@ export const PrivateEndpointConnectionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforMySQL/flexibleServers/{serverName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2024-12-30",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PrivateEndpointConnectionsCreateOrUpdateInput =
@@ -2715,6 +2730,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforMySQL/flexibleServers/{serverName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2024-12-30",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =
@@ -3082,6 +3098,7 @@ export const ServerKeysCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforMySQL/servers/{serverName}/keys/{keyName}",
       apiVersion: "2020-01-01",
+      longRunning: {},
     }),
   );
 export type ServerKeysCreateOrUpdateInput =
@@ -3122,6 +3139,7 @@ export const ServerKeysDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforMySQL/servers/{serverName}/keys/{keyName}",
     apiVersion: "2020-01-01",
+    longRunning: {},
   }),
 );
 export type ServerKeysDeleteInput = typeof ServerKeysDeleteInput.Type;
@@ -3409,6 +3427,7 @@ export const ServersCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforMySQL/flexibleServers/{serverName}",
     apiVersion: "2024-12-30",
+    longRunning: { finalStateVia: "original-uri" },
   }),
 );
 export type ServersCreateInput = typeof ServersCreateInput.Type;
@@ -3458,6 +3477,7 @@ export const ServersDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforMySQL/flexibleServers/{serverName}",
     apiVersion: "2024-12-30",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type ServersDeleteInput = typeof ServersDeleteInput.Type;
@@ -3494,6 +3514,7 @@ export const ServersDetachVNetInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforMySQL/flexibleServers/{serverName}/detachVNet",
     apiVersion: "2024-12-30",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type ServersDetachVNetInput = typeof ServersDetachVNetInput.Type;
@@ -3544,6 +3565,7 @@ export const ServersFailoverInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforMySQL/flexibleServers/{serverName}/failover",
     apiVersion: "2024-12-30",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ServersFailoverInput = typeof ServersFailoverInput.Type;
@@ -3757,6 +3779,7 @@ export const ServersMigrationCutoverMigrationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforMySQL/flexibleServers/{serverName}/cutoverMigration",
       apiVersion: "2024-12-30",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ServersMigrationCutoverMigrationInput =
@@ -3811,6 +3834,7 @@ export const ServersResetGtidInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforMySQL/flexibleServers/{serverName}/resetGtid",
     apiVersion: "2024-12-30",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type ServersResetGtidInput = typeof ServersResetGtidInput.Type;
@@ -3846,6 +3870,7 @@ export const ServersRestartInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforMySQL/flexibleServers/{serverName}/restart",
     apiVersion: "2024-12-30",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ServersRestartInput = typeof ServersRestartInput.Type;
@@ -3877,6 +3902,7 @@ export const ServersStartInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforMySQL/flexibleServers/{serverName}/start",
     apiVersion: "2024-12-30",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ServersStartInput = typeof ServersStartInput.Type;
@@ -3908,6 +3934,7 @@ export const ServersStopInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforMySQL/flexibleServers/{serverName}/stop",
     apiVersion: "2024-12-30",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ServersStopInput = typeof ServersStopInput.Type;
@@ -4051,6 +4078,7 @@ export const ServersUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforMySQL/flexibleServers/{serverName}",
     apiVersion: "2024-12-30",
+    longRunning: { finalStateVia: "original-uri" },
   }),
 );
 export type ServersUpdateInput = typeof ServersUpdateInput.Type;
@@ -4104,6 +4132,7 @@ export const ServersUpgradeInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforMySQL/servers/{serverName}/upgrade",
     apiVersion: "2020-01-01",
+    longRunning: {},
   }),
 );
 export type ServersUpgradeInput = typeof ServersUpgradeInput.Type;

--- a/packages/azure/src/services/netapp.ts
+++ b/packages/azure/src/services/netapp.ts
@@ -29,6 +29,7 @@ export const AccountsChangeKeyVaultInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/changeKeyVault",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AccountsChangeKeyVaultInput =
@@ -174,6 +175,7 @@ export const AccountsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AccountsCreateOrUpdateInput =
@@ -228,6 +230,7 @@ export const AccountsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}",
     apiVersion: "2025-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type AccountsDeleteInput = typeof AccountsDeleteInput.Type;
@@ -309,6 +312,7 @@ export const AccountsGetChangeKeyVaultInformationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/getKeyVaultStatus",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AccountsGetChangeKeyVaultInformationInput =
@@ -479,6 +483,7 @@ export const AccountsRenewCredentialsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/renewCredentials",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AccountsRenewCredentialsInput =
@@ -518,6 +523,7 @@ export const AccountsTransitionToCmkInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/transitiontocmk",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AccountsTransitionToCmkInput =
@@ -662,6 +668,7 @@ export const AccountsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}",
     apiVersion: "2025-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type AccountsUpdateInput = typeof AccountsUpdateInput.Type;
@@ -735,6 +742,7 @@ export const BackupPoliciesCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/backupPolicies/{backupPolicyName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type BackupPoliciesCreateInput = typeof BackupPoliciesCreateInput.Type;
@@ -790,6 +798,7 @@ export const BackupPoliciesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/backupPolicies/{backupPolicyName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BackupPoliciesDeleteInput = typeof BackupPoliciesDeleteInput.Type;
@@ -973,6 +982,7 @@ export const BackupPoliciesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/backupPolicies/{backupPolicyName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type BackupPoliciesUpdateInput = typeof BackupPoliciesUpdateInput.Type;
@@ -1044,6 +1054,7 @@ export const BackupsCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/backupVaults/{backupVaultName}/backups/{backupName}",
     apiVersion: "2025-12-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type BackupsCreateInput = typeof BackupsCreateInput.Type;
@@ -1097,6 +1108,7 @@ export const BackupsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/backupVaults/{backupVaultName}/backups/{backupName}",
     apiVersion: "2025-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type BackupsDeleteInput = typeof BackupsDeleteInput.Type;
@@ -1361,6 +1373,7 @@ export const BackupsUnderAccountMigrateBackupsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/migrateBackups",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BackupsUnderAccountMigrateBackupsInput =
@@ -1402,6 +1415,7 @@ export const BackupsUnderBackupVaultRestoreFilesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/backupVaults/{backupVaultName}/backups/{backupName}/restoreFiles",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BackupsUnderBackupVaultRestoreFilesInput =
@@ -1443,6 +1457,7 @@ export const BackupsUnderVolumeMigrateBackupsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}/migrateBackups",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BackupsUnderVolumeMigrateBackupsInput =
@@ -1487,6 +1502,7 @@ export const BackupsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/backupVaults/{backupVaultName}/backups/{backupName}",
     apiVersion: "2025-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type BackupsUpdateInput = typeof BackupsUpdateInput.Type;
@@ -1547,6 +1563,7 @@ export const BackupVaultsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/backupVaults/{backupVaultName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type BackupVaultsCreateOrUpdateInput =
@@ -1604,6 +1621,7 @@ export const BackupVaultsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/backupVaults/{backupVaultName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BackupVaultsDeleteInput = typeof BackupVaultsDeleteInput.Type;
@@ -1759,6 +1777,7 @@ export const BackupVaultsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/backupVaults/{backupVaultName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BackupVaultsUpdateInput = typeof BackupVaultsUpdateInput.Type;
@@ -2445,6 +2464,7 @@ export const NetAppResourceUpdateNetworkSiblingSetInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.NetApp/locations/{location}/updateNetworkSiblingSet",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetAppResourceUpdateNetworkSiblingSetInput =
@@ -2733,6 +2753,7 @@ export const PoolsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PoolsCreateOrUpdateInput = typeof PoolsCreateOrUpdateInput.Type;
@@ -2785,6 +2806,7 @@ export const PoolsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}",
     apiVersion: "2025-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type PoolsDeleteInput = typeof PoolsDeleteInput.Type;
@@ -2936,6 +2958,7 @@ export const PoolsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}",
     apiVersion: "2025-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type PoolsUpdateInput = typeof PoolsUpdateInput.Type;
@@ -2992,6 +3015,7 @@ export const RansomwareReportsClearSuspectsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}/ransomwareReports/{ransomwareReportName}/clearSuspects",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RansomwareReportsClearSuspectsInput =
@@ -3267,6 +3291,7 @@ export const SnapshotPoliciesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/snapshotPolicies/{snapshotPolicyName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SnapshotPoliciesDeleteInput =
@@ -3543,6 +3568,7 @@ export const SnapshotPoliciesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/snapshotPolicies/{snapshotPolicyName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SnapshotPoliciesUpdateInput =
@@ -3609,6 +3635,7 @@ export const SnapshotsCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}/snapshots/{snapshotName}",
     apiVersion: "2025-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type SnapshotsCreateInput = typeof SnapshotsCreateInput.Type;
@@ -3664,6 +3691,7 @@ export const SnapshotsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}/snapshots/{snapshotName}",
     apiVersion: "2025-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type SnapshotsDeleteInput = typeof SnapshotsDeleteInput.Type;
@@ -3817,6 +3845,7 @@ export const SnapshotsRestoreFilesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}/snapshots/{snapshotName}/restoreFiles",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SnapshotsRestoreFilesInput = typeof SnapshotsRestoreFilesInput.Type;
@@ -3858,6 +3887,7 @@ export const SnapshotsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}/snapshots/{snapshotName}",
     apiVersion: "2025-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type SnapshotsUpdateInput = typeof SnapshotsUpdateInput.Type;
@@ -3921,6 +3951,7 @@ export const SubvolumesCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}/subvolumes/{subvolumeName}",
     apiVersion: "2025-12-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type SubvolumesCreateInput = typeof SubvolumesCreateInput.Type;
@@ -3978,6 +4009,7 @@ export const SubvolumesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}/subvolumes/{subvolumeName}",
     apiVersion: "2025-12-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type SubvolumesDeleteInput = typeof SubvolumesDeleteInput.Type;
@@ -4071,6 +4103,7 @@ export const SubvolumesGetMetadataInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}/subvolumes/{subvolumeName}/getMetadata",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SubvolumesGetMetadataInput = typeof SubvolumesGetMetadataInput.Type;
@@ -4210,6 +4243,7 @@ export const SubvolumesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}/subvolumes/{subvolumeName}",
     apiVersion: "2025-12-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type SubvolumesUpdateInput = typeof SubvolumesUpdateInput.Type;
@@ -4530,6 +4564,7 @@ export const VolumeGroupsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/volumeGroups/{volumeGroupName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VolumeGroupsCreateInput = typeof VolumeGroupsCreateInput.Type;
@@ -4583,6 +4618,7 @@ export const VolumeGroupsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/volumeGroups/{volumeGroupName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VolumeGroupsDeleteInput = typeof VolumeGroupsDeleteInput.Type;
@@ -4767,6 +4803,7 @@ export const VolumeQuotaRulesCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}/volumeQuotaRules/{volumeQuotaRuleName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VolumeQuotaRulesCreateInput =
@@ -4828,6 +4865,7 @@ export const VolumeQuotaRulesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}/volumeQuotaRules/{volumeQuotaRuleName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VolumeQuotaRulesDeleteInput =
@@ -5028,6 +5066,7 @@ export const VolumeQuotaRulesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}/volumeQuotaRules/{volumeQuotaRuleName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VolumeQuotaRulesUpdateInput =
@@ -5088,6 +5127,7 @@ export const VolumesAuthorizeExternalReplicationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}/authorizeExternalReplication",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VolumesAuthorizeExternalReplicationInput =
@@ -5131,6 +5171,7 @@ export const VolumesAuthorizeReplicationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}/authorizeReplication",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VolumesAuthorizeReplicationInput =
@@ -5174,6 +5215,7 @@ export const VolumesBreakFileLocksInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}/breakFileLocks",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VolumesBreakFileLocksInput = typeof VolumesBreakFileLocksInput.Type;
@@ -5215,6 +5257,7 @@ export const VolumesBreakReplicationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}/breakReplication",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VolumesBreakReplicationInput =
@@ -5466,6 +5509,7 @@ export const VolumesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VolumesCreateOrUpdateInput = typeof VolumesCreateOrUpdateInput.Type;
@@ -5524,6 +5568,7 @@ export const VolumesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}",
     apiVersion: "2025-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type VolumesDeleteInput = typeof VolumesDeleteInput.Type;
@@ -5561,6 +5606,7 @@ export const VolumesDeleteReplicationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}/deleteReplication",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VolumesDeleteReplicationInput =
@@ -5602,6 +5648,7 @@ export const VolumesFinalizeExternalReplicationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}/finalizeExternalReplication",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VolumesFinalizeExternalReplicationInput =
@@ -5642,6 +5689,7 @@ export const VolumesFinalizeRelocationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}/finalizeRelocation",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VolumesFinalizeRelocationInput =
@@ -5793,6 +5841,7 @@ export const VolumesListGetGroupIdListForLdapUserInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}/getGroupIdListForLdapUser",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VolumesListGetGroupIdListForLdapUserInput =
@@ -5845,6 +5894,7 @@ export const VolumesListQuotaReportInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}/listQuotaReport",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VolumesListQuotaReportInput =
@@ -5971,6 +6021,7 @@ export const VolumesPeerExternalClusterInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}/peerExternalCluster",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VolumesPeerExternalClusterInput =
@@ -6014,6 +6065,7 @@ export const VolumesPerformReplicationTransferInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}/performReplicationTransfer",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VolumesPerformReplicationTransferInput =
@@ -6056,6 +6108,7 @@ export const VolumesPoolChangeInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}/poolChange",
     apiVersion: "2025-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type VolumesPoolChangeInput = typeof VolumesPoolChangeInput.Type;
@@ -6092,6 +6145,7 @@ export const VolumesPopulateAvailabilityZoneInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}/populateAvailabilityZone",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VolumesPopulateAvailabilityZoneInput =
@@ -6151,6 +6205,7 @@ export const VolumesReestablishReplicationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}/reestablishReplication",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VolumesReestablishReplicationInput =
@@ -6191,6 +6246,7 @@ export const VolumesReInitializeReplicationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}/reinitializeReplication",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VolumesReInitializeReplicationInput =
@@ -6231,6 +6287,7 @@ export const VolumesRelocateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}/relocate",
     apiVersion: "2025-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type VolumesRelocateInput = typeof VolumesRelocateInput.Type;
@@ -6318,6 +6375,7 @@ export const VolumesResetCifsPasswordInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}/resetCifsPassword",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VolumesResetCifsPasswordInput =
@@ -6359,6 +6417,7 @@ export const VolumesResyncReplicationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}/resyncReplication",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VolumesResyncReplicationInput =
@@ -6400,6 +6459,7 @@ export const VolumesRevertInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}/revert",
     apiVersion: "2025-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type VolumesRevertInput = typeof VolumesRevertInput.Type;
@@ -6436,6 +6496,7 @@ export const VolumesRevertRelocationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}/revertRelocation",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VolumesRevertRelocationInput =
@@ -6477,6 +6538,7 @@ export const VolumesSplitCloneFromParentInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}/splitCloneFromParent",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VolumesSplitCloneFromParentInput =
@@ -6625,6 +6687,7 @@ export const VolumesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetApp/netAppAccounts/{accountName}/capacityPools/{poolName}/volumes/{volumeName}",
     apiVersion: "2025-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type VolumesUpdateInput = typeof VolumesUpdateInput.Type;

--- a/packages/azure/src/services/network.ts
+++ b/packages/azure/src/services/network.ts
@@ -106,6 +106,7 @@ export const AdminRuleCollectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/securityAdminConfigurations/{configurationName}/ruleCollections/{ruleCollectionName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AdminRuleCollectionsDeleteInput =
@@ -315,6 +316,7 @@ export const AdminRulesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/securityAdminConfigurations/{configurationName}/ruleCollections/{ruleCollectionName}/rules/{ruleName}",
     apiVersion: "2025-05-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type AdminRulesDeleteInput = typeof AdminRulesDeleteInput.Type;
@@ -443,6 +445,7 @@ export const ApplicationGatewayPrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}/privateEndpointConnections/{connectionName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ApplicationGatewayPrivateEndpointConnectionsDeleteInput =
@@ -598,6 +601,7 @@ export const ApplicationGatewayPrivateEndpointConnectionsUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}/privateEndpointConnections/{connectionName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ApplicationGatewayPrivateEndpointConnectionsUpdateInput =
@@ -681,6 +685,7 @@ export const ApplicationGatewaysBackendHealthInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}/backendhealth",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ApplicationGatewaysBackendHealthInput =
@@ -786,6 +791,7 @@ export const ApplicationGatewaysBackendHealthOnDemandInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}/getBackendHealthOnDemand",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ApplicationGatewaysBackendHealthOnDemandInput =
@@ -1234,6 +1240,7 @@ export const ApplicationGatewaysCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ApplicationGatewaysCreateOrUpdateInput =
@@ -1276,6 +1283,7 @@ export const ApplicationGatewaysDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ApplicationGatewaysDeleteInput =
@@ -1699,6 +1707,7 @@ export const ApplicationGatewaysStartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}/start",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ApplicationGatewaysStartInput =
@@ -1736,6 +1745,7 @@ export const ApplicationGatewaysStopInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}/stop",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ApplicationGatewaysStopInput =
@@ -1919,6 +1929,7 @@ export const ApplicationSecurityGroupsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationSecurityGroups/{applicationSecurityGroupName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ApplicationSecurityGroupsCreateOrUpdateInput =
@@ -1961,6 +1972,7 @@ export const ApplicationSecurityGroupsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationSecurityGroups/{applicationSecurityGroupName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ApplicationSecurityGroupsDeleteInput =
@@ -2646,6 +2658,7 @@ export const AzureFirewallsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls/{azureFirewallName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AzureFirewallsCreateOrUpdateInput =
@@ -2688,6 +2701,7 @@ export const AzureFirewallsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls/{azureFirewallName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AzureFirewallsDeleteInput = typeof AzureFirewallsDeleteInput.Type;
@@ -2848,6 +2862,7 @@ export const AzureFirewallsListLearnedPrefixesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls/{azureFirewallName}/learnedIPPrefixes",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AzureFirewallsListLearnedPrefixesInput =
@@ -2910,6 +2925,7 @@ export const AzureFirewallsPacketCaptureInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls/{azureFirewallName}/packetCapture",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AzureFirewallsPacketCaptureInput =
@@ -2971,6 +2987,7 @@ export const AzureFirewallsPacketCaptureOperationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls/{azureFirewallName}/packetCaptureOperation",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AzureFirewallsPacketCaptureOperationInput =
@@ -3024,6 +3041,7 @@ export const AzureFirewallsUpdateTagsInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls/{azureFirewallName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AzureFirewallsUpdateTagsInput =
@@ -3129,6 +3147,7 @@ export const BastionHostsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts/{bastionHostName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type BastionHostsCreateOrUpdateInput =
@@ -3172,6 +3191,7 @@ export const BastionHostsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts/{bastionHostName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BastionHostsDeleteInput = typeof BastionHostsDeleteInput.Type;
@@ -3327,6 +3347,7 @@ export const BastionHostsUpdateTagsInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts/{bastionHostName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type BastionHostsUpdateTagsInput =
@@ -3496,6 +3517,7 @@ export const ConfigurationPolicyGroupsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnServerConfigurations/{vpnServerConfigurationName}/configurationPolicyGroups/{configurationPolicyGroupName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ConfigurationPolicyGroupsCreateOrUpdateInput =
@@ -3536,6 +3558,7 @@ export const ConfigurationPolicyGroupsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnServerConfigurations/{vpnServerConfigurationName}/configurationPolicyGroups/{configurationPolicyGroupName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ConfigurationPolicyGroupsDeleteInput =
@@ -3821,6 +3844,7 @@ export const ConnectionMonitorsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/connectionMonitors/{connectionMonitorName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ConnectionMonitorsCreateOrUpdateInput =
@@ -3867,6 +3891,7 @@ export const ConnectionMonitorsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/connectionMonitors/{connectionMonitorName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ConnectionMonitorsDeleteInput =
@@ -4002,6 +4027,7 @@ export const ConnectionMonitorsStopInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/connectionMonitors/{connectionMonitorName}/stop",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ConnectionMonitorsStopInput =
@@ -4200,6 +4226,7 @@ export const ConnectivityConfigurationsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/connectivityConfigurations/{configurationName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ConnectivityConfigurationsDeleteInput =
@@ -4413,6 +4440,7 @@ export const CustomIPPrefixesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/customIpPrefixes/{customIpPrefixName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CustomIPPrefixesCreateOrUpdateInput =
@@ -4455,6 +4483,7 @@ export const CustomIPPrefixesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/customIpPrefixes/{customIpPrefixName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CustomIPPrefixesDeleteInput =
@@ -4701,6 +4730,7 @@ export const DdosCustomPoliciesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ddosCustomPolicies/{ddosCustomPolicyName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DdosCustomPoliciesCreateOrUpdateInput =
@@ -4743,6 +4773,7 @@ export const DdosCustomPoliciesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ddosCustomPolicies/{ddosCustomPolicyName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DdosCustomPoliciesDeleteInput =
@@ -4901,6 +4932,7 @@ export const DdosProtectionPlansCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ddosProtectionPlans/{ddosProtectionPlanName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DdosProtectionPlansCreateOrUpdateInput =
@@ -4943,6 +4975,7 @@ export const DdosProtectionPlansDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ddosProtectionPlans/{ddosProtectionPlanName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DdosProtectionPlansDeleteInput =
@@ -5257,6 +5290,7 @@ export const DeleteBastionShareableLinkInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts/{bastionHostName}/deleteShareableLinks",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeleteBastionShareableLinkInput =
@@ -5295,6 +5329,7 @@ export const DeleteBastionShareableLinkByTokenInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts/{bastionHostName}/deleteShareableLinksByToken",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeleteBastionShareableLinkByTokenInput =
@@ -5511,6 +5546,7 @@ export const DscpConfigurationCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dscpConfigurations/{dscpConfigurationName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DscpConfigurationCreateOrUpdateInput =
@@ -5553,6 +5589,7 @@ export const DscpConfigurationDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dscpConfigurations/{dscpConfigurationName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DscpConfigurationDeleteInput =
@@ -5743,6 +5780,7 @@ export const ExpressRouteCircuitAuthorizationsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/authorizations/{authorizationName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ExpressRouteCircuitAuthorizationsCreateOrUpdateInput =
@@ -5783,6 +5821,7 @@ export const ExpressRouteCircuitAuthorizationsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/authorizations/{authorizationName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ExpressRouteCircuitAuthorizationsDeleteInput =
@@ -5945,6 +5984,7 @@ export const ExpressRouteCircuitConnectionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/connections/{connectionName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ExpressRouteCircuitConnectionsCreateOrUpdateInput =
@@ -5987,6 +6027,7 @@ export const ExpressRouteCircuitConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/connections/{connectionName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ExpressRouteCircuitConnectionsDeleteInput =
@@ -6278,6 +6319,7 @@ export const ExpressRouteCircuitPeeringsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ExpressRouteCircuitPeeringsCreateOrUpdateInput =
@@ -6318,6 +6360,7 @@ export const ExpressRouteCircuitPeeringsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ExpressRouteCircuitPeeringsDeleteInput =
@@ -6514,6 +6557,7 @@ export const ExpressRouteCircuitsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ExpressRouteCircuitsCreateOrUpdateInput =
@@ -6556,6 +6600,7 @@ export const ExpressRouteCircuitsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ExpressRouteCircuitsDeleteInput =
@@ -6812,6 +6857,7 @@ export const ExpressRouteCircuitsListArpTableInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/arpTables/{devicePath}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ExpressRouteCircuitsListArpTableInput =
@@ -6862,6 +6908,7 @@ export const ExpressRouteCircuitsListRoutesTableInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/routeTables/{devicePath}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ExpressRouteCircuitsListRoutesTableInput =
@@ -6913,6 +6960,7 @@ export const ExpressRouteCircuitsListRoutesTableSummaryInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/routeTablesSummary/{devicePath}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ExpressRouteCircuitsListRoutesTableSummaryInput =
@@ -7092,6 +7140,7 @@ export const ExpressRouteConnectionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteGateways/{expressRouteGatewayName}/expressRouteConnections/{connectionName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ExpressRouteConnectionsCreateOrUpdateInput =
@@ -7132,6 +7181,7 @@ export const ExpressRouteConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteGateways/{expressRouteGatewayName}/expressRouteConnections/{connectionName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ExpressRouteConnectionsDeleteInput =
@@ -7389,6 +7439,7 @@ export const ExpressRouteCrossConnectionPeeringsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/peerings/{peeringName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ExpressRouteCrossConnectionPeeringsCreateOrUpdateInput =
@@ -7429,6 +7480,7 @@ export const ExpressRouteCrossConnectionPeeringsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/peerings/{peeringName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ExpressRouteCrossConnectionPeeringsDeleteInput =
@@ -7595,6 +7647,7 @@ export const ExpressRouteCrossConnectionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ExpressRouteCrossConnectionsCreateOrUpdateInput =
@@ -7726,6 +7779,7 @@ export const ExpressRouteCrossConnectionsListArpTableInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/peerings/{peeringName}/arpTables/{devicePath}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ExpressRouteCrossConnectionsListArpTableInput =
@@ -7821,6 +7875,7 @@ export const ExpressRouteCrossConnectionsListRoutesTableInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/peerings/{peeringName}/routeTables/{devicePath}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ExpressRouteCrossConnectionsListRoutesTableInput =
@@ -7872,6 +7927,7 @@ export const ExpressRouteCrossConnectionsListRoutesTableSummaryInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/peerings/{peeringName}/routeTablesSummary/{devicePath}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ExpressRouteCrossConnectionsListRoutesTableSummaryInput =
@@ -8005,6 +8061,7 @@ export const ExpressRouteGatewaysCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteGateways/{expressRouteGatewayName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ExpressRouteGatewaysCreateOrUpdateInput =
@@ -8047,6 +8104,7 @@ export const ExpressRouteGatewaysDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteGateways/{expressRouteGatewayName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ExpressRouteGatewaysDeleteInput =
@@ -8218,6 +8276,7 @@ export const ExpressRouteGatewaysUpdateTagsInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteGateways/{expressRouteGatewayName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ExpressRouteGatewaysUpdateTagsInput =
@@ -8366,6 +8425,7 @@ export const ExpressRoutePortAuthorizationsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRoutePorts/{expressRoutePortName}/authorizations/{authorizationName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ExpressRoutePortAuthorizationsCreateOrUpdateInput =
@@ -8406,6 +8466,7 @@ export const ExpressRoutePortAuthorizationsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRoutePorts/{expressRoutePortName}/authorizations/{authorizationName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ExpressRoutePortAuthorizationsDeleteInput =
@@ -8594,6 +8655,7 @@ export const ExpressRoutePortsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ExpressRoutePorts/{expressRoutePortName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ExpressRoutePortsCreateOrUpdateInput =
@@ -8636,6 +8698,7 @@ export const ExpressRoutePortsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ExpressRoutePorts/{expressRoutePortName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ExpressRoutePortsDeleteInput =
@@ -9302,6 +9365,7 @@ export const FirewallPoliciesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type FirewallPoliciesCreateOrUpdateInput =
@@ -9344,6 +9408,7 @@ export const FirewallPoliciesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type FirewallPoliciesDeleteInput =
@@ -9555,6 +9620,7 @@ export const FirewallPolicyDeploymentsDeployInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}/deploy",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type FirewallPolicyDeploymentsDeployInput =
@@ -10311,6 +10377,7 @@ export const FirewallPolicyRuleCollectionGroupsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}/ruleCollectionGroups/{ruleCollectionGroupName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type FirewallPolicyRuleCollectionGroupsCreateOrUpdateInput =
@@ -10351,6 +10418,7 @@ export const FirewallPolicyRuleCollectionGroupsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}/ruleCollectionGroups/{ruleCollectionGroupName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type FirewallPolicyRuleCollectionGroupsDeleteInput =
@@ -10546,6 +10614,7 @@ export const FlowLogsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/flowLogs/{flowLogName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type FlowLogsCreateOrUpdateInput =
@@ -10590,6 +10659,7 @@ export const FlowLogsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/flowLogs/{flowLogName}",
     apiVersion: "2025-05-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type FlowLogsDeleteInput = typeof FlowLogsDeleteInput.Type;
@@ -10751,6 +10821,7 @@ export const GeneratevirtualwanvpnserverconfigurationvpnprofileInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualWans/{virtualWANName}/generateVpnProfile",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type GeneratevirtualwanvpnserverconfigurationvpnprofileInput =
@@ -10790,6 +10861,7 @@ export const GetActiveSessionsInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts/{bastionHostName}/getActiveSessions",
     apiVersion: "2025-05-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type GetActiveSessionsInput = typeof GetActiveSessionsInput.Type;
@@ -10941,6 +11013,7 @@ export const HubRouteTablesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/hubRouteTables/{routeTableName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type HubRouteTablesCreateOrUpdateInput =
@@ -10981,6 +11054,7 @@ export const HubRouteTablesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/hubRouteTables/{routeTableName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type HubRouteTablesDeleteInput = typeof HubRouteTablesDeleteInput.Type;
@@ -11182,6 +11256,7 @@ export const HubVirtualNetworkConnectionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/hubVirtualNetworkConnections/{connectionName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type HubVirtualNetworkConnectionsCreateOrUpdateInput =
@@ -11221,6 +11296,7 @@ export const HubVirtualNetworkConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/hubVirtualNetworkConnections/{connectionName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type HubVirtualNetworkConnectionsDeleteInput =
@@ -11382,6 +11458,7 @@ export const InboundNatRulesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/inboundNatRules/{inboundNatRuleName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type InboundNatRulesCreateOrUpdateInput =
@@ -11422,6 +11499,7 @@ export const InboundNatRulesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/inboundNatRules/{inboundNatRuleName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type InboundNatRulesDeleteInput = typeof InboundNatRulesDeleteInput.Type;
@@ -11571,6 +11649,7 @@ export const InboundSecurityRuleCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances/{networkVirtualApplianceName}/inboundSecurityRules/{ruleCollectionName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type InboundSecurityRuleCreateOrUpdateInput =
@@ -11679,6 +11758,7 @@ export const IpAllocationsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/IpAllocations/{ipAllocationName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type IpAllocationsCreateOrUpdateInput =
@@ -11722,6 +11802,7 @@ export const IpAllocationsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/IpAllocations/{ipAllocationName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type IpAllocationsDeleteInput = typeof IpAllocationsDeleteInput.Type;
@@ -11949,6 +12030,7 @@ export const IpamPoolsCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/ipamPools/{poolName}",
     apiVersion: "2025-05-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type IpamPoolsCreateInput = typeof IpamPoolsCreateInput.Type;
@@ -12001,6 +12083,7 @@ export const IpamPoolsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/ipamPools/{poolName}",
     apiVersion: "2025-05-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type IpamPoolsDeleteInput = typeof IpamPoolsDeleteInput.Type;
@@ -12352,6 +12435,7 @@ export const IpGroupsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ipGroups/{ipGroupsName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type IpGroupsCreateOrUpdateInput =
@@ -12394,6 +12478,7 @@ export const IpGroupsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ipGroups/{ipGroupsName}",
     apiVersion: "2025-05-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type IpGroupsDeleteInput = typeof IpGroupsDeleteInput.Type;
@@ -13145,6 +13230,7 @@ export const LoadBalancerBackendAddressPoolsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/backendAddressPools/{backendAddressPoolName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type LoadBalancerBackendAddressPoolsCreateOrUpdateInput =
@@ -13185,6 +13271,7 @@ export const LoadBalancerBackendAddressPoolsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/backendAddressPools/{backendAddressPoolName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LoadBalancerBackendAddressPoolsDeleteInput =
@@ -13429,6 +13516,7 @@ export const LoadBalancerLoadBalancingRulesHealthInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/loadBalancingRules/{loadBalancingRuleName}/health",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LoadBalancerLoadBalancingRulesHealthInput =
@@ -13820,6 +13908,7 @@ export const LoadBalancersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type LoadBalancersCreateOrUpdateInput =
@@ -13863,6 +13952,7 @@ export const LoadBalancersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LoadBalancersDeleteInput = typeof LoadBalancersDeleteInput.Type;
@@ -14029,6 +14119,7 @@ export const LoadBalancersListInboundNatRulePortMappingsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/backendAddressPools/{backendPoolName}/queryInboundNatRulePortMapping",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LoadBalancersListInboundNatRulePortMappingsInput =
@@ -14131,6 +14222,7 @@ export const LoadBalancersSwapPublicIpAddressesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/setLoadBalancerFrontendPublicIpAddresses",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LoadBalancersSwapPublicIpAddressesInput =
@@ -14273,6 +14365,7 @@ export const LocalNetworkGatewaysCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/localNetworkGateways/{localNetworkGatewayName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type LocalNetworkGatewaysCreateOrUpdateInput =
@@ -14315,6 +14408,7 @@ export const LocalNetworkGatewaysDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/localNetworkGateways/{localNetworkGatewayName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LocalNetworkGatewaysDeleteInput =
@@ -14749,6 +14843,7 @@ export const NatGatewaysCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/natGateways/{natGatewayName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NatGatewaysCreateOrUpdateInput =
@@ -14793,6 +14888,7 @@ export const NatGatewaysDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/natGateways/{natGatewayName}",
     apiVersion: "2025-05-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type NatGatewaysDeleteInput = typeof NatGatewaysDeleteInput.Type;
@@ -15039,6 +15135,7 @@ export const NatRulesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/natRules/{natRuleName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NatRulesCreateOrUpdateInput =
@@ -15079,6 +15176,7 @@ export const NatRulesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/natRules/{natRuleName}",
     apiVersion: "2025-05-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type NatRulesDeleteInput = typeof NatRulesDeleteInput.Type;
@@ -15275,6 +15373,7 @@ export const NetworkGroupsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/networkGroups/{networkGroupName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkGroupsDeleteInput = typeof NetworkGroupsDeleteInput.Type;
@@ -15639,6 +15738,7 @@ export const NetworkInterfacesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NetworkInterfacesCreateOrUpdateInput =
@@ -15681,6 +15781,7 @@ export const NetworkInterfacesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkInterfacesDeleteInput =
@@ -15809,6 +15910,7 @@ export const NetworkInterfacesGetEffectiveRouteTableInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/effectiveRouteTable",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkInterfacesGetEffectiveRouteTableInput =
@@ -16060,6 +16162,7 @@ export const NetworkInterfacesListEffectiveNetworkSecurityGroupsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/effectiveNetworkSecurityGroups",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkInterfacesListEffectiveNetworkSecurityGroupsInput =
@@ -16234,6 +16337,7 @@ export const NetworkInterfaceTapConfigurationsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/tapConfigurations/{tapConfigurationName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NetworkInterfaceTapConfigurationsCreateOrUpdateInput =
@@ -16274,6 +16378,7 @@ export const NetworkInterfaceTapConfigurationsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/tapConfigurations/{tapConfigurationName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkInterfaceTapConfigurationsDeleteInput =
@@ -16403,6 +16508,7 @@ export const NetworkManagerCommitsPostInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/commit",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkManagerCommitsPostInput =
@@ -16605,6 +16711,7 @@ export const NetworkManagerRoutingConfigurationsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/routingConfigurations/{configurationName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkManagerRoutingConfigurationsDeleteInput =
@@ -16838,6 +16945,7 @@ export const NetworkManagersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkManagersDeleteInput = typeof NetworkManagersDeleteInput.Type;
@@ -17126,6 +17234,7 @@ export const NetworkProfilesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkProfiles/{networkProfileName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkProfilesDeleteInput = typeof NetworkProfilesDeleteInput.Type;
@@ -17403,6 +17512,7 @@ export const NetworkSecurityGroupsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NetworkSecurityGroupsCreateOrUpdateInput =
@@ -17445,6 +17555,7 @@ export const NetworkSecurityGroupsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkSecurityGroupsDeleteInput =
@@ -18046,6 +18157,7 @@ export const NetworkSecurityPerimeterAssociationsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityPerimeters/{networkSecurityPerimeterName}/resourceAssociations/{associationName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NetworkSecurityPerimeterAssociationsCreateOrUpdateInput =
@@ -18102,6 +18214,7 @@ export const NetworkSecurityPerimeterAssociationsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityPerimeters/{networkSecurityPerimeterName}/resourceAssociations/{associationName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NetworkSecurityPerimeterAssociationsDeleteInput =
@@ -18307,6 +18420,7 @@ export const NetworkSecurityPerimeterLinkReferencesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityPerimeters/{networkSecurityPerimeterName}/linkReferences/{linkReferenceName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkSecurityPerimeterLinkReferencesDeleteInput =
@@ -18556,6 +18670,7 @@ export const NetworkSecurityPerimeterLinksDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityPerimeters/{networkSecurityPerimeterName}/links/{linkName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkSecurityPerimeterLinksDeleteInput =
@@ -19340,6 +19455,7 @@ export const NetworkSecurityPerimetersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityPerimeters/{networkSecurityPerimeterName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NetworkSecurityPerimetersDeleteInput =
@@ -19751,6 +19867,7 @@ export const NetworkVirtualApplianceConnectionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances/{networkVirtualApplianceName}/networkVirtualApplianceConnections/{connectionName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NetworkVirtualApplianceConnectionsCreateOrUpdateInput =
@@ -19790,6 +19907,7 @@ export const NetworkVirtualApplianceConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances/{networkVirtualApplianceName}/networkVirtualApplianceConnections/{connectionName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkVirtualApplianceConnectionsDeleteInput =
@@ -20097,6 +20215,7 @@ export const NetworkVirtualAppliancesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances/{networkVirtualApplianceName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NetworkVirtualAppliancesCreateOrUpdateInput =
@@ -20139,6 +20258,7 @@ export const NetworkVirtualAppliancesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances/{networkVirtualApplianceName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkVirtualAppliancesDeleteInput =
@@ -20223,6 +20343,7 @@ export const NetworkVirtualAppliancesGetBootDiagnosticLogsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances/{networkVirtualApplianceName}/getBootDiagnosticLogs",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkVirtualAppliancesGetBootDiagnosticLogsInput =
@@ -20350,6 +20471,7 @@ export const NetworkVirtualAppliancesReimageInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances/{networkVirtualApplianceName}/reimage",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkVirtualAppliancesReimageInput =
@@ -20389,6 +20511,7 @@ export const NetworkVirtualAppliancesRestartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances/{networkVirtualApplianceName}/restart",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkVirtualAppliancesRestartInput =
@@ -20502,6 +20625,7 @@ export const NetworkWatchersCheckConnectivityInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/connectivityCheck",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkWatchersCheckConnectivityInput =
@@ -20747,6 +20871,7 @@ export const NetworkWatchersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkWatchersDeleteInput = typeof NetworkWatchersDeleteInput.Type;
@@ -20831,6 +20956,7 @@ export const NetworkWatchersGetAzureReachabilityReportInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/azureReachabilityReport",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkWatchersGetAzureReachabilityReportInput =
@@ -20889,6 +21015,7 @@ export const NetworkWatchersGetFlowLogStatusInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/queryFlowLogStatus",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkWatchersGetFlowLogStatusInput =
@@ -20994,6 +21121,7 @@ export const NetworkWatchersGetNetworkConfigurationDiagnosticInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/networkConfigurationDiagnostic",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkWatchersGetNetworkConfigurationDiagnosticInput =
@@ -21085,6 +21213,7 @@ export const NetworkWatchersGetNextHopInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/nextHop",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkWatchersGetNextHopInput =
@@ -21212,6 +21341,7 @@ export const NetworkWatchersGetTroubleshootingInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/troubleshoot",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkWatchersGetTroubleshootingInput =
@@ -21273,6 +21403,7 @@ export const NetworkWatchersGetTroubleshootingResultInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/queryTroubleshootResult",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkWatchersGetTroubleshootingResultInput =
@@ -21334,6 +21465,7 @@ export const NetworkWatchersGetVMSecurityRulesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/securityGroupView",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkWatchersGetVMSecurityRulesInput =
@@ -21544,6 +21676,7 @@ export const NetworkWatchersListAvailableProvidersInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/availableProvidersList",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkWatchersListAvailableProvidersInput =
@@ -21658,6 +21791,7 @@ export const NetworkWatchersSetFlowLogConfigurationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/configureFlowLog",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkWatchersSetFlowLogConfigurationInput =
@@ -21803,6 +21937,7 @@ export const NetworkWatchersVerifyIPFlowInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/ipFlowVerify",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkWatchersVerifyIPFlowInput =
@@ -21988,6 +22123,7 @@ export const P2sVpnGatewaysCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/p2svpnGateways/{gatewayName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type P2sVpnGatewaysCreateOrUpdateInput =
@@ -22030,6 +22166,7 @@ export const P2sVpnGatewaysDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/p2svpnGateways/{gatewayName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type P2sVpnGatewaysDeleteInput = typeof P2sVpnGatewaysDeleteInput.Type;
@@ -22066,6 +22203,7 @@ export const P2sVpnGatewaysDisconnectP2sVpnConnectionsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/p2svpnGateways/{p2sVpnGatewayName}/disconnectP2sVpnConnections",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type P2sVpnGatewaysDisconnectP2sVpnConnectionsInput =
@@ -22105,6 +22243,7 @@ export const P2sVpnGatewaysGenerateVpnProfileInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/p2svpnGateways/{gatewayName}/generatevpnprofile",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type P2sVpnGatewaysGenerateVpnProfileInput =
@@ -22183,6 +22322,7 @@ export const P2sVpnGatewaysGetP2sVpnConnectionHealthInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/p2svpnGateways/{gatewayName}/getP2sVpnConnectionHealth",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type P2sVpnGatewaysGetP2sVpnConnectionHealthInput =
@@ -22227,6 +22367,7 @@ export const P2sVpnGatewaysGetP2sVpnConnectionHealthDetailedInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/p2svpnGateways/{gatewayName}/getP2sVpnConnectionHealthDetailed",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type P2sVpnGatewaysGetP2sVpnConnectionHealthDetailedInput =
@@ -22350,6 +22491,7 @@ export const P2SVpnGatewaysResetInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/p2svpnGateways/{gatewayName}/reset",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type P2SVpnGatewaysResetInput = typeof P2SVpnGatewaysResetInput.Type;
@@ -22390,6 +22532,7 @@ export const P2sVpnGatewaysUpdateTagsInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/p2svpnGateways/{gatewayName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type P2sVpnGatewaysUpdateTagsInput =
@@ -22473,6 +22616,7 @@ export const PacketCapturesCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/packetCaptures/{packetCaptureName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PacketCapturesCreateInput = typeof PacketCapturesCreateInput.Type;
@@ -22554,6 +22698,7 @@ export const PacketCapturesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/packetCaptures/{packetCaptureName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PacketCapturesDeleteInput = typeof PacketCapturesDeleteInput.Type;
@@ -22671,6 +22816,7 @@ export const PacketCapturesGetStatusInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/packetCaptures/{packetCaptureName}/queryStatus",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PacketCapturesGetStatusInput =
@@ -22817,6 +22963,7 @@ export const PacketCapturesStopInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/packetCaptures/{packetCaptureName}/stop",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PacketCapturesStopInput = typeof PacketCapturesStopInput.Type;
@@ -22990,6 +23137,7 @@ export const PrivateDnsZoneGroupsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateEndpoints/{privateEndpointName}/privateDnsZoneGroups/{privateDnsZoneGroupName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PrivateDnsZoneGroupsCreateOrUpdateInput =
@@ -23030,6 +23178,7 @@ export const PrivateDnsZoneGroupsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateEndpoints/{privateEndpointName}/privateDnsZoneGroups/{privateDnsZoneGroupName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateDnsZoneGroupsDeleteInput =
@@ -23252,6 +23401,7 @@ export const PrivateEndpointsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateEndpoints/{privateEndpointName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PrivateEndpointsCreateOrUpdateInput =
@@ -23294,6 +23444,7 @@ export const PrivateEndpointsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateEndpoints/{privateEndpointName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointsDeleteInput =
@@ -23459,6 +23610,7 @@ export const PrivateLinkServicesCheckPrivateLinkServiceVisibilityInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/checkPrivateLinkServiceVisibility",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateLinkServicesCheckPrivateLinkServiceVisibilityInput =
@@ -23497,6 +23649,7 @@ export const PrivateLinkServicesCheckPrivateLinkServiceVisibilityByResourceGroup
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/locations/{location}/checkPrivateLinkServiceVisibility",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateLinkServicesCheckPrivateLinkServiceVisibilityByResourceGroupInput =
@@ -23612,6 +23765,7 @@ export const PrivateLinkServicesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateLinkServices/{serviceName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PrivateLinkServicesCreateOrUpdateInput =
@@ -23654,6 +23808,7 @@ export const PrivateLinkServicesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateLinkServices/{serviceName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateLinkServicesDeleteInput =
@@ -23692,6 +23847,7 @@ export const PrivateLinkServicesDeletePrivateEndpointConnectionInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateLinkServices/{serviceName}/privateEndpointConnections/{peConnectionName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateLinkServicesDeletePrivateEndpointConnectionInput =
@@ -24233,6 +24389,7 @@ export const PublicIPAddressesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPAddresses/{publicIpAddressName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PublicIPAddressesCreateOrUpdateInput =
@@ -24275,6 +24432,7 @@ export const PublicIPAddressesDdosProtectionStatusInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPAddresses/{publicIpAddressName}/ddosProtectionStatus",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PublicIPAddressesDdosProtectionStatusInput =
@@ -24316,6 +24474,7 @@ export const PublicIPAddressesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPAddresses/{publicIpAddressName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PublicIPAddressesDeleteInput =
@@ -24354,6 +24513,7 @@ export const PublicIPAddressesDisassociateCloudServiceReservedPublicIpInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPAddresses/{publicIpAddressName}/disassociateCloudServiceReservedPublicIp",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PublicIPAddressesDisassociateCloudServiceReservedPublicIpInput =
@@ -24684,6 +24844,7 @@ export const PublicIPAddressesReserveCloudServicePublicIpAddressInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPAddresses/{publicIpAddressName}/reserveCloudServicePublicIpAddress",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PublicIPAddressesReserveCloudServicePublicIpAddressInput =
@@ -24844,6 +25005,7 @@ export const PublicIPPrefixesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIpPrefixName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PublicIPPrefixesCreateOrUpdateInput =
@@ -24886,6 +25048,7 @@ export const PublicIPPrefixesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIpPrefixName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PublicIPPrefixesDeleteInput =
@@ -25113,6 +25276,7 @@ export const PutBastionShareableLinkInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts/{bastionHostName}/createShareableLinks",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PutBastionShareableLinkInput =
@@ -25545,6 +25709,7 @@ export const ReachabilityAnalysisRunsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/verifierWorkspaces/{workspaceName}/reachabilityAnalysisRuns/{reachabilityAnalysisRunName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReachabilityAnalysisRunsDeleteInput =
@@ -25791,6 +25956,7 @@ export const RouteFilterRulesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeFilters/{routeFilterName}/routeFilterRules/{ruleName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type RouteFilterRulesCreateOrUpdateInput =
@@ -25831,6 +25997,7 @@ export const RouteFilterRulesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeFilters/{routeFilterName}/routeFilterRules/{ruleName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type RouteFilterRulesDeleteInput =
@@ -25990,6 +26157,7 @@ export const RouteFiltersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeFilters/{routeFilterName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type RouteFiltersCreateOrUpdateInput =
@@ -26033,6 +26201,7 @@ export const RouteFiltersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeFilters/{routeFilterName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type RouteFiltersDeleteInput = typeof RouteFiltersDeleteInput.Type;
@@ -26315,6 +26484,7 @@ export const RouteMapsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/routeMaps/{routeMapName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type RouteMapsCreateOrUpdateInput =
@@ -26357,6 +26527,7 @@ export const RouteMapsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/routeMaps/{routeMapName}",
     apiVersion: "2025-05-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type RouteMapsDeleteInput = typeof RouteMapsDeleteInput.Type;
@@ -26495,6 +26666,7 @@ export const RoutesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeTables/{routeTableName}/routes/{routeName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type RoutesCreateOrUpdateInput = typeof RoutesCreateOrUpdateInput.Type;
@@ -26533,6 +26705,7 @@ export const RoutesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeTables/{routeTableName}/routes/{routeName}",
     apiVersion: "2025-05-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type RoutesDeleteInput = typeof RoutesDeleteInput.Type;
@@ -26675,6 +26848,7 @@ export const RouteTablesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeTables/{routeTableName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type RouteTablesCreateOrUpdateInput =
@@ -26719,6 +26893,7 @@ export const RouteTablesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeTables/{routeTableName}",
     apiVersion: "2025-05-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type RouteTablesDeleteInput = typeof RouteTablesDeleteInput.Type;
@@ -26941,6 +27116,7 @@ export const RoutingIntentCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/routingIntent/{routingIntentName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type RoutingIntentCreateOrUpdateInput =
@@ -26982,6 +27158,7 @@ export const RoutingIntentDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/routingIntent/{routingIntentName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RoutingIntentDeleteInput = typeof RoutingIntentDeleteInput.Type;
@@ -27184,6 +27361,7 @@ export const RoutingRuleCollectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/routingConfigurations/{configurationName}/ruleCollections/{ruleCollectionName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RoutingRuleCollectionsDeleteInput =
@@ -27422,6 +27600,7 @@ export const RoutingRulesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/routingConfigurations/{configurationName}/ruleCollections/{ruleCollectionName}/rules/{ruleName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RoutingRulesDeleteInput = typeof RoutingRulesDeleteInput.Type;
@@ -27841,6 +28020,7 @@ export const SecurityAdminConfigurationsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/securityAdminConfigurations/{configurationName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SecurityAdminConfigurationsDeleteInput =
@@ -28008,6 +28188,7 @@ export const SecurityPartnerProvidersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/securityPartnerProviders/{securityPartnerProviderName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SecurityPartnerProvidersCreateOrUpdateInput =
@@ -28050,6 +28231,7 @@ export const SecurityPartnerProvidersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/securityPartnerProviders/{securityPartnerProviderName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SecurityPartnerProvidersDeleteInput =
@@ -28320,6 +28502,7 @@ export const SecurityRulesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}/securityRules/{securityRuleName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SecurityRulesCreateOrUpdateInput =
@@ -28361,6 +28544,7 @@ export const SecurityRulesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}/securityRules/{securityRuleName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SecurityRulesDeleteInput = typeof SecurityRulesDeleteInput.Type;
@@ -28552,6 +28736,7 @@ export const SecurityUserConfigurationsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/securityUserConfigurations/{configurationName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SecurityUserConfigurationsDeleteInput =
@@ -28770,6 +28955,7 @@ export const SecurityUserRuleCollectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/securityUserConfigurations/{configurationName}/ruleCollections/{ruleCollectionName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SecurityUserRuleCollectionsDeleteInput =
@@ -29015,6 +29201,7 @@ export const SecurityUserRulesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/securityUserConfigurations/{configurationName}/ruleCollections/{ruleCollectionName}/rules/{ruleName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SecurityUserRulesDeleteInput =
@@ -29242,6 +29429,7 @@ export const ServiceEndpointPoliciesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceEndpointPolicies/{serviceEndpointPolicyName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ServiceEndpointPoliciesCreateOrUpdateInput =
@@ -29284,6 +29472,7 @@ export const ServiceEndpointPoliciesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceEndpointPolicies/{serviceEndpointPolicyName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServiceEndpointPoliciesDeleteInput =
@@ -29519,6 +29708,7 @@ export const ServiceEndpointPolicyDefinitionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceEndpointPolicies/{serviceEndpointPolicyName}/serviceEndpointPolicyDefinitions/{serviceEndpointPolicyDefinitionName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ServiceEndpointPolicyDefinitionsCreateOrUpdateInput =
@@ -29559,6 +29749,7 @@ export const ServiceEndpointPolicyDefinitionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceEndpointPolicies/{serviceEndpointPolicyName}/serviceEndpointPolicyDefinitions/{serviceEndpointPolicyDefinitionName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServiceEndpointPolicyDefinitionsDeleteInput =
@@ -29739,6 +29930,7 @@ export const ServiceGatewaysCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceGateways/{serviceGatewayName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ServiceGatewaysCreateOrUpdateInput =
@@ -29793,6 +29985,7 @@ export const ServiceGatewaysDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceGateways/{serviceGatewayName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServiceGatewaysDeleteInput = typeof ServiceGatewaysDeleteInput.Type;
@@ -30140,6 +30333,7 @@ export const ServiceGatewaysUpdateAddressLocationsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceGateways/{serviceGatewayName}/updateAddressLocations",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServiceGatewaysUpdateAddressLocationsInput =
@@ -30210,6 +30404,7 @@ export const ServiceGatewaysUpdateServicesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceGateways/{serviceGatewayName}/updateServices",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServiceGatewaysUpdateServicesInput =
@@ -30493,6 +30688,7 @@ export const StaticCidrsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/ipamPools/{poolName}/staticCidrs/{staticCidrName}",
     apiVersion: "2025-05-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type StaticCidrsDeleteInput = typeof StaticCidrsDeleteInput.Type;
@@ -31032,6 +31228,7 @@ export const SubnetsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SubnetsCreateOrUpdateInput = typeof SubnetsCreateOrUpdateInput.Type;
@@ -31071,6 +31268,7 @@ export const SubnetsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}",
     apiVersion: "2025-05-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type SubnetsDeleteInput = typeof SubnetsDeleteInput.Type;
@@ -31199,6 +31397,7 @@ export const SubnetsPrepareNetworkPoliciesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}/prepareNetworkPolicies",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SubnetsPrepareNetworkPoliciesInput =
@@ -31238,6 +31437,7 @@ export const SubnetsUnprepareNetworkPoliciesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}/unprepareNetworkPolicies",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SubnetsUnprepareNetworkPoliciesInput =
@@ -31647,6 +31847,7 @@ export const VerifierWorkspacesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/verifierWorkspaces/{workspaceName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VerifierWorkspacesDeleteInput =
@@ -31894,6 +32095,7 @@ export const VipSwapCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/microsoft.Compute/cloudServices/{resourceName}/providers/Microsoft.Network/cloudServiceSlots/{singletonResource}",
     apiVersion: "2025-05-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type VipSwapCreateInput = typeof VipSwapCreateInput.Type;
@@ -32032,6 +32234,7 @@ export const VirtualApplianceSitesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances/{networkVirtualApplianceName}/virtualApplianceSites/{siteName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualApplianceSitesCreateOrUpdateInput =
@@ -32072,6 +32275,7 @@ export const VirtualApplianceSitesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances/{networkVirtualApplianceName}/virtualApplianceSites/{siteName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualApplianceSitesDeleteInput =
@@ -32313,6 +32517,7 @@ export const VirtualHubBgpConnectionCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/bgpConnections/{connectionName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualHubBgpConnectionCreateOrUpdateInput =
@@ -32353,6 +32558,7 @@ export const VirtualHubBgpConnectionDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/bgpConnections/{connectionName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualHubBgpConnectionDeleteInput =
@@ -32475,6 +32681,7 @@ export const VirtualHubBgpConnectionsListAdvertisedRoutesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{hubName}/bgpConnections/{connectionName}/advertisedRoutes",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualHubBgpConnectionsListAdvertisedRoutesInput =
@@ -32526,6 +32733,7 @@ export const VirtualHubBgpConnectionsListLearnedRoutesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{hubName}/bgpConnections/{connectionName}/learnedRoutes",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualHubBgpConnectionsListLearnedRoutesInput =
@@ -32612,6 +32820,7 @@ export const VirtualHubIpConfigurationCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/ipConfigurations/{ipConfigName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualHubIpConfigurationCreateOrUpdateInput =
@@ -32652,6 +32861,7 @@ export const VirtualHubIpConfigurationDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/ipConfigurations/{ipConfigName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualHubIpConfigurationDeleteInput =
@@ -32801,6 +33011,7 @@ export const VirtualHubRouteTableV2sCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/routeTables/{routeTableName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualHubRouteTableV2sCreateOrUpdateInput =
@@ -32841,6 +33052,7 @@ export const VirtualHubRouteTableV2sDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/routeTables/{routeTableName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualHubRouteTableV2sDeleteInput =
@@ -33074,6 +33286,7 @@ export const VirtualHubsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualHubsCreateOrUpdateInput =
@@ -33118,6 +33331,7 @@ export const VirtualHubsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}",
     apiVersion: "2025-05-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type VirtualHubsDeleteInput = typeof VirtualHubsDeleteInput.Type;
@@ -33189,6 +33403,7 @@ export const VirtualHubsGetEffectiveVirtualHubRoutesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/effectiveRoutes",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualHubsGetEffectiveVirtualHubRoutesInput =
@@ -33239,6 +33454,7 @@ export const VirtualHubsGetInboundRoutesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/inboundRoutes",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualHubsGetInboundRoutesInput =
@@ -33288,6 +33504,7 @@ export const VirtualHubsGetOutboundRoutesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/outboundRoutes",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualHubsGetOutboundRoutesInput =
@@ -33495,6 +33712,7 @@ export const VirtualNetworkAppliancesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkAppliances/{virtualNetworkApplianceName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualNetworkAppliancesCreateOrUpdateInput =
@@ -33537,6 +33755,7 @@ export const VirtualNetworkAppliancesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkAppliances/{virtualNetworkApplianceName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkAppliancesDeleteInput =
@@ -33954,6 +34173,7 @@ export const VirtualNetworkGatewayConnectionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualNetworkGatewayConnectionsCreateOrUpdateInput =
@@ -33996,6 +34216,7 @@ export const VirtualNetworkGatewayConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkGatewayConnectionsDeleteInput =
@@ -34074,6 +34295,7 @@ export const VirtualNetworkGatewayConnectionsGetIkeSasInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}/getikesas",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkGatewayConnectionsGetIkeSasInput =
@@ -34193,6 +34415,7 @@ export const VirtualNetworkGatewayConnectionsResetConnectionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}/resetconnection",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkGatewayConnectionsResetConnectionInput =
@@ -34230,6 +34453,7 @@ export const VirtualNetworkGatewayConnectionsResetSharedKeyInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}/sharedkey/reset",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkGatewayConnectionsResetSharedKeyInput =
@@ -34270,6 +34494,7 @@ export const VirtualNetworkGatewayConnectionsSetSharedKeyInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}/sharedkey",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualNetworkGatewayConnectionsSetSharedKeyInput =
@@ -34309,6 +34534,7 @@ export const VirtualNetworkGatewayConnectionsStartPacketCaptureInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}/startPacketCapture",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkGatewayConnectionsStartPacketCaptureInput =
@@ -34346,6 +34572,7 @@ export const VirtualNetworkGatewayConnectionsStopPacketCaptureInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}/stopPacketCapture",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkGatewayConnectionsStopPacketCaptureInput =
@@ -34383,6 +34610,7 @@ export const VirtualNetworkGatewayConnectionsUpdateTagsInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualNetworkGatewayConnectionsUpdateTagsInput =
@@ -34463,6 +34691,7 @@ export const VirtualNetworkGatewayNatRulesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/natRules/{natRuleName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualNetworkGatewayNatRulesCreateOrUpdateInput =
@@ -34503,6 +34732,7 @@ export const VirtualNetworkGatewayNatRulesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/natRules/{natRuleName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkGatewayNatRulesDeleteInput =
@@ -34971,6 +35201,7 @@ export const VirtualNetworkGatewaysCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualNetworkGatewaysCreateOrUpdateInput =
@@ -35013,6 +35244,7 @@ export const VirtualNetworkGatewaysDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkGatewaysDeleteInput =
@@ -35050,6 +35282,7 @@ export const VirtualNetworkGatewaysDisconnectVirtualNetworkGatewayVpnConnections
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/disconnectVirtualNetworkGatewayVpnConnections",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkGatewaysDisconnectVirtualNetworkGatewayVpnConnectionsInput =
@@ -35095,6 +35328,7 @@ export const VirtualNetworkGatewaysGeneratevpnclientpackageInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/generatevpnclientpackage",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkGatewaysGeneratevpnclientpackageInput =
@@ -35137,6 +35371,7 @@ export const VirtualNetworkGatewaysGenerateVpnProfileInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/generatevpnprofile",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkGatewaysGenerateVpnProfileInput =
@@ -35217,6 +35452,7 @@ export const VirtualNetworkGatewaysGetAdvertisedRoutesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getAdvertisedRoutes",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkGatewaysGetAdvertisedRoutesInput =
@@ -35269,6 +35505,7 @@ export const VirtualNetworkGatewaysGetBgpPeerStatusInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getBgpPeerStatus",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkGatewaysGetBgpPeerStatusInput =
@@ -35331,6 +35568,7 @@ export const VirtualNetworkGatewaysGetFailoverAllTestDetailsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getFailoverAllTestsDetails",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkGatewaysGetFailoverAllTestDetailsInput =
@@ -35416,6 +35654,7 @@ export const VirtualNetworkGatewaysGetFailoverSingleTestDetailsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getFailoverSingleTestDetails",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkGatewaysGetFailoverSingleTestDetailsInput =
@@ -35492,6 +35731,7 @@ export const VirtualNetworkGatewaysGetLearnedRoutesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getLearnedRoutes",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkGatewaysGetLearnedRoutesInput =
@@ -35543,6 +35783,7 @@ export const VirtualNetworkGatewaysGetResiliencyInformationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getResiliencyInformation",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkGatewaysGetResiliencyInformationInput =
@@ -35609,6 +35850,7 @@ export const VirtualNetworkGatewaysGetRoutesInformationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getRoutesInformation",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkGatewaysGetRoutesInformationInput =
@@ -35680,6 +35922,7 @@ export const VirtualNetworkGatewaysGetVpnclientConnectionHealthInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getVpnClientConnectionHealth",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkGatewaysGetVpnclientConnectionHealthInput =
@@ -35735,6 +35978,7 @@ export const VirtualNetworkGatewaysGetVpnclientIpsecParametersInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getvpnclientipsecparameters",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkGatewaysGetVpnclientIpsecParametersInput =
@@ -35831,6 +36075,7 @@ export const VirtualNetworkGatewaysGetVpnProfilePackageUrlInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getvpnprofilepackageurl",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkGatewaysGetVpnProfilePackageUrlInput =
@@ -35867,6 +36112,7 @@ export const VirtualNetworkGatewaysInvokeAbortMigrationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/abortMigration",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkGatewaysInvokeAbortMigrationInput =
@@ -35903,6 +36149,7 @@ export const VirtualNetworkGatewaysInvokeCommitMigrationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/commitMigration",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkGatewaysInvokeCommitMigrationInput =
@@ -35939,6 +36186,7 @@ export const VirtualNetworkGatewaysInvokeExecuteMigrationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/executeMigration",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkGatewaysInvokeExecuteMigrationInput =
@@ -35977,6 +36225,7 @@ export const VirtualNetworkGatewaysInvokePrepareMigrationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/prepareMigration",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkGatewaysInvokePrepareMigrationInput =
@@ -36151,6 +36400,7 @@ export const VirtualNetworkGatewaysResetInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/reset",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkGatewaysResetInput =
@@ -36195,6 +36445,7 @@ export const VirtualNetworkGatewaysResetVpnClientSharedKeyInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/resetvpnclientsharedkey",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkGatewaysResetVpnClientSharedKeyInput =
@@ -36290,6 +36541,7 @@ export const VirtualNetworkGatewaysSetVpnclientIpsecParametersInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/setvpnclientipsecparameters",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkGatewaysSetVpnclientIpsecParametersInput =
@@ -36387,6 +36639,7 @@ export const VirtualNetworkGatewaysStartExpressRouteSiteFailoverSimulationInput 
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/startSiteFailoverTest",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkGatewaysStartExpressRouteSiteFailoverSimulationInput =
@@ -36427,6 +36680,7 @@ export const VirtualNetworkGatewaysStartPacketCaptureInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/startPacketCapture",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkGatewaysStartPacketCaptureInput =
@@ -36474,6 +36728,7 @@ export const VirtualNetworkGatewaysStopExpressRouteSiteFailoverSimulationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/stopSiteFailoverTest",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkGatewaysStopExpressRouteSiteFailoverSimulationInput =
@@ -36513,6 +36768,7 @@ export const VirtualNetworkGatewaysStopPacketCaptureInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/stopPacketCapture",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkGatewaysStopPacketCaptureInput =
@@ -36586,6 +36842,7 @@ export const VirtualNetworkGatewaysUpdateTagsInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualNetworkGatewaysUpdateTagsInput =
@@ -36807,6 +37064,7 @@ export const VirtualNetworkPeeringsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/virtualNetworkPeerings/{virtualNetworkPeeringName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualNetworkPeeringsCreateOrUpdateInput =
@@ -36848,6 +37106,7 @@ export const VirtualNetworkPeeringsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/virtualNetworkPeerings/{virtualNetworkPeeringName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkPeeringsDeleteInput =
@@ -37128,6 +37387,7 @@ export const VirtualNetworksCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualNetworksCreateOrUpdateInput =
@@ -37170,6 +37430,7 @@ export const VirtualNetworksDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworksDeleteInput = typeof VirtualNetworksDeleteInput.Type;
@@ -37335,6 +37596,7 @@ export const VirtualNetworksListDdosProtectionStatusInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/ddosProtectionStatus",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworksListDdosProtectionStatusInput =
@@ -37522,6 +37784,7 @@ export const VirtualNetworkTapsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkTaps/{tapName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualNetworkTapsCreateOrUpdateInput =
@@ -37564,6 +37827,7 @@ export const VirtualNetworkTapsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkTaps/{tapName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkTapsDeleteInput =
@@ -37796,6 +38060,7 @@ export const VirtualRouterPeeringsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualRouters/{virtualRouterName}/peerings/{peeringName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualRouterPeeringsCreateOrUpdateInput =
@@ -37836,6 +38101,7 @@ export const VirtualRouterPeeringsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualRouters/{virtualRouterName}/peerings/{peeringName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualRouterPeeringsDeleteInput =
@@ -37998,6 +38264,7 @@ export const VirtualRoutersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualRouters/{virtualRouterName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualRoutersCreateOrUpdateInput =
@@ -38040,6 +38307,7 @@ export const VirtualRoutersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualRouters/{virtualRouterName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualRoutersDeleteInput = typeof VirtualRoutersDeleteInput.Type;
@@ -38243,6 +38511,7 @@ export const VirtualWansCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualWans/{VirtualWANName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualWansCreateOrUpdateInput =
@@ -38287,6 +38556,7 @@ export const VirtualWansDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualWans/{VirtualWANName}",
     apiVersion: "2025-05-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type VirtualWansDeleteInput = typeof VirtualWansDeleteInput.Type;
@@ -38669,6 +38939,7 @@ export const VpnConnectionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/vpnConnections/{connectionName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VpnConnectionsCreateOrUpdateInput =
@@ -38709,6 +38980,7 @@ export const VpnConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/vpnConnections/{connectionName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VpnConnectionsDeleteInput = typeof VpnConnectionsDeleteInput.Type;
@@ -38829,6 +39101,7 @@ export const VpnConnectionsStartPacketCaptureInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/vpnConnections/{vpnConnectionName}/startpacketcapture",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VpnConnectionsStartPacketCaptureInput =
@@ -38869,6 +39142,7 @@ export const VpnConnectionsStopPacketCaptureInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/vpnConnections/{vpnConnectionName}/stoppacketcapture",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VpnConnectionsStopPacketCaptureInput =
@@ -38980,6 +39254,7 @@ export const VpnGatewaysCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VpnGatewaysCreateOrUpdateInput =
@@ -39024,6 +39299,7 @@ export const VpnGatewaysDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}",
     apiVersion: "2025-05-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type VpnGatewaysDeleteInput = typeof VpnGatewaysDeleteInput.Type;
@@ -39176,6 +39452,7 @@ export const VpnGatewaysResetInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/reset",
     apiVersion: "2025-05-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type VpnGatewaysResetInput = typeof VpnGatewaysResetInput.Type;
@@ -39218,6 +39495,7 @@ export const VpnGatewaysStartPacketCaptureInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/startpacketcapture",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VpnGatewaysStartPacketCaptureInput =
@@ -39255,6 +39533,7 @@ export const VpnGatewaysStopPacketCaptureInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/stoppacketcapture",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VpnGatewaysStopPacketCaptureInput =
@@ -39292,6 +39571,7 @@ export const VpnGatewaysUpdateTagsInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VpnGatewaysUpdateTagsInput = typeof VpnGatewaysUpdateTagsInput.Type;
@@ -39426,6 +39706,7 @@ export const VpnLinkConnectionsGetIkeSasInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/vpnConnections/{connectionName}/vpnLinkConnections/{linkConnectionName}/getikesas",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VpnLinkConnectionsGetIkeSasInput =
@@ -39554,6 +39835,7 @@ export const VpnLinkConnectionsResetConnectionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/vpnConnections/{connectionName}/vpnLinkConnections/{linkConnectionName}/resetconnection",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VpnLinkConnectionsResetConnectionInput =
@@ -39612,6 +39894,7 @@ export const VpnLinkConnectionsSetOrInitDefaultSharedKeyInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/vpnConnections/{connectionName}/vpnLinkConnections/{linkConnectionName}/sharedKeys/default",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VpnLinkConnectionsSetOrInitDefaultSharedKeyInput =
@@ -39652,6 +39935,7 @@ export const VpnServerConfigurationsAssociatedWithVirtualWanListInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualWans/{virtualWANName}/vpnServerConfigurations",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VpnServerConfigurationsAssociatedWithVirtualWanListInput =
@@ -39846,6 +40130,7 @@ export const VpnServerConfigurationsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnServerConfigurations/{vpnServerConfigurationName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VpnServerConfigurationsCreateOrUpdateInput =
@@ -39888,6 +40173,7 @@ export const VpnServerConfigurationsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnServerConfigurations/{vpnServerConfigurationName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VpnServerConfigurationsDeleteInput =
@@ -40268,6 +40554,7 @@ export const VpnSitesConfigurationDownloadInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualWans/{virtualWANName}/vpnConfiguration",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VpnSitesConfigurationDownloadInput =
@@ -40400,6 +40687,7 @@ export const VpnSitesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnSites/{vpnSiteName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VpnSitesCreateOrUpdateInput =
@@ -40442,6 +40730,7 @@ export const VpnSitesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnSites/{vpnSiteName}",
     apiVersion: "2025-05-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type VpnSitesDeleteInput = typeof VpnSitesDeleteInput.Type;
@@ -41021,6 +41310,7 @@ export const WebApplicationFirewallPoliciesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/{policyName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebApplicationFirewallPoliciesDeleteInput =

--- a/packages/azure/src/services/networkcloud.ts
+++ b/packages/azure/src/services/networkcloud.ts
@@ -148,6 +148,7 @@ export const AgentPoolsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/kubernetesClusters/{kubernetesClusterName}/agentPools/{agentPoolName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AgentPoolsCreateOrUpdateInput =
@@ -204,6 +205,7 @@ export const AgentPoolsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/kubernetesClusters/{kubernetesClusterName}/agentPools/{agentPoolName}",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type AgentPoolsDeleteInput = typeof AgentPoolsDeleteInput.Type;
@@ -381,6 +383,7 @@ export const AgentPoolsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/kubernetesClusters/{kubernetesClusterName}/agentPools/{agentPoolName}",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type AgentPoolsUpdateInput = typeof AgentPoolsUpdateInput.Type;
@@ -488,6 +491,7 @@ export const BareMetalMachineKeySetsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/clusters/{clusterName}/bareMetalMachineKeySets/{bareMetalMachineKeySetName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type BareMetalMachineKeySetsCreateOrUpdateInput =
@@ -544,6 +548,7 @@ export const BareMetalMachineKeySetsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/clusters/{clusterName}/bareMetalMachineKeySets/{bareMetalMachineKeySetName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BareMetalMachineKeySetsDeleteInput =
@@ -727,6 +732,7 @@ export const BareMetalMachineKeySetsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/clusters/{clusterName}/bareMetalMachineKeySets/{bareMetalMachineKeySetName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type BareMetalMachineKeySetsUpdateInput =
@@ -783,6 +789,7 @@ export const BareMetalMachinesCordonInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/bareMetalMachines/{bareMetalMachineName}/cordon",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BareMetalMachinesCordonInput =
@@ -985,6 +992,7 @@ export const BareMetalMachinesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/bareMetalMachines/{bareMetalMachineName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type BareMetalMachinesCreateOrUpdateInput =
@@ -1039,6 +1047,7 @@ export const BareMetalMachinesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/bareMetalMachines/{bareMetalMachineName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BareMetalMachinesDeleteInput =
@@ -1262,6 +1271,7 @@ export const BareMetalMachinesPowerOffInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/bareMetalMachines/{bareMetalMachineName}/powerOff",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BareMetalMachinesPowerOffInput =
@@ -1299,6 +1309,7 @@ export const BareMetalMachinesReimageInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/bareMetalMachines/{bareMetalMachineName}/reimage",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BareMetalMachinesReimageInput =
@@ -1348,6 +1359,7 @@ export const BareMetalMachinesReplaceInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/bareMetalMachines/{bareMetalMachineName}/replace",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BareMetalMachinesReplaceInput =
@@ -1385,6 +1397,7 @@ export const BareMetalMachinesRestartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/bareMetalMachines/{bareMetalMachineName}/restart",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BareMetalMachinesRestartInput =
@@ -1425,6 +1438,7 @@ export const BareMetalMachinesRunCommandInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/bareMetalMachines/{bareMetalMachineName}/runCommand",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BareMetalMachinesRunCommandInput =
@@ -1469,6 +1483,7 @@ export const BareMetalMachinesRunDataExtractsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/bareMetalMachines/{bareMetalMachineName}/runDataExtracts",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BareMetalMachinesRunDataExtractsInput =
@@ -1512,6 +1527,7 @@ export const BareMetalMachinesRunDataExtractsRestrictedInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/bareMetalMachines/{bareMetalMachineName}/runDataExtractsRestricted",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BareMetalMachinesRunDataExtractsRestrictedInput =
@@ -1555,6 +1571,7 @@ export const BareMetalMachinesRunReadCommandsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/bareMetalMachines/{bareMetalMachineName}/runReadCommands",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BareMetalMachinesRunReadCommandsInput =
@@ -1591,6 +1608,7 @@ export const BareMetalMachinesStartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/bareMetalMachines/{bareMetalMachineName}/start",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BareMetalMachinesStartInput =
@@ -1628,6 +1646,7 @@ export const BareMetalMachinesUncordonInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/bareMetalMachines/{bareMetalMachineName}/uncordon",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BareMetalMachinesUncordonInput =
@@ -1671,6 +1690,7 @@ export const BareMetalMachinesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/bareMetalMachines/{bareMetalMachineName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type BareMetalMachinesUpdateInput =
@@ -1777,6 +1797,7 @@ export const BmcKeySetsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/clusters/{clusterName}/bmcKeySets/{bmcKeySetName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type BmcKeySetsCreateOrUpdateInput =
@@ -1833,6 +1854,7 @@ export const BmcKeySetsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/clusters/{clusterName}/bmcKeySets/{bmcKeySetName}",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type BmcKeySetsDeleteInput = typeof BmcKeySetsDeleteInput.Type;
@@ -2005,6 +2027,7 @@ export const BmcKeySetsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/clusters/{clusterName}/bmcKeySets/{bmcKeySetName}",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type BmcKeySetsUpdateInput = typeof BmcKeySetsUpdateInput.Type;
@@ -2142,6 +2165,7 @@ export const CloudServicesNetworksCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/cloudServicesNetworks/{cloudServicesNetworkName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CloudServicesNetworksCreateOrUpdateInput =
@@ -2196,6 +2220,7 @@ export const CloudServicesNetworksDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/cloudServicesNetworks/{cloudServicesNetworkName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CloudServicesNetworksDeleteInput =
@@ -2448,6 +2473,7 @@ export const CloudServicesNetworksUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/cloudServicesNetworks/{cloudServicesNetworkName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CloudServicesNetworksUpdateInput =
@@ -2574,6 +2600,7 @@ export const ClusterManagersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/clusterManagers/{clusterManagerName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ClusterManagersCreateOrUpdateInput =
@@ -2628,6 +2655,7 @@ export const ClusterManagersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/clusterManagers/{clusterManagerName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ClusterManagersDeleteInput = typeof ClusterManagersDeleteInput.Type;
@@ -2926,6 +2954,7 @@ export const ClustersContinueUpdateVersionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/clusters/{clusterName}/continueUpdateVersion",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ClustersContinueUpdateVersionInput =
@@ -3310,6 +3339,7 @@ export const ClustersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/clusters/{clusterName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ClustersCreateOrUpdateInput =
@@ -3364,6 +3394,7 @@ export const ClustersDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/clusters/{clusterName}",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ClustersDeleteInput = typeof ClustersDeleteInput.Type;
@@ -3396,6 +3427,7 @@ export const ClustersDeployInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/clusters/{clusterName}/deploy",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ClustersDeployInput = typeof ClustersDeployInput.Type;
@@ -3612,6 +3644,7 @@ export const ClustersScanRuntimeInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/clusters/{clusterName}/scanRuntime",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ClustersScanRuntimeInput = typeof ClustersScanRuntimeInput.Type;
@@ -3878,6 +3911,7 @@ export const ClustersUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/clusters/{clusterName}",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type ClustersUpdateInput = typeof ClustersUpdateInput.Type;
@@ -3929,6 +3963,7 @@ export const ClustersUpdateVersionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/clusters/{clusterName}/updateVersion",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ClustersUpdateVersionInput = typeof ClustersUpdateVersionInput.Type;
@@ -3993,6 +4028,7 @@ export const ConsolesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/virtualMachines/{virtualMachineName}/consoles/{consoleName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ConsolesCreateOrUpdateInput =
@@ -4049,6 +4085,7 @@ export const ConsolesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/virtualMachines/{virtualMachineName}/consoles/{consoleName}",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ConsolesDeleteInput = typeof ConsolesDeleteInput.Type;
@@ -4214,6 +4251,7 @@ export const ConsolesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/virtualMachines/{virtualMachineName}/consoles/{consoleName}",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type ConsolesUpdateInput = typeof ConsolesUpdateInput.Type;
@@ -4300,6 +4338,7 @@ export const KubernetesClusterFeaturesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/kubernetesClusters/{kubernetesClusterName}/features/{featureName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type KubernetesClusterFeaturesCreateOrUpdateInput =
@@ -4356,6 +4395,7 @@ export const KubernetesClusterFeaturesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/kubernetesClusters/{kubernetesClusterName}/features/{featureName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type KubernetesClusterFeaturesDeleteInput =
@@ -4532,6 +4572,7 @@ export const KubernetesClusterFeaturesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/kubernetesClusters/{kubernetesClusterName}/features/{featureName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type KubernetesClusterFeaturesUpdateInput =
@@ -4988,6 +5029,7 @@ export const KubernetesClustersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/kubernetesClusters/{kubernetesClusterName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type KubernetesClustersCreateOrUpdateInput =
@@ -5042,6 +5084,7 @@ export const KubernetesClustersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/kubernetesClusters/{kubernetesClusterName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type KubernetesClustersDeleteInput =
@@ -5266,6 +5309,7 @@ export const KubernetesClustersRestartNodeInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/kubernetesClusters/{kubernetesClusterName}/restartNode",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type KubernetesClustersRestartNodeInput =
@@ -5335,6 +5379,7 @@ export const KubernetesClustersUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/kubernetesClusters/{kubernetesClusterName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type KubernetesClustersUpdateInput =
@@ -5425,6 +5470,7 @@ export const L2NetworksCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/l2Networks/{l2NetworkName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type L2NetworksCreateOrUpdateInput =
@@ -5479,6 +5525,7 @@ export const L2NetworksDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/l2Networks/{l2NetworkName}",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type L2NetworksDeleteInput = typeof L2NetworksDeleteInput.Type;
@@ -5786,6 +5833,7 @@ export const L3NetworksCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/l3Networks/{l3NetworkName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type L3NetworksCreateOrUpdateInput =
@@ -5840,6 +5888,7 @@ export const L3NetworksDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/l3Networks/{l3NetworkName}",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type L3NetworksDeleteInput = typeof L3NetworksDeleteInput.Type;
@@ -6131,6 +6180,7 @@ export const MetricsConfigurationsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/clusters/{clusterName}/metricsConfigurations/{metricsConfigurationName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type MetricsConfigurationsCreateOrUpdateInput =
@@ -6187,6 +6237,7 @@ export const MetricsConfigurationsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/clusters/{clusterName}/metricsConfigurations/{metricsConfigurationName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type MetricsConfigurationsDeleteInput =
@@ -6359,6 +6410,7 @@ export const MetricsConfigurationsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/clusters/{clusterName}/metricsConfigurations/{metricsConfigurationName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type MetricsConfigurationsUpdateInput =
@@ -6490,6 +6542,7 @@ export const RacksCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/racks/{rackName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type RacksCreateOrUpdateInput = typeof RacksCreateOrUpdateInput.Type;
@@ -6540,6 +6593,7 @@ export const RacksDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/racks/{rackName}",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type RacksDeleteInput = typeof RacksDeleteInput.Type;
@@ -6874,6 +6928,7 @@ export const RacksUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/racks/{rackName}",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type RacksUpdateInput = typeof RacksUpdateInput.Type;
@@ -6991,6 +7046,7 @@ export const StorageAppliancesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/storageAppliances/{storageApplianceName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type StorageAppliancesCreateOrUpdateInput =
@@ -7045,6 +7101,7 @@ export const StorageAppliancesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/storageAppliances/{storageApplianceName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StorageAppliancesDeleteInput =
@@ -7082,6 +7139,7 @@ export const StorageAppliancesDisableRemoteVendorManagementInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/storageAppliances/{storageApplianceName}/disableRemoteVendorManagement",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StorageAppliancesDisableRemoteVendorManagementInput =
@@ -7119,6 +7177,7 @@ export const StorageAppliancesEnableRemoteVendorManagementInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/storageAppliances/{storageApplianceName}/enableRemoteVendorManagement",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StorageAppliancesEnableRemoteVendorManagementInput =
@@ -7347,6 +7406,7 @@ export const StorageAppliancesRunReadCommandsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/storageAppliances/{storageApplianceName}/runReadCommands",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StorageAppliancesRunReadCommandsInput =
@@ -7389,6 +7449,7 @@ export const StorageAppliancesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/storageAppliances/{storageApplianceName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type StorageAppliancesUpdateInput =
@@ -7480,6 +7541,7 @@ export const TrunkedNetworksCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/trunkedNetworks/{trunkedNetworkName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type TrunkedNetworksCreateOrUpdateInput =
@@ -7534,6 +7596,7 @@ export const TrunkedNetworksDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/trunkedNetworks/{trunkedNetworkName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type TrunkedNetworksDeleteInput = typeof TrunkedNetworksDeleteInput.Type;
@@ -7810,6 +7873,7 @@ export const VirtualMachinesAssignRelayInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/virtualMachines/{virtualMachineName}/assignRelay",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesAssignRelayInput =
@@ -7986,6 +8050,7 @@ export const VirtualMachinesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/virtualMachines/{virtualMachineName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualMachinesCreateOrUpdateInput =
@@ -8040,6 +8105,7 @@ export const VirtualMachinesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/virtualMachines/{virtualMachineName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesDeleteInput = typeof VirtualMachinesDeleteInput.Type;
@@ -8260,6 +8326,7 @@ export const VirtualMachinesPowerOffInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/virtualMachines/{virtualMachineName}/powerOff",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesPowerOffInput =
@@ -8297,6 +8364,7 @@ export const VirtualMachinesReimageInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/virtualMachines/{virtualMachineName}/reimage",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesReimageInput =
@@ -8334,6 +8402,7 @@ export const VirtualMachinesRestartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/virtualMachines/{virtualMachineName}/restart",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesRestartInput =
@@ -8371,6 +8440,7 @@ export const VirtualMachinesStartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/virtualMachines/{virtualMachineName}/start",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesStartInput = typeof VirtualMachinesStartInput.Type;
@@ -8439,6 +8509,7 @@ export const VirtualMachinesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/virtualMachines/{virtualMachineName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualMachinesUpdateInput = typeof VirtualMachinesUpdateInput.Type;
@@ -8520,6 +8591,7 @@ export const VolumesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/volumes/{volumeName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VolumesCreateOrUpdateInput = typeof VolumesCreateOrUpdateInput.Type;
@@ -8573,6 +8645,7 @@ export const VolumesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkCloud/volumes/{volumeName}",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type VolumesDeleteInput = typeof VolumesDeleteInput.Type;

--- a/packages/azure/src/services/networkfunction.ts
+++ b/packages/azure/src/services/networkfunction.ts
@@ -173,6 +173,7 @@ export const AzureTrafficCollectorsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkFunction/azureTrafficCollectors/{azureTrafficCollectorName}",
       apiVersion: "2022-11-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AzureTrafficCollectorsCreateOrUpdateInput =
@@ -227,6 +228,7 @@ export const AzureTrafficCollectorsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkFunction/azureTrafficCollectors/{azureTrafficCollectorName}",
       apiVersion: "2022-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AzureTrafficCollectorsDeleteInput =
@@ -413,6 +415,7 @@ export const CollectorPoliciesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkFunction/azureTrafficCollectors/{azureTrafficCollectorName}/collectorPolicies/{collectorPolicyName}",
       apiVersion: "2022-11-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CollectorPoliciesCreateOrUpdateInput =
@@ -469,6 +472,7 @@ export const CollectorPoliciesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NetworkFunction/azureTrafficCollectors/{azureTrafficCollectorName}/collectorPolicies/{collectorPolicyName}",
       apiVersion: "2022-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CollectorPoliciesDeleteInput =

--- a/packages/azure/src/services/notificationhubs.ts
+++ b/packages/azure/src/services/notificationhubs.ts
@@ -279,6 +279,7 @@ export const NamespacesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NotificationHubs/namespaces/{namespaceName}",
       apiVersion: "2023-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type NamespacesCreateOrUpdateInput =
@@ -2183,6 +2184,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NotificationHubs/namespaces/{namespaceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2023-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =
@@ -2508,6 +2510,7 @@ export const PrivateEndpointConnectionsUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.NotificationHubs/namespaces/{namespaceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2023-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PrivateEndpointConnectionsUpdateInput =

--- a/packages/azure/src/services/operationalinsights.ts
+++ b/packages/azure/src/services/operationalinsights.ts
@@ -173,6 +173,7 @@ export const ClustersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.OperationalInsights/clusters/{clusterName}",
       apiVersion: "2025-07-01",
+      longRunning: {},
     }),
   );
 export type ClustersCreateOrUpdateInput =
@@ -213,6 +214,7 @@ export const ClustersDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.OperationalInsights/clusters/{clusterName}",
     apiVersion: "2025-07-01",
+    longRunning: {},
   }),
 );
 export type ClustersDeleteInput = typeof ClustersDeleteInput.Type;
@@ -404,6 +406,7 @@ export const ClustersUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.OperationalInsights/clusters/{clusterName}",
     apiVersion: "2025-07-01",
+    longRunning: {},
   }),
 );
 export type ClustersUpdateInput = typeof ClustersUpdateInput.Type;
@@ -1080,6 +1083,7 @@ export const LinkedServicesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.OperationalInsights/workspaces/{workspaceName}/linkedServices/{linkedServiceName}",
       apiVersion: "2025-07-01",
+      longRunning: {},
     }),
   );
 export type LinkedServicesCreateOrUpdateInput =
@@ -1122,6 +1126,7 @@ export const LinkedServicesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.OperationalInsights/workspaces/{workspaceName}/linkedServices/{linkedServiceName}",
       apiVersion: "2025-07-01",
+      longRunning: {},
     }),
   );
 export type LinkedServicesDeleteInput = typeof LinkedServicesDeleteInput.Type;
@@ -2852,6 +2857,7 @@ export const SummaryLogsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OperationalInsights/workspaces/{workspaceName}/summaryLogs/{summaryLogsName}",
       apiVersion: "2025-07-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SummaryLogsCreateOrUpdateInput =
@@ -2908,6 +2914,7 @@ export const SummaryLogsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OperationalInsights/workspaces/{workspaceName}/summaryLogs/{summaryLogsName}",
     apiVersion: "2025-07-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type SummaryLogsDeleteInput = typeof SummaryLogsDeleteInput.Type;
@@ -3066,6 +3073,7 @@ export const SummaryLogsRetryBinInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OperationalInsights/workspaces/{workspaceName}/summaryLogs/{summaryLogsName}/retrybin",
       apiVersion: "2025-07-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SummaryLogsRetryBinInput = typeof SummaryLogsRetryBinInput.Type;
@@ -3098,6 +3106,7 @@ export const SummaryLogsStartInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OperationalInsights/workspaces/{workspaceName}/summaryLogs/{summaryLogsName}/start",
     apiVersion: "2025-07-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type SummaryLogsStartInput = typeof SummaryLogsStartInput.Type;
@@ -3326,6 +3335,7 @@ export const TablesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OperationalInsights/workspaces/{workspaceName}/tables/{tableName}",
       apiVersion: "2025-07-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type TablesCreateOrUpdateInput = typeof TablesCreateOrUpdateInput.Type;
@@ -3366,6 +3376,7 @@ export const TablesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OperationalInsights/workspaces/{workspaceName}/tables/{tableName}",
     apiVersion: "2025-07-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type TablesDeleteInput = typeof TablesDeleteInput.Type;
@@ -3645,6 +3656,7 @@ export const TablesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OperationalInsights/workspaces/{workspaceName}/tables/{tableName}",
     apiVersion: "2025-07-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type TablesUpdateInput = typeof TablesUpdateInput.Type;
@@ -3958,6 +3970,7 @@ export const WorkspacesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.OperationalInsights/workspaces/{workspaceName}",
       apiVersion: "2025-07-01",
+      longRunning: {},
     }),
   );
 export type WorkspacesCreateOrUpdateInput =
@@ -3999,6 +4012,7 @@ export const WorkspacesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.OperationalInsights/workspaces/{workspaceName}",
     apiVersion: "2025-07-01",
+    longRunning: {},
   }),
 );
 export type WorkspacesDeleteInput = typeof WorkspacesDeleteInput.Type;
@@ -4032,6 +4046,7 @@ export const WorkspacesFailbackInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OperationalInsights/workspaces/{workspaceName}/failback",
       apiVersion: "2025-07-01",
+      longRunning: {},
     }),
   );
 export type WorkspacesFailbackInput = typeof WorkspacesFailbackInput.Type;
@@ -4066,6 +4081,7 @@ export const WorkspacesFailoverInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OperationalInsights/locations/{location}/workspaces/{workspaceName}/failover",
       apiVersion: "2025-07-01",
+      longRunning: {},
     }),
   );
 export type WorkspacesFailoverInput = typeof WorkspacesFailoverInput.Type;
@@ -4336,6 +4352,7 @@ export const WorkspacesReconcileNSPInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OperationalInsights/workspaces/{workspaceName}/networkSecurityPerimeterConfigurations/{networkSecurityPerimeterConfigurationName}/reconcile",
       apiVersion: "2025-07-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkspacesReconcileNSPInput =

--- a/packages/azure/src/services/orbital.ts
+++ b/packages/azure/src/services/orbital.ts
@@ -132,6 +132,7 @@ export const ContactProfilesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Orbital/contactProfiles/{contactProfileName}",
       apiVersion: "2022-11-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ContactProfilesCreateOrUpdateInput =
@@ -184,6 +185,7 @@ export const ContactProfilesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Orbital/contactProfiles/{contactProfileName}",
       apiVersion: "2022-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ContactProfilesDeleteInput = typeof ContactProfilesDeleteInput.Type;
@@ -401,6 +403,7 @@ export const ContactProfilesUpdateTagsInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Orbital/contactProfiles/{contactProfileName}",
       apiVersion: "2022-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ContactProfilesUpdateTagsInput =
@@ -496,6 +499,7 @@ export const ContactsCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Orbital/spacecrafts/{spacecraftName}/contacts/{contactName}",
     apiVersion: "2022-11-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type ContactsCreateInput = typeof ContactsCreateInput.Type;
@@ -543,6 +547,7 @@ export const ContactsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Orbital/spacecrafts/{spacecraftName}/contacts/{contactName}",
     apiVersion: "2022-11-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ContactsDeleteInput = typeof ContactsDeleteInput.Type;
@@ -1524,6 +1529,7 @@ export const L2ConnectionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Orbital/l2Connections/{l2ConnectionName}",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type L2ConnectionsCreateOrUpdateInput =
@@ -1577,6 +1583,7 @@ export const L2ConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Orbital/l2Connections/{l2ConnectionName}",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type L2ConnectionsDeleteInput = typeof L2ConnectionsDeleteInput.Type;
@@ -1792,6 +1799,7 @@ export const L2ConnectionsUpdateTagsInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Orbital/l2Connections/{l2ConnectionName}",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type L2ConnectionsUpdateTagsInput =
@@ -1894,6 +1902,7 @@ export const OperationsResultsGetInput =
       method: "GET",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.Orbital/locations/{location}/operationResults/{operationId}",
       apiVersion: "2022-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type OperationsResultsGetInput = typeof OperationsResultsGetInput.Type;
@@ -1986,6 +1995,7 @@ export const SpacecraftsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Orbital/spacecrafts/{spacecraftName}",
       apiVersion: "2022-11-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SpacecraftsCreateOrUpdateInput =
@@ -2040,6 +2050,7 @@ export const SpacecraftsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Orbital/spacecrafts/{spacecraftName}",
     apiVersion: "2022-11-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type SpacecraftsDeleteInput = typeof SpacecraftsDeleteInput.Type;
@@ -2187,6 +2198,7 @@ export const SpacecraftsListAvailableContactsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Orbital/spacecrafts/{spacecraftName}/listAvailableContacts",
       apiVersion: "2022-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SpacecraftsListAvailableContactsInput =
@@ -2316,6 +2328,7 @@ export const SpacecraftsUpdateTagsInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Orbital/spacecrafts/{spacecraftName}",
       apiVersion: "2022-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SpacecraftsUpdateTagsInput = typeof SpacecraftsUpdateTagsInput.Type;

--- a/packages/azure/src/services/orbitalplanetarycomputer.ts
+++ b/packages/azure/src/services/orbitalplanetarycomputer.ts
@@ -68,6 +68,7 @@ export const GeoCatalogsCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Orbital/geoCatalogs/{catalogName}",
     apiVersion: "2026-04-15",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type GeoCatalogsCreateInput = typeof GeoCatalogsCreateInput.Type;
@@ -120,6 +121,7 @@ export const GeoCatalogsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Orbital/geoCatalogs/{catalogName}",
     apiVersion: "2026-04-15",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type GeoCatalogsDeleteInput = typeof GeoCatalogsDeleteInput.Type;
@@ -356,6 +358,7 @@ export const GeoCatalogsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Orbital/geoCatalogs/{catalogName}",
     apiVersion: "2026-04-15",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type GeoCatalogsUpdateInput = typeof GeoCatalogsUpdateInput.Type;

--- a/packages/azure/src/services/playwrighttesting.ts
+++ b/packages/azure/src/services/playwrighttesting.ts
@@ -209,6 +209,7 @@ export const AccountsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzurePlaywrightService/accounts/{accountName}",
       apiVersion: "2024-12-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AccountsCreateOrUpdateInput =
@@ -263,6 +264,7 @@ export const AccountsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzurePlaywrightService/accounts/{accountName}",
     apiVersion: "2024-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type AccountsDeleteInput = typeof AccountsDeleteInput.Type;

--- a/packages/azure/src/services/policyinsights.ts
+++ b/packages/azure/src/services/policyinsights.ts
@@ -55,6 +55,7 @@ export const AttestationsCreateOrUpdateAtResourceInput =
       method: "PUT",
       path: "/{resourceId}/providers/Microsoft.PolicyInsights/attestations/{attestationName}",
       apiVersion: "2024-10-01",
+      longRunning: {},
     }),
   );
 export type AttestationsCreateOrUpdateAtResourceInput =
@@ -130,6 +131,7 @@ export const AttestationsCreateOrUpdateAtResourceGroupInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.PolicyInsights/attestations/{attestationName}",
       apiVersion: "2024-10-01",
+      longRunning: {},
     }),
   );
 export type AttestationsCreateOrUpdateAtResourceGroupInput =
@@ -206,6 +208,7 @@ export const AttestationsCreateOrUpdateAtSubscriptionInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.PolicyInsights/attestations/{attestationName}",
       apiVersion: "2024-10-01",
+      longRunning: {},
     }),
   );
 export type AttestationsCreateOrUpdateAtSubscriptionInput =
@@ -4617,6 +4620,7 @@ export const PolicyStatesTriggerResourceGroupEvaluationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.PolicyInsights/policyStates/latest/triggerEvaluation",
       apiVersion: "2024-10-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PolicyStatesTriggerResourceGroupEvaluationInput =
@@ -4644,6 +4648,7 @@ export const PolicyStatesTriggerSubscriptionEvaluationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.PolicyInsights/policyStates/latest/triggerEvaluation",
       apiVersion: "2024-10-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PolicyStatesTriggerSubscriptionEvaluationInput =

--- a/packages/azure/src/services/postgresql.ts
+++ b/packages/azure/src/services/postgresql.ts
@@ -30,6 +30,7 @@ export const AdministratorsMicrosoftEntraCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/administrators/{objectId}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AdministratorsMicrosoftEntraCreateOrUpdateInput =
@@ -68,6 +69,7 @@ export const AdministratorsMicrosoftEntraDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/administrators/{objectId}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AdministratorsMicrosoftEntraDeleteInput =
@@ -356,6 +358,7 @@ export const BackupsAutomaticAndOnDemandCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/backups/{backupName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type BackupsAutomaticAndOnDemandCreateInput =
@@ -394,6 +397,7 @@ export const BackupsAutomaticAndOnDemandDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/backups/{backupName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BackupsAutomaticAndOnDemandDeleteInput =
@@ -731,6 +735,7 @@ export const BackupsLongTermRetentionStartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/startLtrBackup",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BackupsLongTermRetentionStartInput =
@@ -1099,6 +1104,7 @@ export const ConfigurationsPutInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/configurations/{configurationName}",
     apiVersion: "2025-08-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type ConfigurationsPutInput = typeof ConfigurationsPutInput.Type;
@@ -1157,6 +1163,7 @@ export const ConfigurationsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/configurations/{configurationName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ConfigurationsUpdateInput = typeof ConfigurationsUpdateInput.Type;
@@ -1199,6 +1206,7 @@ export const DatabasesCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/databases/{databaseName}",
     apiVersion: "2025-08-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type DatabasesCreateInput = typeof DatabasesCreateInput.Type;
@@ -1232,6 +1240,7 @@ export const DatabasesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/databases/{databaseName}",
     apiVersion: "2025-08-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type DatabasesDeleteInput = typeof DatabasesDeleteInput.Type;
@@ -1390,6 +1399,7 @@ export const FirewallRulesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/firewallRules/{firewallRuleName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type FirewallRulesCreateOrUpdateInput =
@@ -1429,6 +1439,7 @@ export const FirewallRulesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/firewallRules/{firewallRuleName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type FirewallRulesDeleteInput = typeof FirewallRulesDeleteInput.Type;
@@ -2388,6 +2399,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =
@@ -2588,6 +2600,7 @@ export const PrivateEndpointConnectionsUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PrivateEndpointConnectionsUpdateInput =
@@ -3115,6 +3128,7 @@ export const ServersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/flexibleServers/{serverName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ServersCreateOrUpdateInput = typeof ServersCreateOrUpdateInput.Type;
@@ -3150,6 +3164,7 @@ export const ServersDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/flexibleServers/{serverName}",
     apiVersion: "2025-08-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ServersDeleteInput = typeof ServersDeleteInput.Type;
@@ -3373,6 +3388,7 @@ export const ServersRestartInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/restart",
     apiVersion: "2025-08-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ServersRestartInput = typeof ServersRestartInput.Type;
@@ -3404,6 +3420,7 @@ export const ServersStartInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/start",
     apiVersion: "2025-08-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ServersStartInput = typeof ServersStartInput.Type;
@@ -3435,6 +3452,7 @@ export const ServersStopInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/stop",
     apiVersion: "2025-08-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ServersStopInput = typeof ServersStopInput.Type;
@@ -3646,6 +3664,7 @@ export const ServersUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/flexibleServers/{serverName}",
     apiVersion: "2025-08-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type ServersUpdateInput = typeof ServersUpdateInput.Type;
@@ -3685,6 +3704,7 @@ export const ServerThreatProtectionSettingsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/advancedThreatProtectionSettings/{threatProtectionName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ServerThreatProtectionSettingsCreateOrUpdateInput =
@@ -3928,6 +3948,7 @@ export const VirtualEndpointsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/virtualendpoints/{virtualEndpointName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualEndpointsCreateInput =
@@ -3967,6 +3988,7 @@ export const VirtualEndpointsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/virtualendpoints/{virtualEndpointName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualEndpointsDeleteInput =
@@ -4135,6 +4157,7 @@ export const VirtualEndpointsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/flexibleServers/{serverName}/virtualendpoints/{virtualEndpointName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualEndpointsUpdateInput =

--- a/packages/azure/src/services/postgresqlhsc.ts
+++ b/packages/azure/src/services/postgresqlhsc.ts
@@ -135,6 +135,7 @@ export const ClustersCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/serverGroupsv2/{clusterName}",
     apiVersion: "2022-11-08",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type ClustersCreateInput = typeof ClustersCreateInput.Type;
@@ -182,6 +183,7 @@ export const ClustersDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/serverGroupsv2/{clusterName}",
     apiVersion: "2022-11-08",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ClustersDeleteInput = typeof ClustersDeleteInput.Type;
@@ -391,6 +393,7 @@ export const ClustersPromoteReadReplicaInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/serverGroupsv2/{clusterName}/promote",
       apiVersion: "2022-11-08",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ClustersPromoteReadReplicaInput =
@@ -425,6 +428,7 @@ export const ClustersRestartInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/serverGroupsv2/{clusterName}/restart",
     apiVersion: "2022-11-08",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ClustersRestartInput = typeof ClustersRestartInput.Type;
@@ -454,6 +458,7 @@ export const ClustersStartInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/serverGroupsv2/{clusterName}/start",
     apiVersion: "2022-11-08",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ClustersStartInput = typeof ClustersStartInput.Type;
@@ -483,6 +488,7 @@ export const ClustersStopInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/serverGroupsv2/{clusterName}/stop",
     apiVersion: "2022-11-08",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ClustersStopInput = typeof ClustersStopInput.Type;
@@ -540,6 +546,7 @@ export const ClustersUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/serverGroupsv2/{clusterName}",
     apiVersion: "2022-11-08",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ClustersUpdateInput = typeof ClustersUpdateInput.Type;
@@ -898,6 +905,7 @@ export const ConfigurationsUpdateOnCoordinatorInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/serverGroupsv2/{clusterName}/coordinatorConfigurations/{configurationName}",
       apiVersion: "2022-11-08",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ConfigurationsUpdateOnCoordinatorInput =
@@ -966,6 +974,7 @@ export const ConfigurationsUpdateOnNodeInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/serverGroupsv2/{clusterName}/nodeConfigurations/{configurationName}",
       apiVersion: "2022-11-08",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ConfigurationsUpdateOnNodeInput =
@@ -1026,6 +1035,7 @@ export const FirewallRulesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/serverGroupsv2/{clusterName}/firewallRules/{firewallRuleName}",
       apiVersion: "2022-11-08",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type FirewallRulesCreateOrUpdateInput =
@@ -1079,6 +1089,7 @@ export const FirewallRulesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/serverGroupsv2/{clusterName}/firewallRules/{firewallRuleName}",
       apiVersion: "2022-11-08",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type FirewallRulesDeleteInput = typeof FirewallRulesDeleteInput.Type;
@@ -1315,6 +1326,7 @@ export const PrivateEndpointConnectionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/serverGroupsv2/{clusterName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2022-11-08",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PrivateEndpointConnectionsCreateOrUpdateInput =
@@ -1368,6 +1380,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/serverGroupsv2/{clusterName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2022-11-08",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =
@@ -1648,6 +1661,7 @@ export const RolesCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/serverGroupsv2/{clusterName}/roles/{roleName}",
     apiVersion: "2022-11-08",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type RolesCreateInput = typeof RolesCreateInput.Type;
@@ -1695,6 +1709,7 @@ export const RolesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DBforPostgreSQL/serverGroupsv2/{clusterName}/roles/{roleName}",
     apiVersion: "2022-11-08",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type RolesDeleteInput = typeof RolesDeleteInput.Type;

--- a/packages/azure/src/services/powerbidedicated.ts
+++ b/packages/azure/src/services/powerbidedicated.ts
@@ -431,6 +431,7 @@ export const CapacitiesCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.PowerBIDedicated/capacities/{dedicatedCapacityName}",
     apiVersion: "2021-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type CapacitiesCreateInput = typeof CapacitiesCreateInput.Type;
@@ -482,6 +483,7 @@ export const CapacitiesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.PowerBIDedicated/capacities/{dedicatedCapacityName}",
     apiVersion: "2021-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type CapacitiesDeleteInput = typeof CapacitiesDeleteInput.Type;
@@ -777,6 +779,7 @@ export const CapacitiesResumeInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.PowerBIDedicated/capacities/{dedicatedCapacityName}/resume",
     apiVersion: "2021-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type CapacitiesResumeInput = typeof CapacitiesResumeInput.Type;
@@ -810,6 +813,7 @@ export const CapacitiesSuspendInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.PowerBIDedicated/capacities/{dedicatedCapacityName}/suspend",
     apiVersion: "2021-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type CapacitiesSuspendInput = typeof CapacitiesSuspendInput.Type;
@@ -863,6 +867,7 @@ export const CapacitiesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.PowerBIDedicated/capacities/{dedicatedCapacityName}",
     apiVersion: "2021-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type CapacitiesUpdateInput = typeof CapacitiesUpdateInput.Type;

--- a/packages/azure/src/services/powerbiembedded.ts
+++ b/packages/azure/src/services/powerbiembedded.ts
@@ -155,6 +155,7 @@ export const WorkspaceCollectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.PowerBI/workspaceCollections/{workspaceCollectionName}",
       apiVersion: "2016-01-29",
+      longRunning: {},
     }),
   );
 export type WorkspaceCollectionsDeleteInput =

--- a/packages/azure/src/services/powerbiprivatelinks.ts
+++ b/packages/azure/src/services/powerbiprivatelinks.ts
@@ -760,6 +760,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.PowerBI/privateLinkServicesForPowerBI/{azureResourceName}/privateEndpointConnections/{privateEndpointName}",
       apiVersion: "2020-06-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =
@@ -1064,6 +1065,7 @@ export const PrivateLinkServiceResourceOperationResultsGetInput =
       method: "GET",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.PowerBI/operationResults/{operationId}",
       apiVersion: "2020-06-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PrivateLinkServiceResourceOperationResultsGetInput =

--- a/packages/azure/src/services/privatedns.ts
+++ b/packages/azure/src/services/privatedns.ts
@@ -47,6 +47,7 @@ export const PrivateZonesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateDnsZones/{privateZoneName}",
       apiVersion: "2024-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateZonesCreateOrUpdateInput =
@@ -104,6 +105,7 @@ export const PrivateZonesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateDnsZones/{privateZoneName}",
       apiVersion: "2024-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateZonesDeleteInput = typeof PrivateZonesDeleteInput.Type;
@@ -347,6 +349,7 @@ export const PrivateZonesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateDnsZones/{privateZoneName}",
       apiVersion: "2024-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateZonesUpdateInput = typeof PrivateZonesUpdateInput.Type;
@@ -954,6 +957,7 @@ export const VirtualNetworkLinksCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateDnsZones/{privateZoneName}/virtualNetworkLinks/{virtualNetworkLinkName}",
       apiVersion: "2024-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkLinksCreateOrUpdateInput =
@@ -1012,6 +1016,7 @@ export const VirtualNetworkLinksDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateDnsZones/{privateZoneName}/virtualNetworkLinks/{virtualNetworkLinkName}",
       apiVersion: "2024-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkLinksDeleteInput =
@@ -1210,6 +1215,7 @@ export const VirtualNetworkLinksUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateDnsZones/{privateZoneName}/virtualNetworkLinks/{virtualNetworkLinkName}",
       apiVersion: "2024-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkLinksUpdateInput =

--- a/packages/azure/src/services/providerhub.ts
+++ b/packages/azure/src/services/providerhub.ts
@@ -54,6 +54,7 @@ export const AuthorizedApplicationsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.ProviderHub/providerRegistrations/{providerNamespace}/authorizedApplications/{applicationId}",
       apiVersion: "2024-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AuthorizedApplicationsCreateOrUpdateInput =
@@ -434,6 +435,7 @@ export const CustomRolloutsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.ProviderHub/providerRegistrations/{providerNamespace}/customRollouts/{rolloutName}",
       apiVersion: "2024-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CustomRolloutsCreateOrUpdateInput =
@@ -829,6 +831,7 @@ export const DefaultRolloutsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.ProviderHub/providerRegistrations/{providerNamespace}/defaultRollouts/{rolloutName}",
       apiVersion: "2024-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DefaultRolloutsCreateOrUpdateInput =
@@ -3274,6 +3277,7 @@ export const ProviderMonitorSettingsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ProviderHub/providerMonitorSettings/{providerMonitorSettingName}",
       apiVersion: "2024-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ProviderMonitorSettingsCreateInput =
@@ -4016,6 +4020,7 @@ export const ProviderRegistrationsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.ProviderHub/providerRegistrations/{providerNamespace}",
       apiVersion: "2024-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ProviderRegistrationsCreateOrUpdateInput =
@@ -4285,6 +4290,7 @@ export const ResourceActionsDeleteResourcesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.ProviderHub/providerRegistrations/{providerNamespace}/resourceActions/{resourceActionName}/deleteResources",
       apiVersion: "2024-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ResourceActionsDeleteResourcesInput =
@@ -5146,6 +5152,7 @@ export const ResourceTypeRegistrationsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.ProviderHub/providerRegistrations/{providerNamespace}/resourcetypeRegistrations/{resourceType}",
       apiVersion: "2024-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ResourceTypeRegistrationsCreateOrUpdateInput =
@@ -5200,6 +5207,7 @@ export const ResourceTypeRegistrationsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.ProviderHub/providerRegistrations/{providerNamespace}/resourcetypeRegistrations/{resourceType}",
       apiVersion: "2024-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ResourceTypeRegistrationsDeleteInput =

--- a/packages/azure/src/services/purview.ts
+++ b/packages/azure/src/services/purview.ts
@@ -235,6 +235,7 @@ export const AccountsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Purview/accounts/{accountName}",
       apiVersion: "2021-12-01",
+      longRunning: {},
     }),
   );
 export type AccountsCreateOrUpdateInput =
@@ -304,6 +305,7 @@ export const AccountsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Purview/accounts/{accountName}",
     apiVersion: "2021-12-01",
+    longRunning: {},
   }),
 );
 export type AccountsDeleteInput = typeof AccountsDeleteInput.Type;
@@ -728,6 +730,7 @@ export const AccountsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Purview/accounts/{accountName}",
     apiVersion: "2021-12-01",
+    longRunning: {},
   }),
 );
 export type AccountsUpdateInput = typeof AccountsUpdateInput.Type;
@@ -1358,6 +1361,7 @@ export const PrivateEndpointConnectionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Purview/accounts/{accountName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2021-12-01",
+      longRunning: {},
     }),
   );
 export type PrivateEndpointConnectionsCreateOrUpdateInput =
@@ -1409,6 +1413,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Purview/accounts/{accountName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2021-12-01",
+      longRunning: {},
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =

--- a/packages/azure/src/services/quota.ts
+++ b/packages/azure/src/services/quota.ts
@@ -252,6 +252,7 @@ export const GroupQuotaLimitsRequestUpdateInput =
       method: "PATCH",
       path: "/providers/Microsoft.Management/managementGroups/{managementGroupId}/providers/Microsoft.Quota/groupQuotas/{groupQuotaName}/resourceProviders/{resourceProviderName}/groupQuotaLimits/{location}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type GroupQuotaLimitsRequestUpdateInput =
@@ -330,6 +331,7 @@ export const GroupQuotaLocationSettingsCreateOrUpdateInput =
       method: "PUT",
       path: "/providers/Microsoft.Management/managementGroups/{managementGroupId}/providers/Microsoft.Quota/groupQuotas/{groupQuotaName}/resourceProviders/{resourceProviderName}/locationSettings/{location}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type GroupQuotaLocationSettingsCreateOrUpdateInput =
@@ -467,6 +469,7 @@ export const GroupQuotaLocationSettingsUpdateInput =
       method: "PATCH",
       path: "/providers/Microsoft.Management/managementGroups/{managementGroupId}/providers/Microsoft.Quota/groupQuotas/{groupQuotaName}/resourceProviders/{resourceProviderName}/locationSettings/{location}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type GroupQuotaLocationSettingsUpdateInput =
@@ -545,6 +548,7 @@ export const GroupQuotasCreateOrUpdateInput =
       method: "PUT",
       path: "/providers/Microsoft.Management/managementGroups/{managementGroupId}/providers/Microsoft.Quota/groupQuotas/{groupQuotaName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type GroupQuotasCreateOrUpdateInput =
@@ -599,6 +603,7 @@ export const GroupQuotasDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/providers/Microsoft.Management/managementGroups/{managementGroupId}/providers/Microsoft.Quota/groupQuotas/{groupQuotaName}",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type GroupQuotasDeleteInput = typeof GroupQuotasDeleteInput.Type;
@@ -958,6 +963,7 @@ export const GroupQuotaSubscriptionAllocationRequestUpdateInput =
       method: "PATCH",
       path: "/providers/Microsoft.Management/managementGroups/{managementGroupId}/subscriptions/{subscriptionId}/providers/Microsoft.Quota/groupQuotas/{groupQuotaName}/resourceProviders/{resourceProviderName}/quotaAllocations/{location}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type GroupQuotaSubscriptionAllocationRequestUpdateInput =
@@ -1135,6 +1141,7 @@ export const GroupQuotaSubscriptionsCreateOrUpdateInput =
       method: "PUT",
       path: "/providers/Microsoft.Management/managementGroups/{managementGroupId}/providers/Microsoft.Quota/groupQuotas/{groupQuotaName}/subscriptions/{subscriptionId}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type GroupQuotaSubscriptionsCreateOrUpdateInput =
@@ -1189,6 +1196,7 @@ export const GroupQuotaSubscriptionsDeleteInput =
       method: "DELETE",
       path: "/providers/Microsoft.Management/managementGroups/{managementGroupId}/providers/Microsoft.Quota/groupQuotas/{groupQuotaName}/subscriptions/{subscriptionId}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type GroupQuotaSubscriptionsDeleteInput =
@@ -1348,6 +1356,7 @@ export const GroupQuotaSubscriptionsUpdateInput =
       method: "PATCH",
       path: "/providers/Microsoft.Management/managementGroups/{managementGroupId}/providers/Microsoft.Quota/groupQuotas/{groupQuotaName}/subscriptions/{subscriptionId}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type GroupQuotaSubscriptionsUpdateInput =
@@ -1419,6 +1428,7 @@ export const GroupQuotasUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "PATCH",
     path: "/providers/Microsoft.Management/managementGroups/{managementGroupId}/providers/Microsoft.Quota/groupQuotas/{groupQuotaName}",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type GroupQuotasUpdateInput = typeof GroupQuotasUpdateInput.Type;
@@ -1559,6 +1569,7 @@ export const QuotaCreateOrUpdateInput =
       method: "PUT",
       path: "/{scope}/providers/Microsoft.Quota/quotas/{resourceName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type QuotaCreateOrUpdateInput = typeof QuotaCreateOrUpdateInput.Type;
@@ -1903,6 +1914,7 @@ export const QuotaUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/{scope}/providers/Microsoft.Quota/quotas/{resourceName}",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "original-uri" },
   }),
 );
 export type QuotaUpdateInput = typeof QuotaUpdateInput.Type;

--- a/packages/azure/src/services/recommendationsservice.ts
+++ b/packages/azure/src/services/recommendationsservice.ts
@@ -104,6 +104,7 @@ export const AccountsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecommendationsService/accounts/{accountName}",
       apiVersion: "2022-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AccountsCreateOrUpdateInput =
@@ -142,6 +143,7 @@ export const AccountsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecommendationsService/accounts/{accountName}",
     apiVersion: "2022-02-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type AccountsDeleteInput = typeof AccountsDeleteInput.Type;
@@ -371,6 +373,7 @@ export const AccountsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecommendationsService/accounts/{accountName}",
     apiVersion: "2022-02-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type AccountsUpdateInput = typeof AccountsUpdateInput.Type;
@@ -436,6 +439,7 @@ export const ModelingCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecommendationsService/accounts/{accountName}/modeling/{modelingName}",
       apiVersion: "2022-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ModelingCreateOrUpdateInput =
@@ -474,6 +478,7 @@ export const ModelingDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecommendationsService/accounts/{accountName}/modeling/{modelingName}",
     apiVersion: "2022-02-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type ModelingDeleteInput = typeof ModelingDeleteInput.Type;
@@ -591,6 +596,7 @@ export const ModelingUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecommendationsService/accounts/{accountName}/modeling/{modelingName}",
     apiVersion: "2022-02-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type ModelingUpdateInput = typeof ModelingUpdateInput.Type;
@@ -784,6 +790,7 @@ export const ServiceEndpointsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecommendationsService/accounts/{accountName}/serviceEndpoints/{serviceEndpointName}",
       apiVersion: "2022-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ServiceEndpointsCreateOrUpdateInput =
@@ -822,6 +829,7 @@ export const ServiceEndpointsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecommendationsService/accounts/{accountName}/serviceEndpoints/{serviceEndpointName}",
       apiVersion: "2022-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ServiceEndpointsDeleteInput =
@@ -938,6 +946,7 @@ export const ServiceEndpointsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecommendationsService/accounts/{accountName}/serviceEndpoints/{serviceEndpointName}",
       apiVersion: "2022-02-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ServiceEndpointsUpdateInput =

--- a/packages/azure/src/services/recoveryservices.ts
+++ b/packages/azure/src/services/recoveryservices.ts
@@ -199,6 +199,7 @@ export const DeletedVaultsUndeleteInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.RecoveryServices/locations/{location}/deletedVaults/{deletedVaultName}/undelete",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeletedVaultsUndeleteInput = typeof DeletedVaultsUndeleteInput.Type;
@@ -1349,6 +1350,7 @@ export const VaultsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VaultsCreateOrUpdateInput = typeof VaultsCreateOrUpdateInput.Type;
@@ -1401,6 +1403,7 @@ export const VaultsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}",
     apiVersion: "2026-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type VaultsDeleteInput = typeof VaultsDeleteInput.Type;
@@ -1886,6 +1889,7 @@ export const VaultsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}",
     apiVersion: "2026-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type VaultsUpdateInput = typeof VaultsUpdateInput.Type;

--- a/packages/azure/src/services/recoveryservicesbackup.ts
+++ b/packages/azure/src/services/recoveryservicesbackup.ts
@@ -1289,6 +1289,7 @@ export const BMSPrepareDataMoveInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupstorageconfig/vaultstorageconfig/prepareDataMove",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BMSPrepareDataMoveInput = typeof BMSPrepareDataMoveInput.Type;
@@ -1367,6 +1368,7 @@ export const BMSTriggerDataMoveInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupstorageconfig/vaultstorageconfig/triggerDataMove",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BMSTriggerDataMoveInput = typeof BMSTriggerDataMoveInput.Type;
@@ -1592,6 +1594,7 @@ export const FetchTieringCostPostInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupTieringCost/default/fetchTieringCost",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type FetchTieringCostPostInput = typeof FetchTieringCostPostInput.Type;
@@ -2022,6 +2025,7 @@ export const MoveRecoveryPointInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupFabrics/{fabricName}/protectionContainers/{containerName}/protectedItems/{protectedItemName}/recoveryPoints/{recoveryPointId}/move",
     apiVersion: "2025-08-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type MoveRecoveryPointInput = typeof MoveRecoveryPointInput.Type;
@@ -2172,6 +2176,7 @@ export const PrivateEndpointConnectionDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionDeleteInput =
@@ -2304,6 +2309,7 @@ export const PrivateEndpointConnectionPutInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionPutInput =
@@ -2663,6 +2669,7 @@ export const ProtectedItemsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupFabrics/{fabricName}/protectionContainers/{containerName}/protectedItems/{protectedItemName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ProtectedItemsCreateOrUpdateInput =
@@ -3114,6 +3121,7 @@ export const ProtectionContainersRegisterInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupFabrics/{fabricName}/protectionContainers/{containerName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ProtectionContainersRegisterInput =
@@ -3553,6 +3561,7 @@ export const ProtectionPoliciesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupPolicies/{policyName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ProtectionPoliciesDeleteInput =
@@ -4204,6 +4213,7 @@ export const RestoresTriggerInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupFabrics/{fabricName}/protectionContainers/{containerName}/protectedItems/{protectedItemName}/recoveryPoints/{recoveryPointId}/restore",
     apiVersion: "2025-08-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type RestoresTriggerInput = typeof RestoresTriggerInput.Type;
@@ -4461,6 +4471,7 @@ export const ValidateOperationTriggerInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupTriggerValidateOperation",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ValidateOperationTriggerInput =

--- a/packages/azure/src/services/recoveryservicesdatareplication.ts
+++ b/packages/azure/src/services/recoveryservicesdatareplication.ts
@@ -514,6 +514,7 @@ export const FabricAgentCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataReplication/replicationFabrics/{fabricName}/fabricAgents/{fabricAgentName}",
     apiVersion: "2024-09-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type FabricAgentCreateInput = typeof FabricAgentCreateInput.Type;
@@ -568,6 +569,7 @@ export const FabricAgentDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataReplication/replicationFabrics/{fabricName}/fabricAgents/{fabricAgentName}",
     apiVersion: "2024-09-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type FabricAgentDeleteInput = typeof FabricAgentDeleteInput.Type;
@@ -768,6 +770,7 @@ export const FabricCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataReplication/replicationFabrics/{fabricName}",
     apiVersion: "2024-09-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type FabricCreateInput = typeof FabricCreateInput.Type;
@@ -817,6 +820,7 @@ export const FabricDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataReplication/replicationFabrics/{fabricName}",
     apiVersion: "2024-09-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type FabricDeleteInput = typeof FabricDeleteInput.Type;
@@ -1096,6 +1100,7 @@ export const FabricUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataReplication/replicationFabrics/{fabricName}",
     apiVersion: "2024-09-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type FabricUpdateInput = typeof FabricUpdateInput.Type;
@@ -1410,6 +1415,7 @@ export const PolicyCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataReplication/replicationVaults/{vaultName}/replicationPolicies/{policyName}",
     apiVersion: "2024-09-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type PolicyCreateInput = typeof PolicyCreateInput.Type;
@@ -1461,6 +1467,7 @@ export const PolicyDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataReplication/replicationVaults/{vaultName}/replicationPolicies/{policyName}",
     apiVersion: "2024-09-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type PolicyDeleteInput = typeof PolicyDeleteInput.Type;
@@ -1748,6 +1755,7 @@ export const PrivateEndpointConnectionProxiesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataReplication/replicationVaults/{vaultName}/privateEndpointConnectionProxies/{privateEndpointConnectionProxyName}",
       apiVersion: "2024-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionProxiesDeleteInput =
@@ -2059,6 +2067,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataReplication/replicationVaults/{vaultName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2024-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =
@@ -2637,6 +2646,7 @@ export const ProtectedItemCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataReplication/replicationVaults/{vaultName}/protectedItems/{protectedItemName}",
       apiVersion: "2024-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ProtectedItemCreateInput = typeof ProtectedItemCreateInput.Type;
@@ -2691,6 +2701,7 @@ export const ProtectedItemDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataReplication/replicationVaults/{vaultName}/protectedItems/{protectedItemName}",
       apiVersion: "2024-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ProtectedItemDeleteInput = typeof ProtectedItemDeleteInput.Type;
@@ -2858,6 +2869,7 @@ export const ProtectedItemPlannedFailoverInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataReplication/replicationVaults/{vaultName}/protectedItems/{protectedItemName}/plannedFailover",
       apiVersion: "2024-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ProtectedItemPlannedFailoverInput =
@@ -2928,6 +2940,7 @@ export const ProtectedItemUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataReplication/replicationVaults/{vaultName}/protectedItems/{protectedItemName}",
       apiVersion: "2024-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ProtectedItemUpdateInput = typeof ProtectedItemUpdateInput.Type;
@@ -3123,6 +3136,7 @@ export const ReplicationExtensionCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataReplication/replicationVaults/{vaultName}/replicationExtensions/{replicationExtensionName}",
       apiVersion: "2024-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ReplicationExtensionCreateInput =
@@ -3180,6 +3194,7 @@ export const ReplicationExtensionDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataReplication/replicationVaults/{vaultName}/replicationExtensions/{replicationExtensionName}",
       apiVersion: "2024-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationExtensionDeleteInput =
@@ -3386,6 +3401,7 @@ export const VaultCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataReplication/replicationVaults/{vaultName}",
     apiVersion: "2024-09-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type VaultCreateInput = typeof VaultCreateInput.Type;
@@ -3435,6 +3451,7 @@ export const VaultDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataReplication/replicationVaults/{vaultName}",
     apiVersion: "2024-09-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type VaultDeleteInput = typeof VaultDeleteInput.Type;
@@ -3679,6 +3696,7 @@ export const VaultUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataReplication/replicationVaults/{vaultName}",
     apiVersion: "2024-09-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type VaultUpdateInput = typeof VaultUpdateInput.Type;

--- a/packages/azure/src/services/recoveryservicessiterecovery.ts
+++ b/packages/azure/src/services/recoveryservicessiterecovery.ts
@@ -988,6 +988,7 @@ export const ReplicationFabricsCheckConsistencyInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/checkConsistency",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationFabricsCheckConsistencyInput =
@@ -1055,6 +1056,7 @@ export const ReplicationFabricsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationFabricsCreateInput =
@@ -1114,6 +1116,7 @@ export const ReplicationFabricsDeleteInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/remove",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationFabricsDeleteInput =
@@ -1287,6 +1290,7 @@ export const ReplicationFabricsMigrateToAadInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/migratetoaad",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationFabricsMigrateToAadInput =
@@ -1327,6 +1331,7 @@ export const ReplicationFabricsPurgeInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationFabricsPurgeInput =
@@ -1377,6 +1382,7 @@ export const ReplicationFabricsReassociateGatewayInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/reassociateGateway",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationFabricsReassociateGatewayInput =
@@ -1435,6 +1441,7 @@ export const ReplicationFabricsRemoveInfraInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/removeInfra",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationFabricsRemoveInfraInput =
@@ -1478,6 +1485,7 @@ export const ReplicationFabricsRenewCertificateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/renewCertificate",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationFabricsRenewCertificateInput =
@@ -1536,6 +1544,7 @@ export const ReplicationJobsCancelInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationJobs/{jobName}/cancel",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationJobsCancelInput = typeof ReplicationJobsCancelInput.Type;
@@ -1601,6 +1610,7 @@ export const ReplicationJobsExportInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationJobs/export",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationJobsExportInput = typeof ReplicationJobsExportInput.Type;
@@ -1783,6 +1793,7 @@ export const ReplicationJobsRestartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationJobs/{jobName}/restart",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationJobsRestartInput =
@@ -1847,6 +1858,7 @@ export const ReplicationJobsResumeInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationJobs/{jobName}/resume",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationJobsResumeInput = typeof ReplicationJobsResumeInput.Type;
@@ -2046,6 +2058,7 @@ export const ReplicationMigrationItemsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationMigrationItems/{migrationItemName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationMigrationItemsCreateInput =
@@ -2109,6 +2122,7 @@ export const ReplicationMigrationItemsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationMigrationItems/{migrationItemName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationMigrationItemsDeleteInput =
@@ -2377,6 +2391,7 @@ export const ReplicationMigrationItemsMigrateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationMigrationItems/{migrationItemName}/migrate",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationMigrationItemsMigrateInput =
@@ -2442,6 +2457,7 @@ export const ReplicationMigrationItemsPauseReplicationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationMigrationItems/{migrationItemName}/pauseReplication",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationMigrationItemsPauseReplicationInput =
@@ -2509,6 +2525,7 @@ export const ReplicationMigrationItemsResumeReplicationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationMigrationItems/{migrationItemName}/resumeReplication",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationMigrationItemsResumeReplicationInput =
@@ -2576,6 +2593,7 @@ export const ReplicationMigrationItemsResyncInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationMigrationItems/{migrationItemName}/resync",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationMigrationItemsResyncInput =
@@ -2643,6 +2661,7 @@ export const ReplicationMigrationItemsTestMigrateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationMigrationItems/{migrationItemName}/testMigrate",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationMigrationItemsTestMigrateInput =
@@ -2708,6 +2727,7 @@ export const ReplicationMigrationItemsTestMigrateCleanupInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationMigrationItems/{migrationItemName}/testMigrateCleanup",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationMigrationItemsTestMigrateCleanupInput =
@@ -2777,6 +2797,7 @@ export const ReplicationMigrationItemsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationMigrationItems/{migrationItemName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationMigrationItemsUpdateInput =
@@ -2848,6 +2869,7 @@ export const ReplicationNetworkMappingsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationNetworks/{networkName}/replicationNetworkMappings/{networkMappingName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationNetworkMappingsCreateInput =
@@ -2910,6 +2932,7 @@ export const ReplicationNetworkMappingsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationNetworks/{networkName}/replicationNetworkMappings/{networkMappingName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationNetworkMappingsDeleteInput =
@@ -3173,6 +3196,7 @@ export const ReplicationNetworkMappingsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationNetworks/{networkName}/replicationNetworkMappings/{networkMappingName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationNetworkMappingsUpdateInput =
@@ -3448,6 +3472,7 @@ export const ReplicationPoliciesCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationPolicies/{policyName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationPoliciesCreateInput =
@@ -3507,6 +3532,7 @@ export const ReplicationPoliciesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationPolicies/{policyName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationPoliciesDeleteInput =
@@ -3688,6 +3714,7 @@ export const ReplicationPoliciesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationPolicies/{policyName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationPoliciesUpdateInput =
@@ -3901,6 +3928,7 @@ export const ReplicationProtectedItemsAddDisksInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}/addDisks",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationProtectedItemsAddDisksInput =
@@ -3969,6 +3997,7 @@ export const ReplicationProtectedItemsApplyRecoveryPointInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}/applyRecoveryPoint",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationProtectedItemsApplyRecoveryPointInput =
@@ -4042,6 +4071,7 @@ export const ReplicationProtectedItemsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationProtectedItemsCreateInput =
@@ -4114,6 +4144,7 @@ export const ReplicationProtectedItemsDeleteInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}/remove",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationProtectedItemsDeleteInput =
@@ -4158,6 +4189,7 @@ export const ReplicationProtectedItemsFailoverCancelInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}/failoverCancel",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationProtectedItemsFailoverCancelInput =
@@ -4220,6 +4252,7 @@ export const ReplicationProtectedItemsFailoverCommitInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}/failoverCommit",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationProtectedItemsFailoverCommitInput =
@@ -4506,6 +4539,7 @@ export const ReplicationProtectedItemsPlannedFailoverInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}/plannedFailover",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationProtectedItemsPlannedFailoverInput =
@@ -4568,6 +4602,7 @@ export const ReplicationProtectedItemsPurgeInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationProtectedItemsPurgeInput =
@@ -4617,6 +4652,7 @@ export const ReplicationProtectedItemsReinstallMobilityServiceInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}/reinstallMobilityService",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationProtectedItemsReinstallMobilityServiceInput =
@@ -4688,6 +4724,7 @@ export const ReplicationProtectedItemsRemoveDisksInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}/removeDisks",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationProtectedItemsRemoveDisksInput =
@@ -4750,6 +4787,7 @@ export const ReplicationProtectedItemsRepairReplicationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}/repairReplication",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationProtectedItemsRepairReplicationInput =
@@ -4822,6 +4860,7 @@ export const ReplicationProtectedItemsReprotectInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}/reProtect",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationProtectedItemsReprotectInput =
@@ -4895,6 +4934,7 @@ export const ReplicationProtectedItemsResolveHealthErrorsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}/resolveHealthErrors",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationProtectedItemsResolveHealthErrorsInput =
@@ -4967,6 +5007,7 @@ export const ReplicationProtectedItemsSwitchProviderInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}/switchProvider",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ReplicationProtectedItemsSwitchProviderInput =
@@ -5039,6 +5080,7 @@ export const ReplicationProtectedItemsTestFailoverInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}/testFailover",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationProtectedItemsTestFailoverInput =
@@ -5104,6 +5146,7 @@ export const ReplicationProtectedItemsTestFailoverCleanupInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}/testFailoverCleanup",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationProtectedItemsTestFailoverCleanupInput =
@@ -5175,6 +5218,7 @@ export const ReplicationProtectedItemsUnplannedFailoverInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}/unplannedFailover",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationProtectedItemsUnplannedFailoverInput =
@@ -5298,6 +5342,7 @@ export const ReplicationProtectedItemsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationProtectedItemsUpdateInput =
@@ -5366,6 +5411,7 @@ export const ReplicationProtectedItemsUpdateApplianceInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}/updateAppliance",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationProtectedItemsUpdateApplianceInput =
@@ -5433,6 +5479,7 @@ export const ReplicationProtectedItemsUpdateMobilityServiceInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectedItems/{replicatedProtectedItemName}/updateMobilityService",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationProtectedItemsUpdateMobilityServiceInput =
@@ -5504,6 +5551,7 @@ export const ReplicationProtectionClustersApplyRecoveryPointInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectionClusters/{replicationProtectionClusterName}/applyRecoveryPoint",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationProtectionClustersApplyRecoveryPointInput =
@@ -5730,6 +5778,7 @@ export const ReplicationProtectionClustersCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectionClusters/{replicationProtectionClusterName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationProtectionClustersCreateInput =
@@ -5792,6 +5841,7 @@ export const ReplicationProtectionClustersFailoverCommitInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectionClusters/{replicationProtectionClusterName}/failoverCommit",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationProtectionClustersFailoverCommitInput =
@@ -6132,6 +6182,7 @@ export const ReplicationProtectionClustersPurgeInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectionClusters/{replicationProtectionClusterName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationProtectionClustersPurgeInput =
@@ -6176,6 +6227,7 @@ export const ReplicationProtectionClustersRepairReplicationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectionClusters/{replicationProtectionClusterName}/repairReplication",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationProtectionClustersRepairReplicationInput =
@@ -6250,6 +6302,7 @@ export const ReplicationProtectionClustersTestFailoverInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectionClusters/{replicationProtectionClusterName}/testFailover",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationProtectionClustersTestFailoverInput =
@@ -6315,6 +6368,7 @@ export const ReplicationProtectionClustersTestFailoverCleanupInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectionClusters/{replicationProtectionClusterName}/testFailoverCleanup",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationProtectionClustersTestFailoverCleanupInput =
@@ -6386,6 +6440,7 @@ export const ReplicationProtectionClustersUnplannedFailoverInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectionClusters/{replicationProtectionClusterName}/unplannedFailover",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationProtectionClustersUnplannedFailoverInput =
@@ -6459,6 +6514,7 @@ export const ReplicationProtectionContainerMappingsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectionContainerMappings/{mappingName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationProtectionContainerMappingsCreateInput =
@@ -6530,6 +6586,7 @@ export const ReplicationProtectionContainerMappingsDeleteInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectionContainerMappings/{mappingName}/remove",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationProtectionContainerMappingsDeleteInput =
@@ -6784,6 +6841,7 @@ export const ReplicationProtectionContainerMappingsPurgeInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectionContainerMappings/{mappingName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationProtectionContainerMappingsPurgeInput =
@@ -6837,6 +6895,7 @@ export const ReplicationProtectionContainerMappingsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/replicationProtectionContainerMappings/{mappingName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationProtectionContainerMappingsUpdateInput =
@@ -6909,6 +6968,7 @@ export const ReplicationProtectionContainersCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationProtectionContainersCreateInput =
@@ -6969,6 +7029,7 @@ export const ReplicationProtectionContainersDeleteInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/remove",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationProtectionContainersDeleteInput =
@@ -7018,6 +7079,7 @@ export const ReplicationProtectionContainersDiscoverProtectableItemInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/discoverProtectableItem",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationProtectionContainersDiscoverProtectableItemInput =
@@ -7292,6 +7354,7 @@ export const ReplicationProtectionContainersSwitchClusterProtectionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/switchClusterProtection",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationProtectionContainersSwitchClusterProtectionInput =
@@ -7362,6 +7425,7 @@ export const ReplicationProtectionContainersSwitchProtectionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationProtectionContainers/{protectionContainerName}/switchprotection",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationProtectionContainersSwitchProtectionInput =
@@ -7710,6 +7774,7 @@ export const ReplicationRecoveryPlansCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationRecoveryPlans/{recoveryPlanName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationRecoveryPlansCreateInput =
@@ -7768,6 +7833,7 @@ export const ReplicationRecoveryPlansDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationRecoveryPlans/{recoveryPlanName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationRecoveryPlansDeleteInput =
@@ -7808,6 +7874,7 @@ export const ReplicationRecoveryPlansFailoverCancelInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationRecoveryPlans/{recoveryPlanName}/failoverCancel",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationRecoveryPlansFailoverCancelInput =
@@ -7866,6 +7933,7 @@ export const ReplicationRecoveryPlansFailoverCommitInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationRecoveryPlans/{recoveryPlanName}/failoverCommit",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationRecoveryPlansFailoverCommitInput =
@@ -8067,6 +8135,7 @@ export const ReplicationRecoveryPlansPlannedFailoverInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationRecoveryPlans/{recoveryPlanName}/plannedFailover",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationRecoveryPlansPlannedFailoverInput =
@@ -8125,6 +8194,7 @@ export const ReplicationRecoveryPlansReprotectInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationRecoveryPlans/{recoveryPlanName}/reProtect",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationRecoveryPlansReprotectInput =
@@ -8198,6 +8268,7 @@ export const ReplicationRecoveryPlansTestFailoverInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationRecoveryPlans/{recoveryPlanName}/testFailover",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationRecoveryPlansTestFailoverInput =
@@ -8259,6 +8330,7 @@ export const ReplicationRecoveryPlansTestFailoverCleanupInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationRecoveryPlans/{recoveryPlanName}/testFailoverCleanup",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationRecoveryPlansTestFailoverCleanupInput =
@@ -8331,6 +8403,7 @@ export const ReplicationRecoveryPlansUnplannedFailoverInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationRecoveryPlans/{recoveryPlanName}/unplannedFailover",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationRecoveryPlansUnplannedFailoverInput =
@@ -8476,6 +8549,7 @@ export const ReplicationRecoveryPlansUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationRecoveryPlans/{recoveryPlanName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationRecoveryPlansUpdateInput =
@@ -8563,6 +8637,7 @@ export const ReplicationRecoveryServicesProvidersCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationRecoveryServicesProviders/{providerName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationRecoveryServicesProvidersCreateInput =
@@ -8623,6 +8698,7 @@ export const ReplicationRecoveryServicesProvidersDeleteInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationRecoveryServicesProviders/{providerName}/remove",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationRecoveryServicesProvidersDeleteInput =
@@ -8871,6 +8947,7 @@ export const ReplicationRecoveryServicesProvidersPurgeInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationRecoveryServicesProviders/{providerName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationRecoveryServicesProvidersPurgeInput =
@@ -8913,6 +8990,7 @@ export const ReplicationRecoveryServicesProvidersRefreshProviderInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationRecoveryServicesProviders/{providerName}/refreshProvider",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationRecoveryServicesProvidersRefreshProviderInput =
@@ -8979,6 +9057,7 @@ export const ReplicationStorageClassificationMappingsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationStorageClassifications/{storageClassificationName}/replicationStorageClassificationMappings/{storageClassificationMappingName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationStorageClassificationMappingsCreateInput =
@@ -9041,6 +9120,7 @@ export const ReplicationStorageClassificationMappingsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationStorageClassifications/{storageClassificationName}/replicationStorageClassificationMappings/{storageClassificationMappingName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationStorageClassificationMappingsDeleteInput =
@@ -9554,6 +9634,7 @@ export const ReplicationVaultHealthRefreshInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationVaultHealth/default/refresh",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationVaultHealthRefreshInput =
@@ -9613,6 +9694,7 @@ export const ReplicationVaultSettingCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationVaultSettings/{vaultSettingName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationVaultSettingCreateInput =
@@ -9812,6 +9894,7 @@ export const ReplicationvCentersCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationvCenters/{vcenterName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationvCentersCreateInput =
@@ -9873,6 +9956,7 @@ export const ReplicationvCentersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationvCenters/{vcenterName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationvCentersDeleteInput =
@@ -10131,6 +10215,7 @@ export const ReplicationvCentersUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{resourceName}/replicationFabrics/{fabricName}/replicationvCenters/{vcenterName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationvCentersUpdateInput =

--- a/packages/azure/src/services/redhatopenshift.ts
+++ b/packages/azure/src/services/redhatopenshift.ts
@@ -182,6 +182,7 @@ export const OpenShiftClustersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RedHatOpenShift/openShiftClusters/{resourceName}",
       apiVersion: "2025-07-25",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type OpenShiftClustersCreateOrUpdateInput =
@@ -238,6 +239,7 @@ export const OpenShiftClustersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RedHatOpenShift/openShiftClusters/{resourceName}",
       apiVersion: "2025-07-25",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type OpenShiftClustersDeleteInput =
@@ -710,6 +712,7 @@ export const OpenShiftClustersUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RedHatOpenShift/openShiftClusters/{resourceName}",
       apiVersion: "2025-07-25",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type OpenShiftClustersUpdateInput =

--- a/packages/azure/src/services/redis.ts
+++ b/packages/azure/src/services/redis.ts
@@ -37,6 +37,7 @@ export const AccessPolicyAssignmentCreateUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redis/{cacheName}/accessPolicyAssignments/{accessPolicyAssignmentName}",
       apiVersion: "2024-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AccessPolicyAssignmentCreateUpdateInput =
@@ -93,6 +94,7 @@ export const AccessPolicyAssignmentDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redis/{cacheName}/accessPolicyAssignments/{accessPolicyAssignmentName}",
       apiVersion: "2024-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AccessPolicyAssignmentDeleteInput =
@@ -274,6 +276,7 @@ export const AccessPolicyCreateUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redis/{cacheName}/accessPolicies/{accessPolicyName}",
       apiVersion: "2024-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AccessPolicyCreateUpdateInput =
@@ -331,6 +334,7 @@ export const AccessPolicyDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redis/{cacheName}/accessPolicies/{accessPolicyName}",
       apiVersion: "2024-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AccessPolicyDeleteInput = typeof AccessPolicyDeleteInput.Type;
@@ -794,6 +798,7 @@ export const LinkedServerCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redis/{name}/linkedServers/{linkedServerName}",
       apiVersion: "2024-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LinkedServerCreateInput = typeof LinkedServerCreateInput.Type;
@@ -847,6 +852,7 @@ export const LinkedServerDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redis/{name}/linkedServers/{linkedServerName}",
       apiVersion: "2024-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LinkedServerDeleteInput = typeof LinkedServerDeleteInput.Type;
@@ -1475,6 +1481,7 @@ export const PrivateEndpointConnectionsPutInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redis/{cacheName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2024-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsPutInput =
@@ -1702,6 +1709,7 @@ export const RedisCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redis/{name}",
     apiVersion: "2024-11-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type RedisCreateInput = typeof RedisCreateInput.Type;
@@ -1751,6 +1759,7 @@ export const RedisDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redis/{name}",
     apiVersion: "2024-11-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type RedisDeleteInput = typeof RedisDeleteInput.Type;
@@ -1787,6 +1796,7 @@ export const RedisExportDataInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redis/{name}/export",
     apiVersion: "2024-11-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type RedisExportDataInput = typeof RedisExportDataInput.Type;
@@ -1818,6 +1828,7 @@ export const RedisFlushCacheInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redis/{cacheName}/flush",
     apiVersion: "2024-11-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type RedisFlushCacheInput = typeof RedisFlushCacheInput.Type;
@@ -1994,6 +2005,7 @@ export const RedisImportDataInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redis/{name}/import",
     apiVersion: "2024-11-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type RedisImportDataInput = typeof RedisImportDataInput.Type;
@@ -2349,6 +2361,7 @@ export const RedisUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redis/{name}",
     apiVersion: "2024-11-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type RedisUpdateInput = typeof RedisUpdateInput.Type;

--- a/packages/azure/src/services/redisenterprise.ts
+++ b/packages/azure/src/services/redisenterprise.ts
@@ -36,6 +36,7 @@ export const AccessPolicyAssignmentCreateUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}/databases/{databaseName}/accessPolicyAssignments/{accessPolicyAssignmentName}",
       apiVersion: "2025-07-01",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type AccessPolicyAssignmentCreateUpdateInput =
@@ -74,6 +75,7 @@ export const AccessPolicyAssignmentDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}/databases/{databaseName}/accessPolicyAssignments/{accessPolicyAssignmentName}",
       apiVersion: "2025-07-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AccessPolicyAssignmentDeleteInput =
@@ -289,6 +291,7 @@ export const DatabasesCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}/databases/{databaseName}",
     apiVersion: "2025-07-01",
+    longRunning: { finalStateVia: "original-uri" },
   }),
 );
 export type DatabasesCreateInput = typeof DatabasesCreateInput.Type;
@@ -322,6 +325,7 @@ export const DatabasesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}/databases/{databaseName}",
     apiVersion: "2025-07-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type DatabasesDeleteInput = typeof DatabasesDeleteInput.Type;
@@ -352,6 +356,7 @@ export const DatabasesExportInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}/databases/{databaseName}/export",
     apiVersion: "2025-07-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type DatabasesExportInput = typeof DatabasesExportInput.Type;
@@ -382,6 +387,7 @@ export const DatabasesFlushInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}/databases/{databaseName}/flush",
     apiVersion: "2025-07-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type DatabasesFlushInput = typeof DatabasesFlushInput.Type;
@@ -431,6 +437,7 @@ export const DatabasesForceLinkToReplicationGroupInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}/databases/{databaseName}/forceLinkToReplicationGroup",
       apiVersion: "2025-07-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DatabasesForceLinkToReplicationGroupInput =
@@ -466,6 +473,7 @@ export const DatabasesForceUnlinkInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}/databases/{databaseName}/forceUnlink",
       apiVersion: "2025-07-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DatabasesForceUnlinkInput = typeof DatabasesForceUnlinkInput.Type;
@@ -532,6 +540,7 @@ export const DatabasesImportInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}/databases/{databaseName}/import",
     apiVersion: "2025-07-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type DatabasesImportInput = typeof DatabasesImportInput.Type;
@@ -644,6 +653,7 @@ export const DatabasesRegenerateKeyInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}/databases/{databaseName}/regenerateKey",
       apiVersion: "2025-07-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DatabasesRegenerateKeyInput =
@@ -778,6 +788,7 @@ export const DatabasesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}/databases/{databaseName}",
     apiVersion: "2025-07-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type DatabasesUpdateInput = typeof DatabasesUpdateInput.Type;
@@ -812,6 +823,7 @@ export const DatabasesUpgradeDBRedisVersionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}/databases/{databaseName}/upgradeDBRedisVersion",
       apiVersion: "2025-07-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DatabasesUpgradeDBRedisVersionInput =
@@ -954,6 +966,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-07-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =
@@ -1096,6 +1109,7 @@ export const PrivateEndpointConnectionsPutInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-07-01",
+      longRunning: {},
     }),
   );
 export type PrivateEndpointConnectionsPutInput =
@@ -1338,6 +1352,7 @@ export const RedisEnterpriseCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}",
       apiVersion: "2025-07-01",
+      longRunning: { finalStateVia: "original-uri" },
     }),
   );
 export type RedisEnterpriseCreateInput = typeof RedisEnterpriseCreateInput.Type;
@@ -1376,6 +1391,7 @@ export const RedisEnterpriseDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}",
       apiVersion: "2025-07-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type RedisEnterpriseDeleteInput = typeof RedisEnterpriseDeleteInput.Type;
@@ -1730,6 +1746,7 @@ export const RedisEnterpriseUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}",
       apiVersion: "2025-07-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type RedisEnterpriseUpdateInput = typeof RedisEnterpriseUpdateInput.Type;

--- a/packages/azure/src/services/relay.ts
+++ b/packages/azure/src/services/relay.ts
@@ -676,6 +676,7 @@ export const NamespacesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Relay/namespaces/{namespaceName}",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NamespacesCreateOrUpdateInput =
@@ -863,6 +864,7 @@ export const NamespacesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Relay/namespaces/{namespaceName}",
     apiVersion: "2024-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type NamespacesDeleteInput = typeof NamespacesDeleteInput.Type;
@@ -1609,6 +1611,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Relay/namespaces/{namespaceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2024-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =

--- a/packages/azure/src/services/reservations.ts
+++ b/packages/azure/src/services/reservations.ts
@@ -140,6 +140,7 @@ export const CalculateExchangePostInput =
       method: "POST",
       path: "/providers/Microsoft.Capacity/calculateExchange",
       apiVersion: "2022-11-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CalculateExchangePostInput = typeof CalculateExchangePostInput.Type;
@@ -582,6 +583,7 @@ export const ExchangePostInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/providers/Microsoft.Capacity/exchange",
     apiVersion: "2022-11-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type ExchangePostInput = typeof ExchangePostInput.Type;
@@ -1093,6 +1095,7 @@ export const ReservationAvailableScopesInput =
       method: "POST",
       path: "/providers/Microsoft.Capacity/reservationOrders/{reservationOrderId}/reservations/{reservationId}/availableScopes",
       apiVersion: "2022-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReservationAvailableScopesInput =
@@ -1406,6 +1409,7 @@ export const ReservationMergeInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/providers/Microsoft.Capacity/reservationOrders/{reservationOrderId}/merge",
     apiVersion: "2022-11-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ReservationMergeInput = typeof ReservationMergeInput.Type;
@@ -1864,6 +1868,7 @@ export const ReservationOrderPurchaseInput =
       method: "PUT",
       path: "/providers/Microsoft.Capacity/reservationOrders/{reservationOrderId}",
       apiVersion: "2022-11-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReservationOrderPurchaseInput =
@@ -1922,6 +1927,7 @@ export const ReservationSplitInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/providers/Microsoft.Capacity/reservationOrders/{reservationOrderId}/split",
     apiVersion: "2022-11-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ReservationSplitInput = typeof ReservationSplitInput.Type;
@@ -2109,6 +2115,7 @@ export const ReservationUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "PATCH",
     path: "/providers/Microsoft.Capacity/reservationOrders/{reservationOrderId}/reservations/{reservationId}",
     apiVersion: "2022-11-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type ReservationUpdateInput = typeof ReservationUpdateInput.Type;
@@ -2171,6 +2178,7 @@ export const ReturnPostInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/providers/Microsoft.Capacity/reservationOrders/{reservationOrderId}/return",
     apiVersion: "2022-11-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ReturnPostInput = typeof ReturnPostInput.Type;

--- a/packages/azure/src/services/resourceconnector.ts
+++ b/packages/azure/src/services/resourceconnector.ts
@@ -80,6 +80,7 @@ export const AppliancesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ResourceConnector/appliances/{resourceName}",
       apiVersion: "2022-10-27",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AppliancesCreateOrUpdateInput =
@@ -136,6 +137,7 @@ export const AppliancesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ResourceConnector/appliances/{resourceName}",
     apiVersion: "2022-10-27",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type AppliancesDeleteInput = typeof AppliancesDeleteInput.Type;

--- a/packages/azure/src/services/resourcemover.ts
+++ b/packages/azure/src/services/resourcemover.ts
@@ -23,6 +23,7 @@ export const MoveCollectionsBulkRemoveInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Migrate/moveCollections/{moveCollectionName}/bulkRemove",
       apiVersion: "2023-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type MoveCollectionsBulkRemoveInput =
@@ -93,6 +94,7 @@ export const MoveCollectionsCommitInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Migrate/moveCollections/{moveCollectionName}/commit",
       apiVersion: "2023-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type MoveCollectionsCommitInput = typeof MoveCollectionsCommitInput.Type;
@@ -295,6 +297,7 @@ export const MoveCollectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Migrate/moveCollections/{moveCollectionName}",
       apiVersion: "2023-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type MoveCollectionsDeleteInput = typeof MoveCollectionsDeleteInput.Type;
@@ -364,6 +367,7 @@ export const MoveCollectionsDiscardInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Migrate/moveCollections/{moveCollectionName}/discard",
       apiVersion: "2023-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type MoveCollectionsDiscardInput =
@@ -514,6 +518,7 @@ export const MoveCollectionsInitiateMoveInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Migrate/moveCollections/{moveCollectionName}/initiateMove",
       apiVersion: "2023-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type MoveCollectionsInitiateMoveInput =
@@ -831,6 +836,7 @@ export const MoveCollectionsPrepareInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Migrate/moveCollections/{moveCollectionName}/prepare",
       apiVersion: "2023-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type MoveCollectionsPrepareInput =
@@ -895,6 +901,7 @@ export const MoveCollectionsResolveDependenciesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Migrate/moveCollections/{moveCollectionName}/resolveDependencies",
       apiVersion: "2023-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type MoveCollectionsResolveDependenciesInput =
@@ -1181,6 +1188,7 @@ export const MoveResourcesCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Migrate/moveCollections/{moveCollectionName}/moveResources/{moveResourceName}",
       apiVersion: "2023-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type MoveResourcesCreateInput = typeof MoveResourcesCreateInput.Type;
@@ -1334,6 +1342,7 @@ export const MoveResourcesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Migrate/moveCollections/{moveCollectionName}/moveResources/{moveResourceName}",
       apiVersion: "2023-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type MoveResourcesDeleteInput = typeof MoveResourcesDeleteInput.Type;

--- a/packages/azure/src/services/resources.ts
+++ b/packages/azure/src/services/resources.ts
@@ -100,6 +100,7 @@ export const ApplicationDefinitionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Solutions/applicationDefinitions/{applicationDefinitionName}",
       apiVersion: "2019-07-01",
+      longRunning: {},
     }),
   );
 export type ApplicationDefinitionsCreateOrUpdateInput =
@@ -139,6 +140,7 @@ export const ApplicationDefinitionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Solutions/applicationDefinitions/{applicationDefinitionName}",
       apiVersion: "2019-07-01",
+      longRunning: {},
     }),
   );
 export type ApplicationDefinitionsDeleteInput =
@@ -398,6 +400,7 @@ export const ApplicationsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Solutions/applications/{applicationName}",
       apiVersion: "2019-07-01",
+      longRunning: {},
     }),
   );
 export type ApplicationsCreateOrUpdateInput =
@@ -579,6 +582,7 @@ export const ApplicationsCreateOrUpdateByIdInput =
       method: "PUT",
       path: "/{applicationId}",
       apiVersion: "2019-07-01",
+      longRunning: {},
     }),
   );
 export type ApplicationsCreateOrUpdateByIdInput =
@@ -617,6 +621,7 @@ export const ApplicationsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Solutions/applications/{applicationName}",
       apiVersion: "2019-07-01",
+      longRunning: {},
     }),
   );
 export type ApplicationsDeleteInput = typeof ApplicationsDeleteInput.Type;
@@ -645,6 +650,7 @@ export const ApplicationsDeleteByIdInput =
       method: "DELETE",
       path: "/{applicationId}",
       apiVersion: "2019-07-01",
+      longRunning: {},
     }),
   );
 export type ApplicationsDeleteByIdInput =
@@ -830,6 +836,7 @@ export const ApplicationsRefreshPermissionsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Solutions/applications/{applicationName}/refreshPermissions",
       apiVersion: "2019-07-01",
+      longRunning: {},
     }),
   );
 export type ApplicationsRefreshPermissionsInput =
@@ -3446,6 +3453,7 @@ export const DeploymentsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Resources/deployments/{deploymentName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeploymentsCreateOrUpdateInput =
@@ -3612,6 +3620,7 @@ export const DeploymentsCreateOrUpdateAtManagementGroupScopeInput =
       method: "PUT",
       path: "/providers/Microsoft.Management/managementGroups/{groupId}/providers/Microsoft.Resources/deployments/{deploymentName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeploymentsCreateOrUpdateAtManagementGroupScopeInput =
@@ -3790,6 +3799,7 @@ export const DeploymentsCreateOrUpdateAtScopeInput =
       method: "PUT",
       path: "/{scope}/providers/Microsoft.Resources/deployments/{deploymentName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeploymentsCreateOrUpdateAtScopeInput =
@@ -3968,6 +3978,7 @@ export const DeploymentsCreateOrUpdateAtSubscriptionScopeInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.Resources/deployments/{deploymentName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeploymentsCreateOrUpdateAtSubscriptionScopeInput =
@@ -4131,6 +4142,7 @@ export const DeploymentsCreateOrUpdateAtTenantScopeInput =
       method: "PUT",
       path: "/providers/Microsoft.Resources/deployments/{deploymentName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeploymentsCreateOrUpdateAtTenantScopeInput =
@@ -4202,6 +4214,7 @@ export const DeploymentScriptsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Resources/deploymentScripts/{scriptName}",
       apiVersion: "2023-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeploymentScriptsCreateInput =
@@ -4657,6 +4670,7 @@ export const DeploymentsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Resources/deployments/{deploymentName}",
     apiVersion: "2025-04-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type DeploymentsDeleteInput = typeof DeploymentsDeleteInput.Type;
@@ -4690,6 +4704,7 @@ export const DeploymentsDeleteAtManagementGroupScopeInput =
       method: "DELETE",
       path: "/providers/Microsoft.Management/managementGroups/{groupId}/providers/Microsoft.Resources/deployments/{deploymentName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeploymentsDeleteAtManagementGroupScopeInput =
@@ -4726,6 +4741,7 @@ export const DeploymentsDeleteAtScopeInput =
       method: "DELETE",
       path: "/{scope}/providers/Microsoft.Resources/deployments/{deploymentName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeploymentsDeleteAtScopeInput =
@@ -4763,6 +4779,7 @@ export const DeploymentsDeleteAtSubscriptionScopeInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.Resources/deployments/{deploymentName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeploymentsDeleteAtSubscriptionScopeInput =
@@ -4798,6 +4815,7 @@ export const DeploymentsDeleteAtTenantScopeInput =
       method: "DELETE",
       path: "/providers/Microsoft.Resources/deployments/{deploymentName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeploymentsDeleteAtTenantScopeInput =
@@ -5986,6 +6004,7 @@ export const DeploymentStacksCreateOrUpdateAtManagementGroupInput =
       method: "PUT",
       path: "/providers/Microsoft.Management/managementGroups/{managementGroupId}/providers/Microsoft.Resources/deploymentStacks/{deploymentStackName}",
       apiVersion: "2025-07-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DeploymentStacksCreateOrUpdateAtManagementGroupInput =
@@ -6409,6 +6428,7 @@ export const DeploymentStacksCreateOrUpdateAtResourceGroupInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Resources/deploymentStacks/{deploymentStackName}",
       apiVersion: "2025-07-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DeploymentStacksCreateOrUpdateAtResourceGroupInput =
@@ -6832,6 +6852,7 @@ export const DeploymentStacksCreateOrUpdateAtSubscriptionInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.Resources/deploymentStacks/{deploymentStackName}",
       apiVersion: "2025-07-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DeploymentStacksCreateOrUpdateAtSubscriptionInput =
@@ -6884,6 +6905,7 @@ export const DeploymentStacksDeleteAtManagementGroupInput =
       method: "DELETE",
       path: "/providers/Microsoft.Management/managementGroups/{managementGroupId}/providers/Microsoft.Resources/deploymentStacks/{deploymentStackName}",
       apiVersion: "2025-07-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeploymentStacksDeleteAtManagementGroupInput =
@@ -6919,6 +6941,7 @@ export const DeploymentStacksDeleteAtResourceGroupInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Resources/deploymentStacks/{deploymentStackName}",
       apiVersion: "2025-07-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeploymentStacksDeleteAtResourceGroupInput =
@@ -6954,6 +6977,7 @@ export const DeploymentStacksDeleteAtSubscriptionInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.Resources/deploymentStacks/{deploymentStackName}",
       apiVersion: "2025-07-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeploymentStacksDeleteAtSubscriptionInput =
@@ -7850,6 +7874,7 @@ export const DeploymentStacksValidateStackAtManagementGroupInput =
       method: "POST",
       path: "/providers/Microsoft.Management/managementGroups/{managementGroupId}/providers/Microsoft.Resources/deploymentStacks/{deploymentStackName}/validate",
       apiVersion: "2025-07-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeploymentStacksValidateStackAtManagementGroupInput =
@@ -8430,6 +8455,7 @@ export const DeploymentStacksValidateStackAtResourceGroupInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Resources/deploymentStacks/{deploymentStackName}/validate",
       apiVersion: "2025-07-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeploymentStacksValidateStackAtResourceGroupInput =
@@ -9010,6 +9036,7 @@ export const DeploymentStacksValidateStackAtSubscriptionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.Resources/deploymentStacks/{deploymentStackName}/validate",
       apiVersion: "2025-07-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeploymentStacksValidateStackAtSubscriptionInput =
@@ -9567,6 +9594,7 @@ export const DeploymentStacksWhatIfResultsAtManagementGroupCreateOrUpdateInput =
       method: "PUT",
       path: "/providers/Microsoft.Management/managementGroups/{managementGroupId}/providers/Microsoft.Resources/deploymentStacksWhatIfResults/{deploymentStacksWhatIfResultName}",
       apiVersion: "2025-07-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DeploymentStacksWhatIfResultsAtManagementGroupCreateOrUpdateInput =
@@ -9772,6 +9800,7 @@ export const DeploymentStacksWhatIfResultsAtManagementGroupWhatIfInput =
       method: "POST",
       path: "/providers/Microsoft.Management/managementGroups/{managementGroupId}/providers/Microsoft.Resources/deploymentStacksWhatIfResults/{deploymentStacksWhatIfResultName}/whatIf",
       apiVersion: "2025-07-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeploymentStacksWhatIfResultsAtManagementGroupWhatIfInput =
@@ -10173,6 +10202,7 @@ export const DeploymentStacksWhatIfResultsAtResourceGroupCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Resources/deploymentStacksWhatIfResults/{deploymentStacksWhatIfResultName}",
       apiVersion: "2025-07-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DeploymentStacksWhatIfResultsAtResourceGroupCreateOrUpdateInput =
@@ -10386,6 +10416,7 @@ export const DeploymentStacksWhatIfResultsAtResourceGroupWhatIfInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Resources/deploymentStacksWhatIfResults/{deploymentStacksWhatIfResultName}/whatIf",
       apiVersion: "2025-07-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeploymentStacksWhatIfResultsAtResourceGroupWhatIfInput =
@@ -10787,6 +10818,7 @@ export const DeploymentStacksWhatIfResultsAtSubscriptionCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.Resources/deploymentStacksWhatIfResults/{deploymentStacksWhatIfResultName}",
       apiVersion: "2025-07-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DeploymentStacksWhatIfResultsAtSubscriptionCreateOrUpdateInput =
@@ -10991,6 +11023,7 @@ export const DeploymentStacksWhatIfResultsAtSubscriptionWhatIfInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.Resources/deploymentStacksWhatIfResults/{deploymentStacksWhatIfResultName}/whatIf",
       apiVersion: "2025-07-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeploymentStacksWhatIfResultsAtSubscriptionWhatIfInput =
@@ -11168,6 +11201,7 @@ export const DeploymentsValidateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Resources/deployments/{deploymentName}/validate",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeploymentsValidateInput = typeof DeploymentsValidateInput.Type;
@@ -11714,6 +11748,7 @@ export const DeploymentsValidateAtManagementGroupScopeInput =
       method: "POST",
       path: "/providers/Microsoft.Management/managementGroups/{groupId}/providers/Microsoft.Resources/deployments/{deploymentName}/validate",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeploymentsValidateAtManagementGroupScopeInput =
@@ -12276,6 +12311,7 @@ export const DeploymentsValidateAtScopeInput =
       method: "POST",
       path: "/{scope}/providers/Microsoft.Resources/deployments/{deploymentName}/validate",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeploymentsValidateAtScopeInput =
@@ -12839,6 +12875,7 @@ export const DeploymentsValidateAtSubscriptionScopeInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.Resources/deployments/{deploymentName}/validate",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeploymentsValidateAtSubscriptionScopeInput =
@@ -13386,6 +13423,7 @@ export const DeploymentsValidateAtTenantScopeInput =
       method: "POST",
       path: "/providers/Microsoft.Resources/deployments/{deploymentName}/validate",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeploymentsValidateAtTenantScopeInput =
@@ -13934,6 +13972,7 @@ export const DeploymentsWhatIfInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Resources/deployments/{deploymentName}/whatIf",
     apiVersion: "2025-04-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type DeploymentsWhatIfInput = typeof DeploymentsWhatIfInput.Type;
@@ -14265,6 +14304,7 @@ export const DeploymentsWhatIfAtManagementGroupScopeInput =
       method: "POST",
       path: "/providers/Microsoft.Management/managementGroups/{groupId}/providers/Microsoft.Resources/deployments/{deploymentName}/whatIf",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeploymentsWhatIfAtManagementGroupScopeInput =
@@ -14598,6 +14638,7 @@ export const DeploymentsWhatIfAtSubscriptionScopeInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.Resources/deployments/{deploymentName}/whatIf",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeploymentsWhatIfAtSubscriptionScopeInput =
@@ -14930,6 +14971,7 @@ export const DeploymentsWhatIfAtTenantScopeInput =
       method: "POST",
       path: "/providers/Microsoft.Resources/deployments/{deploymentName}/whatIf",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeploymentsWhatIfAtTenantScopeInput =
@@ -15414,6 +15456,7 @@ export const JitRequestsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Solutions/jitRequests/{jitRequestName}",
       apiVersion: "2019-07-01",
+      longRunning: {},
     }),
   );
 export type JitRequestsCreateOrUpdateInput =
@@ -22266,6 +22309,7 @@ export const ResourceGroupsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}",
       apiVersion: "2025-04-01",
+      longRunning: {},
     }),
   );
 export type ResourceGroupsDeleteInput = typeof ResourceGroupsDeleteInput.Type;
@@ -22302,6 +22346,7 @@ export const ResourceGroupsExportTemplateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/exportTemplate",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ResourceGroupsExportTemplateInput =
@@ -22985,6 +23030,7 @@ export const ResourcesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{parentResourcePath}/{resourceType}/{resourceName}",
       apiVersion: "2025-04-01",
+      longRunning: {},
     }),
   );
 export type ResourcesCreateOrUpdateInput =
@@ -23086,7 +23132,12 @@ export const ResourcesCreateOrUpdateByIdInput =
     ),
     tags: Schema.optional(Schema.Record(Schema.String, Schema.String)),
   }).pipe(
-    T.Http({ method: "PUT", path: "/{resourceId}", apiVersion: "2025-04-01" }),
+    T.Http({
+      method: "PUT",
+      path: "/{resourceId}",
+      apiVersion: "2025-04-01",
+      longRunning: {},
+    }),
   );
 export type ResourcesCreateOrUpdateByIdInput =
   typeof ResourcesCreateOrUpdateByIdInput.Type;
@@ -23134,6 +23185,7 @@ export const ResourcesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{parentResourcePath}/{resourceType}/{resourceName}",
     apiVersion: "2025-04-01",
+    longRunning: {},
   }),
 );
 export type ResourcesDeleteInput = typeof ResourcesDeleteInput.Type;
@@ -23166,6 +23218,7 @@ export const ResourcesDeleteByIdInput =
       method: "DELETE",
       path: "/{resourceId}",
       apiVersion: "2025-04-01",
+      longRunning: {},
     }),
   );
 export type ResourcesDeleteByIdInput = typeof ResourcesDeleteByIdInput.Type;
@@ -23386,6 +23439,7 @@ export const ResourcesMoveResourcesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{sourceResourceGroupName}/moveResources",
       apiVersion: "2025-04-01",
+      longRunning: {},
     }),
   );
 export type ResourcesMoveResourcesInput =
@@ -23479,6 +23533,7 @@ export const ResourcesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{parentResourcePath}/{resourceType}/{resourceName}",
     apiVersion: "2025-04-01",
+    longRunning: {},
   }),
 );
 export type ResourcesUpdateInput = typeof ResourcesUpdateInput.Type;
@@ -23579,6 +23634,7 @@ export const ResourcesUpdateByIdInput =
       method: "PATCH",
       path: "/{resourceId}",
       apiVersion: "2025-04-01",
+      longRunning: {},
     }),
   );
 export type ResourcesUpdateByIdInput = typeof ResourcesUpdateByIdInput.Type;
@@ -23622,6 +23678,7 @@ export const ResourcesValidateMoveResourcesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{sourceResourceGroupName}/validateMoveResources",
       apiVersion: "2025-04-01",
+      longRunning: {},
     }),
   );
 export type ResourcesValidateMoveResourcesInput =
@@ -24218,6 +24275,7 @@ export const TagsCreateOrUpdateAtScopeInput =
       method: "PUT",
       path: "/{scope}/providers/Microsoft.Resources/tags/default",
       apiVersion: "2025-04-01",
+      longRunning: {},
     }),
   );
 export type TagsCreateOrUpdateAtScopeInput =
@@ -24329,6 +24387,7 @@ export const TagsDeleteAtScopeInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/{scope}/providers/Microsoft.Resources/tags/default",
     apiVersion: "2025-04-01",
+    longRunning: {},
   }),
 );
 export type TagsDeleteAtScopeInput = typeof TagsDeleteAtScopeInput.Type;
@@ -24475,6 +24534,7 @@ export const TagsUpdateAtScopeInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "PATCH",
     path: "/{scope}/providers/Microsoft.Resources/tags/default",
     apiVersion: "2025-04-01",
+    longRunning: {},
   }),
 );
 export type TagsUpdateAtScopeInput = typeof TagsUpdateAtScopeInput.Type;

--- a/packages/azure/src/services/scheduler.ts
+++ b/packages/azure/src/services/scheduler.ts
@@ -118,6 +118,7 @@ export const JobCollectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Scheduler/jobCollections/{jobCollectionName}",
       apiVersion: "2016-03-01",
+      longRunning: {},
     }),
   );
 export type JobCollectionsDeleteInput = typeof JobCollectionsDeleteInput.Type;
@@ -150,6 +151,7 @@ export const JobCollectionsDisableInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Scheduler/jobCollections/{jobCollectionName}/disable",
       apiVersion: "2016-03-01",
+      longRunning: {},
     }),
   );
 export type JobCollectionsDisableInput = typeof JobCollectionsDisableInput.Type;
@@ -183,6 +185,7 @@ export const JobCollectionsEnableInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Scheduler/jobCollections/{jobCollectionName}/enable",
       apiVersion: "2016-03-01",
+      longRunning: {},
     }),
   );
 export type JobCollectionsEnableInput = typeof JobCollectionsEnableInput.Type;

--- a/packages/azure/src/services/scvmm.ts
+++ b/packages/azure/src/services/scvmm.ts
@@ -44,6 +44,7 @@ export const AvailabilitySetsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ScVmm/availabilitySets/{availabilitySetResourceName}",
       apiVersion: "2025-03-13",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AvailabilitySetsCreateOrUpdateInput =
@@ -100,6 +101,7 @@ export const AvailabilitySetsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ScVmm/availabilitySets/{availabilitySetResourceName}",
       apiVersion: "2025-03-13",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AvailabilitySetsDeleteInput =
@@ -329,6 +331,7 @@ export const AvailabilitySetsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ScVmm/availabilitySets/{availabilitySetResourceName}",
       apiVersion: "2025-03-13",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AvailabilitySetsUpdateInput =
@@ -432,6 +435,7 @@ export const CloudsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ScVmm/clouds/{cloudResourceName}",
       apiVersion: "2025-03-13",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CloudsCreateOrUpdateInput = typeof CloudsCreateOrUpdateInput.Type;
@@ -486,6 +490,7 @@ export const CloudsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ScVmm/clouds/{cloudResourceName}",
     apiVersion: "2025-03-13",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type CloudsDeleteInput = typeof CloudsDeleteInput.Type;
@@ -709,6 +714,7 @@ export const CloudsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ScVmm/clouds/{cloudResourceName}",
     apiVersion: "2025-03-13",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type CloudsUpdateInput = typeof CloudsUpdateInput.Type;
@@ -793,6 +799,7 @@ export const GuestAgentsCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "PUT",
     path: "/{resourceUri}/providers/Microsoft.ScVmm/virtualMachineInstances/default/guestAgents/default",
     apiVersion: "2025-03-13",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type GuestAgentsCreateInput = typeof GuestAgentsCreateInput.Type;
@@ -1277,6 +1284,7 @@ export const VirtualMachineInstancesCreateCheckpointInput =
       method: "POST",
       path: "/{resourceUri}/providers/Microsoft.ScVmm/virtualMachineInstances/default/createCheckpoint",
       apiVersion: "2025-03-13",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineInstancesCreateCheckpointInput =
@@ -1463,6 +1471,7 @@ export const VirtualMachineInstancesCreateOrUpdateInput =
       method: "PUT",
       path: "/{resourceUri}/providers/Microsoft.ScVmm/virtualMachineInstances/default",
       apiVersion: "2025-03-13",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualMachineInstancesCreateOrUpdateInput =
@@ -1514,6 +1523,7 @@ export const VirtualMachineInstancesDeleteInput =
       method: "DELETE",
       path: "/{resourceUri}/providers/Microsoft.ScVmm/virtualMachineInstances/default",
       apiVersion: "2025-03-13",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualMachineInstancesDeleteInput =
@@ -1548,6 +1558,7 @@ export const VirtualMachineInstancesDeleteCheckpointInput =
       method: "POST",
       path: "/{resourceUri}/providers/Microsoft.ScVmm/virtualMachineInstances/default/deleteCheckpoint",
       apiVersion: "2025-03-13",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineInstancesDeleteCheckpointInput =
@@ -1694,6 +1705,7 @@ export const VirtualMachineInstancesRestartInput =
       method: "POST",
       path: "/{resourceUri}/providers/Microsoft.ScVmm/virtualMachineInstances/default/restart",
       apiVersion: "2025-03-13",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineInstancesRestartInput =
@@ -1727,6 +1739,7 @@ export const VirtualMachineInstancesRestoreCheckpointInput =
       method: "POST",
       path: "/{resourceUri}/providers/Microsoft.ScVmm/virtualMachineInstances/default/restoreCheckpoint",
       apiVersion: "2025-03-13",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineInstancesRestoreCheckpointInput =
@@ -1758,6 +1771,7 @@ export const VirtualMachineInstancesStartInput =
       method: "POST",
       path: "/{resourceUri}/providers/Microsoft.ScVmm/virtualMachineInstances/default/start",
       apiVersion: "2025-03-13",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineInstancesStartInput =
@@ -1791,6 +1805,7 @@ export const VirtualMachineInstancesStopInput =
       method: "POST",
       path: "/{resourceUri}/providers/Microsoft.ScVmm/virtualMachineInstances/default/stop",
       apiVersion: "2025-03-13",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachineInstancesStopInput =
@@ -1901,6 +1916,7 @@ export const VirtualMachineInstancesUpdateInput =
       method: "PATCH",
       path: "/{resourceUri}/providers/Microsoft.ScVmm/virtualMachineInstances/default",
       apiVersion: "2025-03-13",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualMachineInstancesUpdateInput =
@@ -2045,6 +2061,7 @@ export const VirtualMachineTemplatesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ScVmm/virtualMachineTemplates/{virtualMachineTemplateName}",
       apiVersion: "2025-03-13",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualMachineTemplatesCreateOrUpdateInput =
@@ -2101,6 +2118,7 @@ export const VirtualMachineTemplatesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ScVmm/virtualMachineTemplates/{virtualMachineTemplateName}",
       apiVersion: "2025-03-13",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualMachineTemplatesDeleteInput =
@@ -2333,6 +2351,7 @@ export const VirtualMachineTemplatesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ScVmm/virtualMachineTemplates/{virtualMachineTemplateName}",
       apiVersion: "2025-03-13",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualMachineTemplatesUpdateInput =
@@ -2415,6 +2434,7 @@ export const VirtualNetworksCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ScVmm/virtualNetworks/{virtualNetworkName}",
       apiVersion: "2025-03-13",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualNetworksCreateOrUpdateInput =
@@ -2471,6 +2491,7 @@ export const VirtualNetworksDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ScVmm/virtualNetworks/{virtualNetworkName}",
       apiVersion: "2025-03-13",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualNetworksDeleteInput = typeof VirtualNetworksDeleteInput.Type;
@@ -2699,6 +2720,7 @@ export const VirtualNetworksUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ScVmm/virtualNetworks/{virtualNetworkName}",
       apiVersion: "2025-03-13",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VirtualNetworksUpdateInput = typeof VirtualNetworksUpdateInput.Type;
@@ -2904,6 +2926,7 @@ export const VmmServersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ScVmm/vmmServers/{vmmServerName}",
       apiVersion: "2025-03-13",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type VmmServersCreateOrUpdateInput =
@@ -2960,6 +2983,7 @@ export const VmmServersDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ScVmm/vmmServers/{vmmServerName}",
     apiVersion: "2025-03-13",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type VmmServersDeleteInput = typeof VmmServersDeleteInput.Type;
@@ -3181,6 +3205,7 @@ export const VmmServersUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ScVmm/vmmServers/{vmmServerName}",
     apiVersion: "2025-03-13",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type VmmServersUpdateInput = typeof VmmServersUpdateInput.Type;

--- a/packages/azure/src/services/search.ts
+++ b/packages/azure/src/services/search.ts
@@ -219,6 +219,7 @@ export const NetworkSecurityPerimeterConfigurationsReconcileInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Search/searchServices/{searchServiceName}/networkSecurityPerimeterConfigurations/{nspConfigName}/reconcile",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkSecurityPerimeterConfigurationsReconcileInput =
@@ -995,6 +996,7 @@ export const ServicesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Search/searchServices/{searchServiceName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServicesCreateOrUpdateInput =
@@ -1519,6 +1521,7 @@ export const ServicesUpgradeInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Search/searchServices/{searchServiceName}/upgrade",
     apiVersion: "2025-05-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ServicesUpgradeInput = typeof ServicesUpgradeInput.Type;
@@ -1590,6 +1593,7 @@ export const SharedPrivateLinkResourcesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Search/searchServices/{searchServiceName}/sharedPrivateLinkResources/{sharedPrivateLinkResourceName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SharedPrivateLinkResourcesCreateOrUpdateInput =
@@ -1647,6 +1651,7 @@ export const SharedPrivateLinkResourcesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Search/searchServices/{searchServiceName}/sharedPrivateLinkResources/{sharedPrivateLinkResourceName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SharedPrivateLinkResourcesDeleteInput =

--- a/packages/azure/src/services/security.ts
+++ b/packages/azure/src/services/security.ts
@@ -56,6 +56,7 @@ export const PrivateEndpointConnectionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Security/privateLinks/{privateLinkName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PrivateEndpointConnectionsCreateOrUpdateInput =
@@ -111,6 +112,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Security/privateLinks/{privateLinkName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =
@@ -475,6 +477,7 @@ export const PrivateLinksCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Security/privateLinks/{privateLinkName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PrivateLinksCreateInput = typeof PrivateLinksCreateInput.Type;
@@ -524,6 +527,7 @@ export const PrivateLinksDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Security/privateLinks/{privateLinkName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PrivateLinksDeleteInput = typeof PrivateLinksDeleteInput.Type;

--- a/packages/azure/src/services/securityandcompliance.ts
+++ b/packages/azure/src/services/securityandcompliance.ts
@@ -137,6 +137,7 @@ export const PrivateEndpointConnectionsAdtAPICreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SecurityAndCompliance/privateLinkServicesForO365ManagementActivityAPI/{resourceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2021-03-08",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsAdtAPICreateOrUpdateInput =
@@ -181,6 +182,7 @@ export const PrivateEndpointConnectionsAdtAPIDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SecurityAndCompliance/privateLinkServicesForO365ManagementActivityAPI/{resourceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2021-03-08",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsAdtAPIDeleteInput =
@@ -344,6 +346,7 @@ export const PrivateEndpointConnectionsCompCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SecurityAndCompliance/privateLinkServicesForM365ComplianceCenter/{resourceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2021-03-08",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsCompCreateOrUpdateInput =
@@ -388,6 +391,7 @@ export const PrivateEndpointConnectionsCompDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SecurityAndCompliance/privateLinkServicesForM365ComplianceCenter/{resourceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2021-03-08",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsCompDeleteInput =
@@ -551,6 +555,7 @@ export const PrivateEndpointConnectionsForEDMCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SecurityAndCompliance/privateLinkServicesForEDMUpload/{resourceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2021-03-08",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsForEDMCreateOrUpdateInput =
@@ -595,6 +600,7 @@ export const PrivateEndpointConnectionsForEDMDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SecurityAndCompliance/privateLinkServicesForEDMUpload/{resourceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2021-03-08",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsForEDMDeleteInput =
@@ -758,6 +764,7 @@ export const PrivateEndpointConnectionsForMIPPolicySyncCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SecurityAndCompliance/privateLinkServicesForMIPPolicySync/{resourceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2021-03-08",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsForMIPPolicySyncCreateOrUpdateInput =
@@ -803,6 +810,7 @@ export const PrivateEndpointConnectionsForMIPPolicySyncDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SecurityAndCompliance/privateLinkServicesForMIPPolicySync/{resourceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2021-03-08",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsForMIPPolicySyncDeleteInput =
@@ -966,6 +974,7 @@ export const PrivateEndpointConnectionsForSCCPowershellCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SecurityAndCompliance/privateLinkServicesForSCCPowershell/{resourceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2021-03-08",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsForSCCPowershellCreateOrUpdateInput =
@@ -1011,6 +1020,7 @@ export const PrivateEndpointConnectionsForSCCPowershellDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SecurityAndCompliance/privateLinkServicesForSCCPowershell/{resourceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2021-03-08",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsForSCCPowershellDeleteInput =
@@ -1174,6 +1184,7 @@ export const PrivateEndpointConnectionsSecCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SecurityAndCompliance/privateLinkServicesForM365SecurityCenter/{resourceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2021-03-08",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsSecCreateOrUpdateInput =
@@ -1218,6 +1229,7 @@ export const PrivateEndpointConnectionsSecDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SecurityAndCompliance/privateLinkServicesForM365SecurityCenter/{resourceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2021-03-08",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsSecDeleteInput =
@@ -1972,6 +1984,7 @@ export const PrivateLinkServicesForEDMUploadCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SecurityAndCompliance/privateLinkServicesForEDMUpload/{resourceName}",
       apiVersion: "2021-03-08",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateLinkServicesForEDMUploadCreateOrUpdateInput =
@@ -2272,6 +2285,7 @@ export const PrivateLinkServicesForEDMUploadUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SecurityAndCompliance/privateLinkServicesForEDMUpload/{resourceName}",
       apiVersion: "2021-03-08",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateLinkServicesForEDMUploadUpdateInput =
@@ -2430,6 +2444,7 @@ export const PrivateLinkServicesForM365ComplianceCenterCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SecurityAndCompliance/privateLinkServicesForM365ComplianceCenter/{resourceName}",
       apiVersion: "2021-03-08",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateLinkServicesForM365ComplianceCenterCreateOrUpdateInput =
@@ -2496,6 +2511,7 @@ export const PrivateLinkServicesForM365ComplianceCenterDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SecurityAndCompliance/privateLinkServicesForM365ComplianceCenter/{resourceName}",
       apiVersion: "2021-03-08",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateLinkServicesForM365ComplianceCenterDeleteInput =
@@ -2769,6 +2785,7 @@ export const PrivateLinkServicesForM365ComplianceCenterUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SecurityAndCompliance/privateLinkServicesForM365ComplianceCenter/{resourceName}",
       apiVersion: "2021-03-08",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateLinkServicesForM365ComplianceCenterUpdateInput =
@@ -2927,6 +2944,7 @@ export const PrivateLinkServicesForM365SecurityCenterCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SecurityAndCompliance/privateLinkServicesForM365SecurityCenter/{resourceName}",
       apiVersion: "2021-03-08",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateLinkServicesForM365SecurityCenterCreateOrUpdateInput =
@@ -2992,6 +3010,7 @@ export const PrivateLinkServicesForM365SecurityCenterDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SecurityAndCompliance/privateLinkServicesForM365SecurityCenter/{resourceName}",
       apiVersion: "2021-03-08",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateLinkServicesForM365SecurityCenterDeleteInput =
@@ -3265,6 +3284,7 @@ export const PrivateLinkServicesForM365SecurityCenterUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SecurityAndCompliance/privateLinkServicesForM365SecurityCenter/{resourceName}",
       apiVersion: "2021-03-08",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateLinkServicesForM365SecurityCenterUpdateInput =
@@ -3423,6 +3443,7 @@ export const PrivateLinkServicesForMIPPolicySyncCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SecurityAndCompliance/privateLinkServicesForMIPPolicySync/{resourceName}",
       apiVersion: "2021-03-08",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateLinkServicesForMIPPolicySyncCreateOrUpdateInput =
@@ -3488,6 +3509,7 @@ export const PrivateLinkServicesForMIPPolicySyncDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SecurityAndCompliance/privateLinkServicesForMIPPolicySync/{resourceName}",
       apiVersion: "2021-03-08",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateLinkServicesForMIPPolicySyncDeleteInput =
@@ -3759,6 +3781,7 @@ export const PrivateLinkServicesForMIPPolicySyncUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SecurityAndCompliance/privateLinkServicesForMIPPolicySync/{resourceName}",
       apiVersion: "2021-03-08",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateLinkServicesForMIPPolicySyncUpdateInput =
@@ -3917,6 +3940,7 @@ export const PrivateLinkServicesForO365ManagementActivityAPICreateOrUpdateInput 
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SecurityAndCompliance/privateLinkServicesForO365ManagementActivityAPI/{resourceName}",
       apiVersion: "2021-03-08",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateLinkServicesForO365ManagementActivityAPICreateOrUpdateInput =
@@ -3984,6 +4008,7 @@ export const PrivateLinkServicesForO365ManagementActivityAPIDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SecurityAndCompliance/privateLinkServicesForO365ManagementActivityAPI/{resourceName}",
       apiVersion: "2021-03-08",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateLinkServicesForO365ManagementActivityAPIDeleteInput =
@@ -4257,6 +4282,7 @@ export const PrivateLinkServicesForO365ManagementActivityAPIUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SecurityAndCompliance/privateLinkServicesForO365ManagementActivityAPI/{resourceName}",
       apiVersion: "2021-03-08",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateLinkServicesForO365ManagementActivityAPIUpdateInput =
@@ -4415,6 +4441,7 @@ export const PrivateLinkServicesForSCCPowershellCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SecurityAndCompliance/privateLinkServicesForSCCPowershell/{resourceName}",
       apiVersion: "2021-03-08",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateLinkServicesForSCCPowershellCreateOrUpdateInput =
@@ -4480,6 +4507,7 @@ export const PrivateLinkServicesForSCCPowershellDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SecurityAndCompliance/privateLinkServicesForSCCPowershell/{resourceName}",
       apiVersion: "2021-03-08",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateLinkServicesForSCCPowershellDeleteInput =
@@ -4751,6 +4779,7 @@ export const PrivateLinkServicesForSCCPowershellUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SecurityAndCompliance/privateLinkServicesForSCCPowershell/{resourceName}",
       apiVersion: "2021-03-08",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateLinkServicesForSCCPowershellUpdateInput =
@@ -4817,6 +4846,7 @@ export const ServicesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SecurityAndCompliance/privateLinkServicesForEDMUpload/{resourceName}",
     apiVersion: "2021-03-08",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ServicesDeleteInput = typeof ServicesDeleteInput.Type;

--- a/packages/azure/src/services/securityinsights.ts
+++ b/packages/azure/src/services/securityinsights.ts
@@ -4974,6 +4974,7 @@ export const WatchlistsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OperationalInsights/workspaces/{workspaceName}/providers/Microsoft.SecurityInsights/watchlists/{watchlistAlias}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type WatchlistsCreateOrUpdateInput =
@@ -5028,6 +5029,7 @@ export const WatchlistsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OperationalInsights/workspaces/{workspaceName}/providers/Microsoft.SecurityInsights/watchlists/{watchlistAlias}",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type WatchlistsDeleteInput = typeof WatchlistsDeleteInput.Type;

--- a/packages/azure/src/services/servicebus.ts
+++ b/packages/azure/src/services/servicebus.ts
@@ -564,6 +564,7 @@ export const MigrationConfigsCreateAndStartMigrationInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/migrationConfigurations/{configName}",
       apiVersion: "2024-01-01",
+      longRunning: {},
     }),
   );
 export type MigrationConfigsCreateAndStartMigrationInput =
@@ -915,6 +916,7 @@ export const NamespacesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}",
       apiVersion: "2024-01-01",
+      longRunning: {},
     }),
   );
 export type NamespacesCreateOrUpdateInput =
@@ -1109,6 +1111,7 @@ export const NamespacesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}",
     apiVersion: "2024-01-01",
+    longRunning: {},
   }),
 );
 export type NamespacesDeleteInput = typeof NamespacesDeleteInput.Type;
@@ -1821,6 +1824,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceBus/namespaces/{namespaceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2024-01-01",
+      longRunning: {},
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =

--- a/packages/azure/src/services/servicefabric.ts
+++ b/packages/azure/src/services/servicefabric.ts
@@ -146,6 +146,7 @@ export const ApplicationsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/clusters/{clusterName}/applications/{applicationName}",
       apiVersion: "2021-06-01",
+      longRunning: {},
     }),
   );
 export type ApplicationsCreateOrUpdateInput =
@@ -176,6 +177,7 @@ export const ApplicationsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/clusters/{clusterName}/applications/{applicationName}",
       apiVersion: "2021-06-01",
+      longRunning: {},
     }),
   );
 export type ApplicationsDeleteInput = typeof ApplicationsDeleteInput.Type;
@@ -404,6 +406,7 @@ export const ApplicationsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/clusters/{clusterName}/applications/{applicationName}",
       apiVersion: "2021-06-01",
+      longRunning: {},
     }),
   );
 export type ApplicationsUpdateInput = typeof ApplicationsUpdateInput.Type;
@@ -497,6 +500,7 @@ export const ApplicationTypesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/clusters/{clusterName}/applicationTypes/{applicationTypeName}",
       apiVersion: "2021-06-01",
+      longRunning: {},
     }),
   );
 export type ApplicationTypesDeleteInput =
@@ -648,6 +652,7 @@ export const ApplicationTypeVersionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/clusters/{clusterName}/applicationTypes/{applicationTypeName}/versions/{version}",
       apiVersion: "2021-06-01",
+      longRunning: {},
     }),
   );
 export type ApplicationTypeVersionsCreateOrUpdateInput =
@@ -677,6 +682,7 @@ export const ApplicationTypeVersionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/clusters/{clusterName}/applicationTypes/{applicationTypeName}/versions/{version}",
       apiVersion: "2021-06-01",
+      longRunning: {},
     }),
   );
 export type ApplicationTypeVersionsDeleteInput =
@@ -1146,6 +1152,7 @@ export const ClustersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/clusters/{clusterName}",
       apiVersion: "2021-06-01",
+      longRunning: {},
     }),
   );
 export type ClustersCreateOrUpdateInput =
@@ -1651,6 +1658,7 @@ export const ClustersUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/clusters/{clusterName}",
     apiVersion: "2021-06-01",
+    longRunning: {},
   }),
 );
 export type ClustersUpdateInput = typeof ClustersUpdateInput.Type;
@@ -1996,6 +2004,7 @@ export const ServicesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/clusters/{clusterName}/applications/{applicationName}/services/{serviceName}",
       apiVersion: "2021-06-01",
+      longRunning: {},
     }),
   );
 export type ServicesCreateOrUpdateInput =
@@ -2027,6 +2036,7 @@ export const ServicesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/clusters/{clusterName}/applications/{applicationName}/services/{serviceName}",
     apiVersion: "2021-06-01",
+    longRunning: {},
   }),
 );
 export type ServicesDeleteInput = typeof ServicesDeleteInput.Type;
@@ -2209,6 +2219,7 @@ export const ServicesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/clusters/{clusterName}/applications/{applicationName}/services/{serviceName}",
     apiVersion: "2021-06-01",
+    longRunning: {},
   }),
 );
 export type ServicesUpdateInput = typeof ServicesUpdateInput.Type;

--- a/packages/azure/src/services/servicefabricmanagedclusters.ts
+++ b/packages/azure/src/services/servicefabricmanagedclusters.ts
@@ -107,6 +107,7 @@ export const ApplicationsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedClusters/{clusterName}/applications/{applicationName}",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ApplicationsCreateOrUpdateInput =
@@ -164,6 +165,7 @@ export const ApplicationsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedClusters/{clusterName}/applications/{applicationName}",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ApplicationsDeleteInput = typeof ApplicationsDeleteInput.Type;
@@ -209,6 +211,7 @@ export const ApplicationsFetchHealthInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedClusters/{clusterName}/applications/{applicationName}/fetchHealth",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ApplicationsFetchHealthInput =
@@ -365,6 +368,7 @@ export const ApplicationsReadUpgradeInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedClusters/{clusterName}/applications/{applicationName}/fetchUpgradeStatus",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ApplicationsReadUpgradeInput =
@@ -409,6 +413,7 @@ export const ApplicationsRestartDeployedCodePackageInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedClusters/{clusterName}/applications/{applicationName}/restartDeployedCodePackage",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ApplicationsRestartDeployedCodePackageInput =
@@ -448,6 +453,7 @@ export const ApplicationsResumeUpgradeInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedClusters/{clusterName}/applications/{applicationName}/resumeUpgrade",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ApplicationsResumeUpgradeInput =
@@ -487,6 +493,7 @@ export const ApplicationsStartRollbackInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedClusters/{clusterName}/applications/{applicationName}/startRollback",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ApplicationsStartRollbackInput =
@@ -534,6 +541,7 @@ export const ApplicationsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedClusters/{clusterName}/applications/{applicationName}",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ApplicationsUpdateInput = typeof ApplicationsUpdateInput.Type;
@@ -630,6 +638,7 @@ export const ApplicationsUpdateUpgradeInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedClusters/{clusterName}/applications/{applicationName}/updateUpgrade",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ApplicationsUpdateUpgradeInput =
@@ -732,6 +741,7 @@ export const ApplicationTypesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedClusters/{clusterName}/applicationTypes/{applicationTypeName}",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ApplicationTypesDeleteInput =
@@ -959,6 +969,7 @@ export const ApplicationTypeVersionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedClusters/{clusterName}/applicationTypes/{applicationTypeName}/versions/{version}",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ApplicationTypeVersionsCreateOrUpdateInput =
@@ -1017,6 +1028,7 @@ export const ApplicationTypeVersionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedClusters/{clusterName}/applicationTypes/{applicationTypeName}/versions/{version}",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ApplicationTypeVersionsDeleteInput =
@@ -1561,6 +1573,7 @@ export const ManagedClustersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedClusters/{clusterName}",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedClustersCreateOrUpdateInput =
@@ -1615,6 +1628,7 @@ export const ManagedClustersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedClusters/{clusterName}",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedClustersDeleteInput = typeof ManagedClustersDeleteInput.Type;
@@ -1835,6 +1849,7 @@ export const ManagedClustersUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedClusters/{clusterName}",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedClustersUpdateInput = typeof ManagedClustersUpdateInput.Type;
@@ -2530,6 +2545,7 @@ export const NodeTypesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedClusters/{clusterName}/nodeTypes/{nodeTypeName}",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NodeTypesCreateOrUpdateInput =
@@ -2592,6 +2608,7 @@ export const NodeTypesDeallocateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedClusters/{clusterName}/nodeTypes/{nodeTypeName}/deallocate",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NodeTypesDeallocateInput = typeof NodeTypesDeallocateInput.Type;
@@ -2626,6 +2643,7 @@ export const NodeTypesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedClusters/{clusterName}/nodeTypes/{nodeTypeName}",
     apiVersion: "2026-02-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type NodeTypesDeleteInput = typeof NodeTypesDeleteInput.Type;
@@ -2665,6 +2683,7 @@ export const NodeTypesDeleteNodeInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedClusters/{clusterName}/nodeTypes/{nodeTypeName}/deleteNode",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NodeTypesDeleteNodeInput = typeof NodeTypesDeleteNodeInput.Type;
@@ -2884,6 +2903,7 @@ export const NodeTypesRedeployInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedClusters/{clusterName}/nodeTypes/{nodeTypeName}/redeploy",
     apiVersion: "2026-02-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type NodeTypesRedeployInput = typeof NodeTypesRedeployInput.Type;
@@ -2920,6 +2940,7 @@ export const NodeTypesReimageInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedClusters/{clusterName}/nodeTypes/{nodeTypeName}/reimage",
     apiVersion: "2026-02-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type NodeTypesReimageInput = typeof NodeTypesReimageInput.Type;
@@ -2956,6 +2977,7 @@ export const NodeTypesRestartInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedClusters/{clusterName}/nodeTypes/{nodeTypeName}/restart",
     apiVersion: "2026-02-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type NodeTypesRestartInput = typeof NodeTypesRestartInput.Type;
@@ -2992,6 +3014,7 @@ export const NodeTypesStartInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedClusters/{clusterName}/nodeTypes/{nodeTypeName}/start",
     apiVersion: "2026-02-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type NodeTypesStartInput = typeof NodeTypesStartInput.Type;
@@ -3033,6 +3056,7 @@ export const NodeTypesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedClusters/{clusterName}/nodeTypes/{nodeTypeName}",
     apiVersion: "2026-02-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type NodeTypesUpdateInput = typeof NodeTypesUpdateInput.Type;
@@ -3275,6 +3299,7 @@ export const ServicesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedClusters/{clusterName}/applications/{applicationName}/services/{serviceName}",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServicesCreateOrUpdateInput =
@@ -3333,6 +3358,7 @@ export const ServicesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedClusters/{clusterName}/applications/{applicationName}/services/{serviceName}",
     apiVersion: "2026-02-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ServicesDeleteInput = typeof ServicesDeleteInput.Type;
@@ -3499,6 +3525,7 @@ export const ServicesRestartReplicaInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedClusters/{clusterName}/applications/{applicationName}/services/{serviceName}/restartReplica",
       apiVersion: "2026-02-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServicesRestartReplicaInput =

--- a/packages/azure/src/services/servicelinker.ts
+++ b/packages/azure/src/services/servicelinker.ts
@@ -169,6 +169,7 @@ export const ConnectorCreateDryrunInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.ServiceLinker/locations/{location}/dryruns/{dryrunName}",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ConnectorCreateDryrunInput = typeof ConnectorCreateDryrunInput.Type;
@@ -368,6 +369,7 @@ export const ConnectorCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.ServiceLinker/locations/{location}/connectors/{connectorName}",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ConnectorCreateOrUpdateInput =
@@ -420,6 +422,7 @@ export const ConnectorDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.ServiceLinker/locations/{location}/connectors/{connectorName}",
     apiVersion: "2024-04-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type ConnectorDeleteInput = typeof ConnectorDeleteInput.Type;
@@ -938,6 +941,7 @@ export const ConnectorUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.ServiceLinker/locations/{location}/connectors/{connectorName}",
     apiVersion: "2024-04-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type ConnectorUpdateInput = typeof ConnectorUpdateInput.Type;
@@ -1021,6 +1025,7 @@ export const ConnectorUpdateDryrunInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.ServiceLinker/locations/{location}/dryruns/{dryrunName}",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ConnectorUpdateDryrunInput = typeof ConnectorUpdateDryrunInput.Type;
@@ -1075,6 +1080,7 @@ export const ConnectorValidateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.ServiceLinker/locations/{location}/connectors/{connectorName}/validate",
     apiVersion: "2024-04-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ConnectorValidateInput = typeof ConnectorValidateInput.Type;
@@ -1290,6 +1296,7 @@ export const LinkerCreateOrUpdateInput =
       method: "PUT",
       path: "/{resourceUri}/providers/Microsoft.ServiceLinker/linkers/{linkerName}",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type LinkerCreateOrUpdateInput = typeof LinkerCreateOrUpdateInput.Type;
@@ -1337,6 +1344,7 @@ export const LinkerDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/{resourceUri}/providers/Microsoft.ServiceLinker/linkers/{linkerName}",
     apiVersion: "2024-04-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type LinkerDeleteInput = typeof LinkerDeleteInput.Type;
@@ -1549,6 +1557,7 @@ export const LinkersCreateDryrunInput =
       method: "PUT",
       path: "/{resourceUri}/providers/Microsoft.ServiceLinker/dryruns/{dryrunName}",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type LinkersCreateDryrunInput = typeof LinkersCreateDryrunInput.Type;
@@ -1936,6 +1945,7 @@ export const LinkersUpdateDryrunInput =
       method: "PATCH",
       path: "/{resourceUri}/providers/Microsoft.ServiceLinker/dryruns/{dryrunName}",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type LinkersUpdateDryrunInput = typeof LinkersUpdateDryrunInput.Type;
@@ -2115,6 +2125,7 @@ export const LinkerUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/{resourceUri}/providers/Microsoft.ServiceLinker/linkers/{linkerName}",
     apiVersion: "2024-04-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type LinkerUpdateInput = typeof LinkerUpdateInput.Type;
@@ -2159,6 +2170,7 @@ export const LinkerValidateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "POST",
     path: "/{resourceUri}/providers/Microsoft.ServiceLinker/linkers/{linkerName}/validateLinker",
     apiVersion: "2024-04-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type LinkerValidateInput = typeof LinkerValidateInput.Type;

--- a/packages/azure/src/services/servicenetworking.ts
+++ b/packages/azure/src/services/servicenetworking.ts
@@ -43,6 +43,7 @@ export const AssociationsInterfaceCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceNetworking/trafficControllers/{trafficControllerName}/associations/{associationName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AssociationsInterfaceCreateOrUpdateInput =
@@ -99,6 +100,7 @@ export const AssociationsInterfaceDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceNetworking/trafficControllers/{trafficControllerName}/associations/{associationName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AssociationsInterfaceDeleteInput =
@@ -350,6 +352,7 @@ export const FrontendsInterfaceCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceNetworking/trafficControllers/{trafficControllerName}/frontends/{frontendName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type FrontendsInterfaceCreateOrUpdateInput =
@@ -406,6 +409,7 @@ export const FrontendsInterfaceDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceNetworking/trafficControllers/{trafficControllerName}/frontends/{frontendName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type FrontendsInterfaceDeleteInput =
@@ -699,6 +703,7 @@ export const SecurityPoliciesInterfaceCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceNetworking/trafficControllers/{trafficControllerName}/securityPolicies/{securityPolicyName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SecurityPoliciesInterfaceCreateOrUpdateInput =
@@ -755,6 +760,7 @@ export const SecurityPoliciesInterfaceDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceNetworking/trafficControllers/{trafficControllerName}/securityPolicies/{securityPolicyName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SecurityPoliciesInterfaceDeleteInput =
@@ -1031,6 +1037,7 @@ export const TrafficControllerInterfaceCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceNetworking/trafficControllers/{trafficControllerName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type TrafficControllerInterfaceCreateOrUpdateInput =
@@ -1085,6 +1092,7 @@ export const TrafficControllerInterfaceDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceNetworking/trafficControllers/{trafficControllerName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type TrafficControllerInterfaceDeleteInput =

--- a/packages/azure/src/services/signalr.ts
+++ b/packages/azure/src/services/signalr.ts
@@ -415,6 +415,7 @@ export const SignalRCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/signalR/{resourceName}",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SignalRCreateOrUpdateInput = typeof SignalRCreateOrUpdateInput.Type;
@@ -486,6 +487,7 @@ export const SignalRCustomCertificatesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/signalR/{resourceName}/customCertificates/{certificateName}",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SignalRCustomCertificatesCreateOrUpdateInput =
@@ -718,6 +720,7 @@ export const SignalRCustomDomainsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/signalR/{resourceName}/customDomains/{name}",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SignalRCustomDomainsCreateOrUpdateInput =
@@ -772,6 +775,7 @@ export const SignalRCustomDomainsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/signalR/{resourceName}/customDomains/{name}",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SignalRCustomDomainsDeleteInput =
@@ -932,6 +936,7 @@ export const SignalRDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/signalR/{resourceName}",
     apiVersion: "2024-03-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type SignalRDeleteInput = typeof SignalRDeleteInput.Type;
@@ -1308,6 +1313,7 @@ export const SignalRPrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/signalR/{resourceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SignalRPrivateEndpointConnectionsDeleteInput =
@@ -1627,6 +1633,7 @@ export const SignalRRegenerateKeyInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/signalR/{resourceName}/regenerateKey",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SignalRRegenerateKeyInput = typeof SignalRRegenerateKeyInput.Type;
@@ -1697,6 +1704,7 @@ export const SignalRReplicasCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/signalR/{resourceName}/replicas/{replicaName}",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SignalRReplicasCreateOrUpdateInput =
@@ -1861,6 +1869,7 @@ export const SignalRReplicaSharedPrivateLinkResourcesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/signalR/{resourceName}/replicas/{replicaName}/sharedPrivateLinkResources/{sharedPrivateLinkResourceName}",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SignalRReplicaSharedPrivateLinkResourcesCreateOrUpdateInput =
@@ -2100,6 +2109,7 @@ export const SignalRReplicasRestartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/signalR/{resourceName}/replicas/{replicaName}/restart",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SignalRReplicasRestartInput =
@@ -2167,6 +2177,7 @@ export const SignalRReplicasUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/signalR/{resourceName}/replicas/{replicaName}",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SignalRReplicasUpdateInput = typeof SignalRReplicasUpdateInput.Type;
@@ -2218,6 +2229,7 @@ export const SignalRRestartInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/signalR/{resourceName}/restart",
     apiVersion: "2024-03-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type SignalRRestartInput = typeof SignalRRestartInput.Type;
@@ -2277,6 +2289,7 @@ export const SignalRSharedPrivateLinkResourcesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/signalR/{resourceName}/sharedPrivateLinkResources/{sharedPrivateLinkResourceName}",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SignalRSharedPrivateLinkResourcesCreateOrUpdateInput =
@@ -2329,6 +2342,7 @@ export const SignalRSharedPrivateLinkResourcesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/signalR/{resourceName}/sharedPrivateLinkResources/{sharedPrivateLinkResourceName}",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SignalRSharedPrivateLinkResourcesDeleteInput =
@@ -2754,6 +2768,7 @@ export const SignalRUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/signalR/{resourceName}",
     apiVersion: "2024-03-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type SignalRUpdateInput = typeof SignalRUpdateInput.Type;

--- a/packages/azure/src/services/solutions.ts
+++ b/packages/azure/src/services/solutions.ts
@@ -579,6 +579,7 @@ export const ApplicationsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Solutions/applications/{applicationName}",
       apiVersion: "2021-07-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ApplicationsCreateOrUpdateInput =
@@ -772,6 +773,7 @@ export const ApplicationsCreateOrUpdateByIdInput =
       method: "PUT",
       path: "/{applicationId}",
       apiVersion: "2021-07-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ApplicationsCreateOrUpdateByIdInput =
@@ -825,6 +827,7 @@ export const ApplicationsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Solutions/applications/{applicationName}",
       apiVersion: "2021-07-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ApplicationsDeleteInput = typeof ApplicationsDeleteInput.Type;
@@ -854,6 +857,7 @@ export const ApplicationsDeleteByIdInput =
       method: "DELETE",
       path: "/{applicationId}",
       apiVersion: "2021-07-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ApplicationsDeleteByIdInput =
@@ -1225,6 +1229,7 @@ export const ApplicationsRefreshPermissionsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Solutions/applications/{applicationName}/refreshPermissions",
       apiVersion: "2021-07-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ApplicationsRefreshPermissionsInput =
@@ -1400,6 +1405,7 @@ export const ApplicationsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Solutions/applications/{applicationName}",
       apiVersion: "2021-07-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ApplicationsUpdateInput = typeof ApplicationsUpdateInput.Type;
@@ -1468,6 +1474,7 @@ export const ApplicationsUpdateAccessInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Solutions/applications/{applicationName}/updateAccess",
       apiVersion: "2021-07-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ApplicationsUpdateAccessInput =
@@ -1644,6 +1651,7 @@ export const ApplicationsUpdateByIdInput =
       method: "PATCH",
       path: "/{applicationId}",
       apiVersion: "2021-07-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ApplicationsUpdateByIdInput =
@@ -1773,6 +1781,7 @@ export const JitRequestsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Solutions/jitRequests/{jitRequestName}",
       apiVersion: "2021-07-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type JitRequestsCreateOrUpdateInput =

--- a/packages/azure/src/services/sphere.ts
+++ b/packages/azure/src/services/sphere.ts
@@ -74,6 +74,7 @@ export const CatalogsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureSphere/catalogs/{catalogName}",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CatalogsCreateOrUpdateInput =
@@ -128,6 +129,7 @@ export const CatalogsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureSphere/catalogs/{catalogName}",
     apiVersion: "2024-04-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type CatalogsDeleteInput = typeof CatalogsDeleteInput.Type;
@@ -701,6 +703,7 @@ export const CatalogsUploadImageInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureSphere/catalogs/{catalogName}/uploadImage",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CatalogsUploadImageInput = typeof CatalogsUploadImageInput.Type;
@@ -1007,6 +1010,7 @@ export const DeploymentsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureSphere/catalogs/{catalogName}/products/{productName}/deviceGroups/{deviceGroupName}/deployments/{deploymentName}",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DeploymentsCreateOrUpdateInput =
@@ -1069,6 +1073,7 @@ export const DeploymentsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureSphere/catalogs/{catalogName}/products/{productName}/deviceGroups/{deviceGroupName}/deployments/{deploymentName}",
     apiVersion: "2024-04-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type DeploymentsDeleteInput = typeof DeploymentsDeleteInput.Type;
@@ -1235,6 +1240,7 @@ export const DeviceGroupsClaimDevicesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureSphere/catalogs/{catalogName}/products/{productName}/deviceGroups/{deviceGroupName}/claimDevices",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeviceGroupsClaimDevicesInput =
@@ -1344,6 +1350,7 @@ export const DeviceGroupsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureSphere/catalogs/{catalogName}/products/{productName}/deviceGroups/{deviceGroupName}",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DeviceGroupsCreateOrUpdateInput =
@@ -1403,6 +1410,7 @@ export const DeviceGroupsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureSphere/catalogs/{catalogName}/products/{productName}/deviceGroups/{deviceGroupName}",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeviceGroupsDeleteInput = typeof DeviceGroupsDeleteInput.Type;
@@ -1577,6 +1585,7 @@ export const DeviceGroupsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureSphere/catalogs/{catalogName}/products/{productName}/deviceGroups/{deviceGroupName}",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeviceGroupsUpdateInput = typeof DeviceGroupsUpdateInput.Type;
@@ -1654,6 +1663,7 @@ export const DevicesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureSphere/catalogs/{catalogName}/products/{productName}/deviceGroups/{deviceGroupName}/devices/{deviceName}",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DevicesCreateOrUpdateInput = typeof DevicesCreateOrUpdateInput.Type;
@@ -1713,6 +1723,7 @@ export const DevicesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureSphere/catalogs/{catalogName}/products/{productName}/deviceGroups/{deviceGroupName}/devices/{deviceName}",
     apiVersion: "2024-04-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type DevicesDeleteInput = typeof DevicesDeleteInput.Type;
@@ -1754,6 +1765,7 @@ export const DevicesGenerateCapabilityImageInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureSphere/catalogs/{catalogName}/products/{productName}/deviceGroups/{deviceGroupName}/devices/{deviceName}/generateCapabilityImage",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DevicesGenerateCapabilityImageInput =
@@ -1931,6 +1943,7 @@ export const DevicesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureSphere/catalogs/{catalogName}/products/{productName}/deviceGroups/{deviceGroupName}/devices/{deviceName}",
     apiVersion: "2024-04-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type DevicesUpdateInput = typeof DevicesUpdateInput.Type;
@@ -2035,6 +2048,7 @@ export const ImagesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureSphere/catalogs/{catalogName}/images/{imageName}",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ImagesCreateOrUpdateInput = typeof ImagesCreateOrUpdateInput.Type;
@@ -2089,6 +2103,7 @@ export const ImagesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureSphere/catalogs/{catalogName}/images/{imageName}",
     apiVersion: "2024-04-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ImagesDeleteInput = typeof ImagesDeleteInput.Type;
@@ -2343,6 +2358,7 @@ export const ProductsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureSphere/catalogs/{catalogName}/products/{productName}",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ProductsCreateOrUpdateInput =
@@ -2399,6 +2415,7 @@ export const ProductsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureSphere/catalogs/{catalogName}/products/{productName}",
     apiVersion: "2024-04-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ProductsDeleteInput = typeof ProductsDeleteInput.Type;
@@ -2628,6 +2645,7 @@ export const ProductsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureSphere/catalogs/{catalogName}/products/{productName}",
     apiVersion: "2024-04-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ProductsUpdateInput = typeof ProductsUpdateInput.Type;

--- a/packages/azure/src/services/sql.ts
+++ b/packages/azure/src/services/sql.ts
@@ -28,6 +28,7 @@ export const BackupShortTermRetentionPoliciesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/backupShortTermRetentionPolicies/{policyName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BackupShortTermRetentionPoliciesCreateOrUpdateInput =
@@ -221,6 +222,7 @@ export const BackupShortTermRetentionPoliciesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/backupShortTermRetentionPolicies/{policyName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BackupShortTermRetentionPoliciesUpdateInput =
@@ -2326,6 +2328,7 @@ export const DatabaseEncryptionProtectorsRevalidateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/encryptionProtector/{encryptionProtectorName}/revalidate",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DatabaseEncryptionProtectorsRevalidateInput =
@@ -2366,6 +2369,7 @@ export const DatabaseEncryptionProtectorsRevertInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/encryptionProtector/{encryptionProtectorName}/revert",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DatabaseEncryptionProtectorsRevertInput =
@@ -2430,6 +2434,7 @@ export const DatabaseExtensionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/extensions/{extensionName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DatabaseExtensionsCreateOrUpdateInput =
@@ -3275,6 +3280,7 @@ export const DatabasesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DatabasesCreateOrUpdateInput =
@@ -3331,6 +3337,7 @@ export const DatabasesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}",
     apiVersion: "2025-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type DatabasesDeleteInput = typeof DatabasesDeleteInput.Type;
@@ -3581,6 +3588,7 @@ export const DatabasesExportInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/export",
     apiVersion: "2025-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type DatabasesExportInput = typeof DatabasesExportInput.Type;
@@ -3637,6 +3645,7 @@ export const DatabasesFailoverInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/failover",
     apiVersion: "2025-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type DatabasesFailoverInput = typeof DatabasesFailoverInput.Type;
@@ -3742,6 +3751,7 @@ export const DatabasesImportInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/import",
     apiVersion: "2025-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type DatabasesImportInput = typeof DatabasesImportInput.Type;
@@ -4004,6 +4014,7 @@ export const DatabasesPauseInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/pause",
     apiVersion: "2025-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type DatabasesPauseInput = typeof DatabasesPauseInput.Type;
@@ -4268,6 +4279,7 @@ export const DatabaseSqlVulnerabilityAssessmentExecuteScanExecuteInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/sqlVulnerabilityAssessments/{vulnerabilityAssessmentName}/initiateScan",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DatabaseSqlVulnerabilityAssessmentExecuteScanExecuteInput =
@@ -5011,6 +5023,7 @@ export const DatabasesResumeInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/resume",
     apiVersion: "2025-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type DatabasesResumeInput = typeof DatabasesResumeInput.Type;
@@ -5216,6 +5229,7 @@ export const DatabasesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}",
     apiVersion: "2025-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type DatabasesUpdateInput = typeof DatabasesUpdateInput.Type;
@@ -5268,6 +5282,7 @@ export const DatabasesUpgradeDataWarehouseInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/upgradeDataWarehouse",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DatabasesUpgradeDataWarehouseInput =
@@ -5824,6 +5839,7 @@ export const DatabaseVulnerabilityAssessmentScansInitiateScanInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/vulnerabilityAssessments/{vulnerabilityAssessmentName}/scans/{scanId}/initiateScan",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DatabaseVulnerabilityAssessmentScansInitiateScanInput =
@@ -6782,6 +6798,7 @@ export const DeletedServersRecoverInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.Sql/locations/{locationName}/deletedServers/{deletedServerName}/recover",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DeletedServersRecoverInput = typeof DeletedServersRecoverInput.Type;
@@ -6895,6 +6912,7 @@ export const DistributedAvailabilityGroupsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/distributedAvailabilityGroups/{distributedAvailabilityGroupName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DistributedAvailabilityGroupsCreateOrUpdateInput =
@@ -6951,6 +6969,7 @@ export const DistributedAvailabilityGroupsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/distributedAvailabilityGroups/{distributedAvailabilityGroupName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DistributedAvailabilityGroupsDeleteInput =
@@ -6990,6 +7009,7 @@ export const DistributedAvailabilityGroupsFailoverInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/distributedAvailabilityGroups/{distributedAvailabilityGroupName}/failover",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DistributedAvailabilityGroupsFailoverInput =
@@ -7175,6 +7195,7 @@ export const DistributedAvailabilityGroupsSetRoleInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/distributedAvailabilityGroups/{distributedAvailabilityGroupName}/setRole",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DistributedAvailabilityGroupsSetRoleInput =
@@ -7289,6 +7310,7 @@ export const DistributedAvailabilityGroupsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/distributedAvailabilityGroups/{distributedAvailabilityGroupName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type DistributedAvailabilityGroupsUpdateInput =
@@ -7587,6 +7609,7 @@ export const ElasticPoolsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/elasticPools/{elasticPoolName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ElasticPoolsCreateOrUpdateInput =
@@ -7644,6 +7667,7 @@ export const ElasticPoolsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/elasticPools/{elasticPoolName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ElasticPoolsDeleteInput = typeof ElasticPoolsDeleteInput.Type;
@@ -7678,6 +7702,7 @@ export const ElasticPoolsFailoverInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/elasticPools/{elasticPoolName}/failover",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ElasticPoolsFailoverInput = typeof ElasticPoolsFailoverInput.Type;
@@ -7874,6 +7899,7 @@ export const ElasticPoolsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/elasticPools/{elasticPoolName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ElasticPoolsUpdateInput = typeof ElasticPoolsUpdateInput.Type;
@@ -7940,6 +7966,7 @@ export const EncryptionProtectorsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/encryptionProtector/{encryptionProtectorName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type EncryptionProtectorsCreateOrUpdateInput =
@@ -8122,6 +8149,7 @@ export const EncryptionProtectorsRevalidateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/encryptionProtector/{encryptionProtectorName}/revalidate",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type EncryptionProtectorsRevalidateInput =
@@ -8504,6 +8532,7 @@ export const ExtendedServerBlobAuditingPoliciesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/extendedAuditingSettings/{blobAuditingPolicyName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ExtendedServerBlobAuditingPoliciesCreateOrUpdateInput =
@@ -8720,6 +8749,7 @@ export const FailoverGroupsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/failoverGroups/{failoverGroupName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type FailoverGroupsCreateOrUpdateInput =
@@ -8776,6 +8806,7 @@ export const FailoverGroupsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/failoverGroups/{failoverGroupName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type FailoverGroupsDeleteInput = typeof FailoverGroupsDeleteInput.Type;
@@ -8813,6 +8844,7 @@ export const FailoverGroupsFailoverInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/failoverGroups/{failoverGroupName}/failover",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type FailoverGroupsFailoverInput =
@@ -8870,6 +8902,7 @@ export const FailoverGroupsForceFailoverAllowDataLossInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/failoverGroups/{failoverGroupName}/forceFailoverAllowDataLoss",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type FailoverGroupsForceFailoverAllowDataLossInput =
@@ -9050,6 +9083,7 @@ export const FailoverGroupsTryPlannedBeforeForcedFailoverInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/failoverGroups/{failoverGroupName}/tryPlannedBeforeForcedFailover",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type FailoverGroupsTryPlannedBeforeForcedFailoverInput =
@@ -9140,6 +9174,7 @@ export const FailoverGroupsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/failoverGroups/{failoverGroupName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type FailoverGroupsUpdateInput = typeof FailoverGroupsUpdateInput.Type;
@@ -9642,6 +9677,7 @@ export const InstanceFailoverGroupsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/locations/{locationName}/instanceFailoverGroups/{failoverGroupName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type InstanceFailoverGroupsCreateOrUpdateInput =
@@ -9698,6 +9734,7 @@ export const InstanceFailoverGroupsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/locations/{locationName}/instanceFailoverGroups/{failoverGroupName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type InstanceFailoverGroupsDeleteInput =
@@ -9736,6 +9773,7 @@ export const InstanceFailoverGroupsFailoverInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/locations/{locationName}/instanceFailoverGroups/{failoverGroupName}/failover",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type InstanceFailoverGroupsFailoverInput =
@@ -9792,6 +9830,7 @@ export const InstanceFailoverGroupsForceFailoverAllowDataLossInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/locations/{locationName}/instanceFailoverGroups/{failoverGroupName}/forceFailoverAllowDataLoss",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type InstanceFailoverGroupsForceFailoverAllowDataLossInput =
@@ -10118,6 +10157,7 @@ export const InstancePoolsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/instancePools/{instancePoolName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type InstancePoolsCreateOrUpdateInput =
@@ -10173,6 +10213,7 @@ export const InstancePoolsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/instancePools/{instancePoolName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type InstancePoolsDeleteInput = typeof InstancePoolsDeleteInput.Type;
@@ -10406,6 +10447,7 @@ export const InstancePoolsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/instancePools/{instancePoolName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type InstancePoolsUpdateInput = typeof InstancePoolsUpdateInput.Type;
@@ -10676,6 +10718,7 @@ export const JobAgentsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/jobAgents/{jobAgentName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type JobAgentsCreateOrUpdateInput =
@@ -10732,6 +10775,7 @@ export const JobAgentsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/jobAgents/{jobAgentName}",
     apiVersion: "2025-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type JobAgentsDeleteInput = typeof JobAgentsDeleteInput.Type;
@@ -10915,6 +10959,7 @@ export const JobAgentsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/jobAgents/{jobAgentName}",
     apiVersion: "2025-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type JobAgentsUpdateInput = typeof JobAgentsUpdateInput.Type;
@@ -11238,6 +11283,7 @@ export const JobExecutionsCreateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/jobAgents/{jobAgentName}/jobs/{jobName}/start",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type JobExecutionsCreateInput = typeof JobExecutionsCreateInput.Type;
@@ -11294,6 +11340,7 @@ export const JobExecutionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/jobAgents/{jobAgentName}/jobs/{jobName}/executions/{jobExecutionId}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type JobExecutionsCreateOrUpdateInput =
@@ -11591,6 +11638,7 @@ export const JobPrivateEndpointsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/jobAgents/{jobAgentName}/privateEndpoints/{privateEndpointName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type JobPrivateEndpointsCreateOrUpdateInput =
@@ -11649,6 +11697,7 @@ export const JobPrivateEndpointsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/jobAgents/{jobAgentName}/privateEndpoints/{privateEndpointName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type JobPrivateEndpointsDeleteInput =
@@ -13203,6 +13252,7 @@ export const LedgerDigestUploadsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/ledgerDigestUploads/{ledgerDigestUploads}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LedgerDigestUploadsCreateOrUpdateInput =
@@ -13260,6 +13310,7 @@ export const LedgerDigestUploadsDisableInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/ledgerDigestUploads/{ledgerDigestUploads}/disable",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LedgerDigestUploadsDisableInput =
@@ -13449,6 +13500,7 @@ export const LongTermRetentionBackupsChangeAccessTierInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.Sql/locations/{locationName}/longTermRetentionServers/{longTermRetentionServerName}/longTermRetentionDatabases/{longTermRetentionDatabaseName}/longTermRetentionBackups/{backupName}/changeAccessTier",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LongTermRetentionBackupsChangeAccessTierInput =
@@ -13510,6 +13562,7 @@ export const LongTermRetentionBackupsChangeAccessTierByResourceGroupInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/locations/{locationName}/longTermRetentionServers/{longTermRetentionServerName}/longTermRetentionDatabases/{longTermRetentionDatabaseName}/longTermRetentionBackups/{backupName}/changeAccessTier",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LongTermRetentionBackupsChangeAccessTierByResourceGroupInput =
@@ -13581,6 +13634,7 @@ export const LongTermRetentionBackupsCopyInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.Sql/locations/{locationName}/longTermRetentionServers/{longTermRetentionServerName}/longTermRetentionDatabases/{longTermRetentionDatabaseName}/longTermRetentionBackups/{backupName}/copy",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LongTermRetentionBackupsCopyInput =
@@ -13652,6 +13706,7 @@ export const LongTermRetentionBackupsCopyByResourceGroupInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/locations/{locationName}/longTermRetentionServers/{longTermRetentionServerName}/longTermRetentionDatabases/{longTermRetentionDatabaseName}/longTermRetentionBackups/{backupName}/copy",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LongTermRetentionBackupsCopyByResourceGroupInput =
@@ -13711,6 +13766,7 @@ export const LongTermRetentionBackupsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.Sql/locations/{locationName}/longTermRetentionServers/{longTermRetentionServerName}/longTermRetentionDatabases/{longTermRetentionDatabaseName}/longTermRetentionBackups/{backupName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LongTermRetentionBackupsDeleteInput =
@@ -13752,6 +13808,7 @@ export const LongTermRetentionBackupsDeleteByResourceGroupInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/locations/{locationName}/longTermRetentionServers/{longTermRetentionServerName}/longTermRetentionDatabases/{longTermRetentionDatabaseName}/longTermRetentionBackups/{backupName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LongTermRetentionBackupsDeleteByResourceGroupInput =
@@ -14368,6 +14425,7 @@ export const LongTermRetentionBackupsLockTimeBasedImmutabilityInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.Sql/locations/{locationName}/longTermRetentionServers/{longTermRetentionServerName}/longTermRetentionDatabases/{longTermRetentionDatabaseName}/longTermRetentionBackups/{backupName}/lockTimeBasedImmutability",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LongTermRetentionBackupsLockTimeBasedImmutabilityInput =
@@ -14427,6 +14485,7 @@ export const LongTermRetentionBackupsLockTimeBasedImmutabilityByResourceGroupInp
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/locations/{locationName}/longTermRetentionServers/{longTermRetentionServerName}/longTermRetentionDatabases/{longTermRetentionDatabaseName}/longTermRetentionBackups/{backupName}/lockTimeBasedImmutability",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LongTermRetentionBackupsLockTimeBasedImmutabilityByResourceGroupInput =
@@ -14488,6 +14547,7 @@ export const LongTermRetentionBackupsRemoveLegalHoldImmutabilityInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.Sql/locations/{locationName}/longTermRetentionServers/{longTermRetentionServerName}/longTermRetentionDatabases/{longTermRetentionDatabaseName}/longTermRetentionBackups/{backupName}/removeLegalHoldImmutability",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LongTermRetentionBackupsRemoveLegalHoldImmutabilityInput =
@@ -14547,6 +14607,7 @@ export const LongTermRetentionBackupsRemoveLegalHoldImmutabilityByResourceGroupI
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/locations/{locationName}/longTermRetentionServers/{longTermRetentionServerName}/longTermRetentionDatabases/{longTermRetentionDatabaseName}/longTermRetentionBackups/{backupName}/removeLegalHoldImmutability",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LongTermRetentionBackupsRemoveLegalHoldImmutabilityByResourceGroupInput =
@@ -14608,6 +14669,7 @@ export const LongTermRetentionBackupsRemoveTimeBasedImmutabilityInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.Sql/locations/{locationName}/longTermRetentionServers/{longTermRetentionServerName}/longTermRetentionDatabases/{longTermRetentionDatabaseName}/longTermRetentionBackups/{backupName}/removeTimeBasedImmutability",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LongTermRetentionBackupsRemoveTimeBasedImmutabilityInput =
@@ -14667,6 +14729,7 @@ export const LongTermRetentionBackupsRemoveTimeBasedImmutabilityByResourceGroupI
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/locations/{locationName}/longTermRetentionServers/{longTermRetentionServerName}/longTermRetentionDatabases/{longTermRetentionDatabaseName}/longTermRetentionBackups/{backupName}/removeTimeBasedImmutability",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LongTermRetentionBackupsRemoveTimeBasedImmutabilityByResourceGroupInput =
@@ -14728,6 +14791,7 @@ export const LongTermRetentionBackupsSetLegalHoldImmutabilityInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.Sql/locations/{locationName}/longTermRetentionServers/{longTermRetentionServerName}/longTermRetentionDatabases/{longTermRetentionDatabaseName}/longTermRetentionBackups/{backupName}/setLegalHoldImmutability",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LongTermRetentionBackupsSetLegalHoldImmutabilityInput =
@@ -14787,6 +14851,7 @@ export const LongTermRetentionBackupsSetLegalHoldImmutabilityByResourceGroupInpu
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/locations/{locationName}/longTermRetentionServers/{longTermRetentionServerName}/longTermRetentionDatabases/{longTermRetentionDatabaseName}/longTermRetentionBackups/{backupName}/setLegalHoldImmutability",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LongTermRetentionBackupsSetLegalHoldImmutabilityByResourceGroupInput =
@@ -14855,6 +14920,7 @@ export const LongTermRetentionBackupsUpdateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.Sql/locations/{locationName}/longTermRetentionServers/{longTermRetentionServerName}/longTermRetentionDatabases/{longTermRetentionDatabaseName}/longTermRetentionBackups/{backupName}/update",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LongTermRetentionBackupsUpdateInput =
@@ -14921,6 +14987,7 @@ export const LongTermRetentionBackupsUpdateByResourceGroupInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/locations/{locationName}/longTermRetentionServers/{longTermRetentionServerName}/longTermRetentionDatabases/{longTermRetentionDatabaseName}/longTermRetentionBackups/{backupName}/update",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LongTermRetentionBackupsUpdateByResourceGroupInput =
@@ -14980,6 +15047,7 @@ export const LongTermRetentionManagedInstanceBackupsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.Sql/locations/{locationName}/longTermRetentionManagedInstances/{managedInstanceName}/longTermRetentionDatabases/{databaseName}/longTermRetentionManagedInstanceBackups/{backupName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LongTermRetentionManagedInstanceBackupsDeleteInput =
@@ -15021,6 +15089,7 @@ export const LongTermRetentionManagedInstanceBackupsDeleteByResourceGroupInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/locations/{locationName}/longTermRetentionManagedInstances/{managedInstanceName}/longTermRetentionDatabases/{databaseName}/longTermRetentionManagedInstanceBackups/{backupName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LongTermRetentionManagedInstanceBackupsDeleteByResourceGroupInput =
@@ -15659,6 +15728,7 @@ export const LongTermRetentionPoliciesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/backupLongTermRetentionPolicies/{policyName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type LongTermRetentionPoliciesCreateOrUpdateInput =
@@ -16031,6 +16101,7 @@ export const ManagedBackupShortTermRetentionPoliciesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/databases/{databaseName}/backupShortTermRetentionPolicies/{policyName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedBackupShortTermRetentionPoliciesCreateOrUpdateInput =
@@ -16223,6 +16294,7 @@ export const ManagedBackupShortTermRetentionPoliciesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/databases/{databaseName}/backupShortTermRetentionPolicies/{policyName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedBackupShortTermRetentionPoliciesUpdateInput =
@@ -17095,6 +17167,7 @@ export const ManagedDatabasesCancelMoveInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/databases/{databaseName}/cancelMove",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedDatabasesCancelMoveInput =
@@ -17267,6 +17340,7 @@ export const ManagedDatabasesCompleteMoveInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/databases/{databaseName}/completeMove",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedDatabasesCompleteMoveInput =
@@ -17306,6 +17380,7 @@ export const ManagedDatabasesCompleteRestoreInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/databases/{databaseName}/completeRestore",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedDatabasesCompleteRestoreInput =
@@ -17413,6 +17488,7 @@ export const ManagedDatabasesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/databases/{databaseName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedDatabasesCreateOrUpdateInput =
@@ -17469,6 +17545,7 @@ export const ManagedDatabasesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/databases/{databaseName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedDatabasesDeleteInput =
@@ -18564,6 +18641,7 @@ export const ManagedDatabasesReevaluateInaccessibleDatabaseStateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/databases/{databaseName}/reevaluateInaccessibleDatabaseState",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedDatabasesReevaluateInaccessibleDatabaseStateInput =
@@ -18622,6 +18700,7 @@ export const ManagedDatabasesStartMoveInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/databases/{databaseName}/startMove",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedDatabasesStartMoveInput =
@@ -18729,6 +18808,7 @@ export const ManagedDatabasesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/databases/{databaseName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedDatabasesUpdateInput =
@@ -19428,6 +19508,7 @@ export const ManagedDatabaseVulnerabilityAssessmentScansInitiateScanInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/databases/{databaseName}/vulnerabilityAssessments/{vulnerabilityAssessmentName}/scans/{scanId}/initiateScan",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedDatabaseVulnerabilityAssessmentScansInitiateScanInput =
@@ -19799,6 +19880,7 @@ export const ManagedInstanceAdministratorsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/administrators/{administratorName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedInstanceAdministratorsCreateOrUpdateInput =
@@ -19854,6 +19936,7 @@ export const ManagedInstanceAdministratorsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/administrators/{administratorName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedInstanceAdministratorsDeleteInput =
@@ -20023,6 +20106,7 @@ export const ManagedInstanceAdvancedThreatProtectionSettingsCreateOrUpdateInput 
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/advancedThreatProtectionSettings/{advancedThreatProtectionName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedInstanceAdvancedThreatProtectionSettingsCreateOrUpdateInput =
@@ -20215,6 +20299,7 @@ export const ManagedInstanceAzureADOnlyAuthenticationsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/azureADOnlyAuthentications/{authenticationName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedInstanceAzureADOnlyAuthenticationsCreateOrUpdateInput =
@@ -20271,6 +20356,7 @@ export const ManagedInstanceAzureADOnlyAuthenticationsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/azureADOnlyAuthentications/{authenticationName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedInstanceAzureADOnlyAuthenticationsDeleteInput =
@@ -20469,6 +20555,7 @@ export const ManagedInstanceDtcsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/dtc/{dtcName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedInstanceDtcsCreateOrUpdateInput =
@@ -20661,6 +20748,7 @@ export const ManagedInstanceEncryptionProtectorsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/encryptionProtector/{encryptionProtectorName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedInstanceEncryptionProtectorsCreateOrUpdateInput =
@@ -20842,6 +20930,7 @@ export const ManagedInstanceEncryptionProtectorsRevalidateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/encryptionProtector/{encryptionProtectorName}/revalidate",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedInstanceEncryptionProtectorsRevalidateInput =
@@ -20890,6 +20979,7 @@ export const ManagedInstanceKeysCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/keys/{keyName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedInstanceKeysCreateOrUpdateInput =
@@ -20946,6 +21036,7 @@ export const ManagedInstanceKeysDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/keys/{keyName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedInstanceKeysDeleteInput =
@@ -21125,6 +21216,7 @@ export const ManagedInstanceLongTermRetentionPoliciesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/databases/{databaseName}/backupLongTermRetentionPolicies/{policyName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedInstanceLongTermRetentionPoliciesCreateOrUpdateInput =
@@ -21183,6 +21275,7 @@ export const ManagedInstanceLongTermRetentionPoliciesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/databases/{databaseName}/backupLongTermRetentionPolicies/{policyName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedInstanceLongTermRetentionPoliciesDeleteInput =
@@ -21547,6 +21640,7 @@ export const ManagedInstancePrivateEndpointConnectionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedInstancePrivateEndpointConnectionsCreateOrUpdateInput =
@@ -21603,6 +21697,7 @@ export const ManagedInstancePrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedInstancePrivateEndpointConnectionsDeleteInput =
@@ -22046,6 +22141,7 @@ export const ManagedInstancesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedInstancesCreateOrUpdateInput =
@@ -22100,6 +22196,7 @@ export const ManagedInstancesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedInstancesDeleteInput =
@@ -22140,6 +22237,7 @@ export const ManagedInstancesFailoverInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/failover",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedInstancesFailoverInput =
@@ -22605,6 +22703,7 @@ export const ManagedInstancesReevaluateInaccessibleDatabaseStateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/reevaluateInaccessibleDatabaseState",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedInstancesReevaluateInaccessibleDatabaseStateInput =
@@ -22641,6 +22740,7 @@ export const ManagedInstancesRefreshStatusInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/refreshExternalGovernanceStatus",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedInstancesRefreshStatusInput =
@@ -22695,6 +22795,7 @@ export const ManagedInstancesStartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/start",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedInstancesStartInput = typeof ManagedInstancesStartInput.Type;
@@ -22749,6 +22850,7 @@ export const ManagedInstancesStopInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/stop",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedInstancesStopInput = typeof ManagedInstancesStopInput.Type;
@@ -22954,6 +23056,7 @@ export const ManagedInstancesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedInstancesUpdateInput =
@@ -23010,6 +23113,7 @@ export const ManagedInstancesValidateAzureKeyVaultEncryptionKeyInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/validateAzureKeyVaultEncryptionKey",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedInstancesValidateAzureKeyVaultEncryptionKeyInput =
@@ -23052,6 +23156,7 @@ export const ManagedInstanceTdeCertificatesCreateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/tdeCertificates",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedInstanceTdeCertificatesCreateInput =
@@ -23335,6 +23440,7 @@ export const ManagedLedgerDigestUploadsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/databases/{databaseName}/ledgerDigestUploads/{ledgerDigestUploads}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedLedgerDigestUploadsCreateOrUpdateInput =
@@ -23392,6 +23498,7 @@ export const ManagedLedgerDigestUploadsDisableInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/databases/{databaseName}/ledgerDigestUploads/{ledgerDigestUploads}/disable",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedLedgerDigestUploadsDisableInput =
@@ -23582,6 +23689,7 @@ export const ManagedRestorableDroppedDatabaseBackupShortTermRetentionPoliciesCre
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/restorableDroppedDatabases/{restorableDroppedDatabaseId}/backupShortTermRetentionPolicies/{policyName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedRestorableDroppedDatabaseBackupShortTermRetentionPoliciesCreateOrUpdateInput =
@@ -23777,6 +23885,7 @@ export const ManagedRestorableDroppedDatabaseBackupShortTermRetentionPoliciesUpd
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/restorableDroppedDatabases/{restorableDroppedDatabaseId}/backupShortTermRetentionPolicies/{policyName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedRestorableDroppedDatabaseBackupShortTermRetentionPoliciesUpdateInput =
@@ -23836,6 +23945,7 @@ export const ManagedServerDnsAliasesAcquireInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/dnsAliases/{dnsAliasName}/acquire",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedServerDnsAliasesAcquireInput =
@@ -23892,6 +24002,7 @@ export const ManagedServerDnsAliasesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/dnsAliases/{dnsAliasName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedServerDnsAliasesCreateOrUpdateInput =
@@ -23947,6 +24058,7 @@ export const ManagedServerDnsAliasesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/dnsAliases/{dnsAliasName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedServerDnsAliasesDeleteInput =
@@ -24121,6 +24233,7 @@ export const ManagedServerSecurityAlertPoliciesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/securityAlertPolicies/{securityAlertPolicyName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ManagedServerSecurityAlertPoliciesCreateOrUpdateInput =
@@ -24426,6 +24539,7 @@ export const NetworkSecurityPerimeterConfigurationsReconcileInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/networkSecurityPerimeterConfigurations/{nspConfigName}/reconcile",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkSecurityPerimeterConfigurationsReconcileInput =
@@ -24528,6 +24642,7 @@ export const OutboundFirewallRulesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/outboundFirewallRules/{outboundRuleFqdn}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type OutboundFirewallRulesCreateOrUpdateInput =
@@ -24583,6 +24698,7 @@ export const OutboundFirewallRulesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/outboundFirewallRules/{outboundRuleFqdn}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type OutboundFirewallRulesDeleteInput =
@@ -24777,6 +24893,7 @@ export const PrivateEndpointConnectionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsCreateOrUpdateInput =
@@ -24833,6 +24950,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =
@@ -25435,6 +25553,7 @@ export const ReplicationLinksCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/replicationLinks/{linkId}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationLinksCreateOrUpdateInput =
@@ -25531,6 +25650,7 @@ export const ReplicationLinksFailoverInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/replicationLinks/{linkId}/failover",
       apiVersion: "2014-04-01-legacy",
+      longRunning: {},
     }),
   );
 export type ReplicationLinksFailoverInput =
@@ -25570,6 +25690,7 @@ export const ReplicationLinksFailoverAllowDataLossInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/replicationLinks/{linkId}/forceFailoverAllowDataLoss",
       apiVersion: "2014-04-01-legacy",
+      longRunning: {},
     }),
   );
 export type ReplicationLinksFailoverAllowDataLossInput =
@@ -25804,6 +25925,7 @@ export const ReplicationLinksUnlinkInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/replicationLinks/{linkId}/unlink",
       apiVersion: "2014-04-01-legacy",
+      longRunning: {},
     }),
   );
 export type ReplicationLinksUnlinkInput =
@@ -25849,6 +25971,7 @@ export const ReplicationLinksUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/replicationLinks/{linkId}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReplicationLinksUpdateInput =
@@ -26160,6 +26283,7 @@ export const RestorePointsCreateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/restorePoints",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RestorePointsCreateInput = typeof RestorePointsCreateInput.Type;
@@ -26972,6 +27096,7 @@ export const ServerAdvancedThreatProtectionSettingsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/advancedThreatProtectionSettings/{advancedThreatProtectionName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServerAdvancedThreatProtectionSettingsCreateOrUpdateInput =
@@ -27530,6 +27655,7 @@ export const ServerAzureADAdministratorsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/administrators/{administratorName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServerAzureADAdministratorsCreateOrUpdateInput =
@@ -27586,6 +27712,7 @@ export const ServerAzureADAdministratorsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/administrators/{administratorName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServerAzureADAdministratorsDeleteInput =
@@ -27756,6 +27883,7 @@ export const ServerAzureADOnlyAuthenticationsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/azureADOnlyAuthentications/{authenticationName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServerAzureADOnlyAuthenticationsCreateOrUpdateInput =
@@ -27812,6 +27940,7 @@ export const ServerAzureADOnlyAuthenticationsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/azureADOnlyAuthentications/{authenticationName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServerAzureADOnlyAuthenticationsDeleteInput =
@@ -27992,6 +28121,7 @@ export const ServerBlobAuditingPoliciesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/auditingSettings/{blobAuditingPolicyName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServerBlobAuditingPoliciesCreateOrUpdateInput =
@@ -28189,6 +28319,7 @@ export const ServerConfigurationOptionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/serverConfigurationOptions/{serverConfigurationOptionName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServerConfigurationOptionsCreateOrUpdateInput =
@@ -28379,6 +28510,7 @@ export const ServerConnectionPoliciesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/connectionPolicies/{connectionPolicyName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServerConnectionPoliciesCreateOrUpdateInput =
@@ -28573,6 +28705,7 @@ export const ServerDevOpsAuditSettingsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/devOpsAuditingSettings/{devOpsAuditingSettingsName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ServerDevOpsAuditSettingsCreateOrUpdateInput =
@@ -28757,6 +28890,7 @@ export const ServerDnsAliasesAcquireInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/dnsAliases/{dnsAliasName}/acquire",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServerDnsAliasesAcquireInput =
@@ -28814,6 +28948,7 @@ export const ServerDnsAliasesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/dnsAliases/{dnsAliasName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServerDnsAliasesCreateOrUpdateInput =
@@ -28870,6 +29005,7 @@ export const ServerDnsAliasesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/dnsAliases/{dnsAliasName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServerDnsAliasesDeleteInput =
@@ -29044,6 +29180,7 @@ export const ServerKeysCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/keys/{keyName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServerKeysCreateOrUpdateInput =
@@ -29100,6 +29237,7 @@ export const ServerKeysDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/keys/{keyName}",
     apiVersion: "2025-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ServerKeysDeleteInput = typeof ServerKeysDeleteInput.Type;
@@ -29474,6 +29612,7 @@ export const ServersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServersCreateOrUpdateInput = typeof ServersCreateOrUpdateInput.Type;
@@ -29527,6 +29666,7 @@ export const ServersDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}",
     apiVersion: "2025-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ServersDeleteInput = typeof ServersDeleteInput.Type;
@@ -29572,6 +29712,7 @@ export const ServerSecurityAlertPoliciesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/securityAlertPolicies/{securityAlertPolicyName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServerSecurityAlertPoliciesCreateOrUpdateInput =
@@ -29825,6 +29966,7 @@ export const ServersImportDatabaseInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/import",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServersImportDatabaseInput = typeof ServersImportDatabaseInput.Type;
@@ -30001,6 +30143,7 @@ export const ServersRefreshStatusInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/refreshExternalGovernanceStatus",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServersRefreshStatusInput = typeof ServersRefreshStatusInput.Type;
@@ -30159,6 +30302,7 @@ export const ServersUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}",
     apiVersion: "2025-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ServersUpdateInput = typeof ServersUpdateInput.Type;
@@ -30217,6 +30361,7 @@ export const ServerTrustCertificatesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/serverTrustCertificates/{certificateName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServerTrustCertificatesCreateOrUpdateInput =
@@ -30273,6 +30418,7 @@ export const ServerTrustCertificatesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/managedInstances/{managedInstanceName}/serverTrustCertificates/{certificateName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServerTrustCertificatesDeleteInput =
@@ -30451,6 +30597,7 @@ export const ServerTrustGroupsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/locations/{locationName}/serverTrustGroups/{serverTrustGroupName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServerTrustGroupsCreateOrUpdateInput =
@@ -30507,6 +30654,7 @@ export const ServerTrustGroupsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/locations/{locationName}/serverTrustGroups/{serverTrustGroupName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServerTrustGroupsDeleteInput =
@@ -31345,6 +31493,7 @@ export const SqlVulnerabilityAssessmentExecuteScanExecuteInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/sqlVulnerabilityAssessments/{vulnerabilityAssessmentName}/initiateScan",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SqlVulnerabilityAssessmentExecuteScanExecuteInput =
@@ -32604,6 +32753,7 @@ export const SyncAgentsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/syncAgents/{syncAgentName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SyncAgentsCreateOrUpdateInput =
@@ -32660,6 +32810,7 @@ export const SyncAgentsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/syncAgents/{syncAgentName}",
     apiVersion: "2025-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type SyncAgentsDeleteInput = typeof SyncAgentsDeleteInput.Type;
@@ -33021,6 +33172,7 @@ export const SyncGroupsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/syncGroups/{syncGroupName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SyncGroupsCreateOrUpdateInput =
@@ -33079,6 +33231,7 @@ export const SyncGroupsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/syncGroups/{syncGroupName}",
     apiVersion: "2025-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type SyncGroupsDeleteInput = typeof SyncGroupsDeleteInput.Type;
@@ -33411,6 +33564,7 @@ export const SyncGroupsRefreshHubSchemaInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/syncGroups/{syncGroupName}/refreshHubSchema",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SyncGroupsRefreshHubSchemaInput =
@@ -33546,6 +33700,7 @@ export const SyncGroupsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/syncGroups/{syncGroupName}",
     apiVersion: "2025-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type SyncGroupsUpdateInput = typeof SyncGroupsUpdateInput.Type;
@@ -33648,6 +33803,7 @@ export const SyncMembersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/syncGroups/{syncGroupName}/syncMembers/{syncMemberName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SyncMembersCreateOrUpdateInput =
@@ -33710,6 +33866,7 @@ export const SyncMembersDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/syncGroups/{syncGroupName}/syncMembers/{syncMemberName}",
     apiVersion: "2025-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type SyncMembersDeleteInput = typeof SyncMembersDeleteInput.Type;
@@ -33949,6 +34106,7 @@ export const SyncMembersRefreshMemberSchemaInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/syncGroups/{syncGroupName}/syncMembers/{syncMemberName}/refreshSchema",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SyncMembersRefreshMemberSchemaInput =
@@ -34037,6 +34195,7 @@ export const SyncMembersUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/syncGroups/{syncGroupName}/syncMembers/{syncMemberName}",
     apiVersion: "2025-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type SyncMembersUpdateInput = typeof SyncMembersUpdateInput.Type;
@@ -34097,6 +34256,7 @@ export const TdeCertificatesCreateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/tdeCertificates",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type TdeCertificatesCreateInput = typeof TdeCertificatesCreateInput.Type;
@@ -34267,6 +34427,7 @@ export const TransparentDataEncryptionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/transparentDataEncryption/{tdeName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type TransparentDataEncryptionsCreateOrUpdateInput =
@@ -34454,6 +34615,7 @@ export const TransparentDataEncryptionsResumeInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/transparentDataEncryption/{tdeName}/resume",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type TransparentDataEncryptionsResumeInput =
@@ -34512,6 +34674,7 @@ export const TransparentDataEncryptionsSuspendInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/transparentDataEncryption/{tdeName}/suspend",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type TransparentDataEncryptionsSuspendInput =
@@ -34634,6 +34797,7 @@ export const VirtualClustersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/virtualClusters/{virtualClusterName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualClustersCreateOrUpdateInput =
@@ -34688,6 +34852,7 @@ export const VirtualClustersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/virtualClusters/{virtualClusterName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualClustersDeleteInput = typeof VirtualClustersDeleteInput.Type;
@@ -34912,6 +35077,7 @@ export const VirtualClustersUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/virtualClusters/{virtualClusterName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualClustersUpdateInput = typeof VirtualClustersUpdateInput.Type;
@@ -34966,6 +35132,7 @@ export const VirtualClustersUpdateDnsServersInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/virtualClusters/{virtualClusterName}/updateManagedInstanceDnsServers",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualClustersUpdateDnsServersInput =
@@ -35037,6 +35204,7 @@ export const VirtualNetworkRulesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/virtualNetworkRules/{virtualNetworkRuleName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkRulesCreateOrUpdateInput =
@@ -35093,6 +35261,7 @@ export const VirtualNetworkRulesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/virtualNetworkRules/{virtualNetworkRuleName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualNetworkRulesDeleteInput =
@@ -35270,6 +35439,7 @@ export const WorkloadClassifiersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/workloadGroups/{workloadGroupName}/workloadClassifiers/{workloadClassifierName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkloadClassifiersCreateOrUpdateInput =
@@ -35330,6 +35500,7 @@ export const WorkloadClassifiersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/workloadGroups/{workloadGroupName}/workloadClassifiers/{workloadClassifierName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkloadClassifiersDeleteInput =
@@ -35516,6 +35687,7 @@ export const WorkloadGroupsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/workloadGroups/{workloadGroupName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkloadGroupsCreateOrUpdateInput =
@@ -35574,6 +35746,7 @@ export const WorkloadGroupsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/workloadGroups/{workloadGroupName}",
       apiVersion: "2025-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkloadGroupsDeleteInput = typeof WorkloadGroupsDeleteInput.Type;

--- a/packages/azure/src/services/sqlvirtualmachine.ts
+++ b/packages/azure/src/services/sqlvirtualmachine.ts
@@ -86,6 +86,7 @@ export const AvailabilityGroupListenersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachineGroups/{sqlVirtualMachineGroupName}/availabilityGroupListeners/{availabilityGroupListenerName}",
       apiVersion: "2023-10-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AvailabilityGroupListenersCreateOrUpdateInput =
@@ -142,6 +143,7 @@ export const AvailabilityGroupListenersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachineGroups/{sqlVirtualMachineGroupName}/availabilityGroupListeners/{availabilityGroupListenerName}",
       apiVersion: "2023-10-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AvailabilityGroupListenersDeleteInput =
@@ -379,6 +381,7 @@ export const SqlVirtualMachineGroupsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachineGroups/{sqlVirtualMachineGroupName}",
       apiVersion: "2023-10-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SqlVirtualMachineGroupsCreateOrUpdateInput =
@@ -433,6 +436,7 @@ export const SqlVirtualMachineGroupsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachineGroups/{sqlVirtualMachineGroupName}",
       apiVersion: "2023-10-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SqlVirtualMachineGroupsDeleteInput =
@@ -658,6 +662,7 @@ export const SqlVirtualMachineGroupsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachineGroups/{sqlVirtualMachineGroupName}",
       apiVersion: "2023-10-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SqlVirtualMachineGroupsUpdateInput =
@@ -978,6 +983,7 @@ export const SqlVirtualMachinesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/{sqlVirtualMachineName}",
       apiVersion: "2023-10-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SqlVirtualMachinesCreateOrUpdateInput =
@@ -1032,6 +1038,7 @@ export const SqlVirtualMachinesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/{sqlVirtualMachineName}",
       apiVersion: "2023-10-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SqlVirtualMachinesDeleteInput =
@@ -1070,6 +1077,7 @@ export const SqlVirtualMachinesFetchDCAssessmentInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/{sqlVirtualMachineName}/fetchDCAssessment",
       apiVersion: "2023-10-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SqlVirtualMachinesFetchDCAssessmentInput =
@@ -1364,6 +1372,7 @@ export const SqlVirtualMachinesRedeployInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/{sqlVirtualMachineName}/redeploy",
       apiVersion: "2023-10-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SqlVirtualMachinesRedeployInput =
@@ -1401,6 +1410,7 @@ export const SqlVirtualMachinesStartAssessmentInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/{sqlVirtualMachineName}/startAssessment",
       apiVersion: "2023-10-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SqlVirtualMachinesStartAssessmentInput =
@@ -1438,6 +1448,7 @@ export const SqlVirtualMachinesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/{sqlVirtualMachineName}",
       apiVersion: "2023-10-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SqlVirtualMachinesUpdateInput =
@@ -1508,6 +1519,7 @@ export const SqlVirtualMachineTroubleshootTroubleshootInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines/{sqlVirtualMachineName}/troubleshoot",
       apiVersion: "2023-10-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SqlVirtualMachineTroubleshootTroubleshootInput =

--- a/packages/azure/src/services/standbypool.ts
+++ b/packages/azure/src/services/standbypool.ts
@@ -224,6 +224,7 @@ export const StandbyContainerGroupPoolsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StandbyPool/standbyContainerGroupPools/{standbyContainerGroupPoolName}",
       apiVersion: "2025-10-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type StandbyContainerGroupPoolsCreateOrUpdateInput =
@@ -278,6 +279,7 @@ export const StandbyContainerGroupPoolsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StandbyPool/standbyContainerGroupPools/{standbyContainerGroupPoolName}",
       apiVersion: "2025-10-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StandbyContainerGroupPoolsDeleteInput =
@@ -738,6 +740,7 @@ export const StandbyVirtualMachinePoolsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StandbyPool/standbyVirtualMachinePools/{standbyVirtualMachinePoolName}",
       apiVersion: "2025-10-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type StandbyVirtualMachinePoolsCreateOrUpdateInput =
@@ -792,6 +795,7 @@ export const StandbyVirtualMachinePoolsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StandbyPool/standbyVirtualMachinePools/{standbyVirtualMachinePoolName}",
       apiVersion: "2025-10-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StandbyVirtualMachinePoolsDeleteInput =

--- a/packages/azure/src/services/storage.ts
+++ b/packages/azure/src/services/storage.ts
@@ -723,6 +723,7 @@ export const BlobContainersObjectLevelWormInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers/{containerName}/migrate",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type BlobContainersObjectLevelWormInput =
@@ -1519,6 +1520,7 @@ export const ConnectorsCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/connectors/{connectorName}",
     apiVersion: "2025-08-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type ConnectorsCreateInput = typeof ConnectorsCreateInput.Type;
@@ -1572,6 +1574,7 @@ export const ConnectorsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/connectors/{connectorName}",
     apiVersion: "2025-08-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ConnectorsDeleteInput = typeof ConnectorsDeleteInput.Type;
@@ -1727,6 +1730,7 @@ export const ConnectorsTestExistingConnectionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/connectors/{connectorName}/testExistingConnection",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ConnectorsTestExistingConnectionInput =
@@ -1784,6 +1788,7 @@ export const ConnectorsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/connectors/{connectorName}",
     apiVersion: "2025-08-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ConnectorsUpdateInput = typeof ConnectorsUpdateInput.Type;
@@ -1867,6 +1872,7 @@ export const DataSharesCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/dataShares/{dataShareName}",
     apiVersion: "2025-08-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type DataSharesCreateInput = typeof DataSharesCreateInput.Type;
@@ -1920,6 +1926,7 @@ export const DataSharesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/dataShares/{dataShareName}",
     apiVersion: "2025-08-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type DataSharesDeleteInput = typeof DataSharesDeleteInput.Type;
@@ -2096,6 +2103,7 @@ export const DataSharesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/dataShares/{dataShareName}",
     apiVersion: "2025-08-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type DataSharesUpdateInput = typeof DataSharesUpdateInput.Type;
@@ -4197,6 +4205,7 @@ export const NetworkSecurityPerimeterConfigurationsReconcileInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/networkSecurityPerimeterConfigurations/{networkSecurityPerimeterConfigurationName}/reconcile",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type NetworkSecurityPerimeterConfigurationsReconcileInput =
@@ -5433,6 +5442,7 @@ export const StorageAccountsAbortHierarchicalNamespaceMigrationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/aborthnsonmigration",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StorageAccountsAbortHierarchicalNamespaceMigrationInput =
@@ -5837,6 +5847,7 @@ export const StorageAccountsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StorageAccountsCreateInput = typeof StorageAccountsCreateInput.Type;
@@ -5920,6 +5931,7 @@ export const StorageAccountsCustomerInitiatedMigrationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/startAccountMigration",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StorageAccountsCustomerInitiatedMigrationInput =
@@ -5993,6 +6005,7 @@ export const StorageAccountsFailoverInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/failover",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StorageAccountsFailoverInput =
@@ -6146,6 +6159,7 @@ export const StorageAccountsHierarchicalNamespaceMigrationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/hnsonmigration",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StorageAccountsHierarchicalNamespaceMigrationInput =
@@ -6521,6 +6535,7 @@ export const StorageAccountsRestoreBlobRangesInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/restoreBlobRanges",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StorageAccountsRestoreBlobRangesInput =
@@ -7125,6 +7140,7 @@ export const StorageTaskAssignmentsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/storageTaskAssignments/{storageTaskAssignmentName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type StorageTaskAssignmentsCreateInput =
@@ -7181,6 +7197,7 @@ export const StorageTaskAssignmentsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/storageTaskAssignments/{storageTaskAssignmentName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StorageTaskAssignmentsDeleteInput =
@@ -7421,6 +7438,7 @@ export const StorageTaskAssignmentsStopAssignmentInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/storageTaskAssignments/{storageTaskAssignmentName}/stopAssignment",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type StorageTaskAssignmentsStopAssignmentInput =
@@ -7531,6 +7549,7 @@ export const StorageTaskAssignmentsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/storageTaskAssignments/{storageTaskAssignmentName}",
       apiVersion: "2025-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type StorageTaskAssignmentsUpdateInput =

--- a/packages/azure/src/services/storageactions.ts
+++ b/packages/azure/src/services/storageactions.ts
@@ -197,6 +197,7 @@ export const StorageTasksCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageActions/storageTasks/{storageTaskName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type StorageTasksCreateInput = typeof StorageTasksCreateInput.Type;
@@ -248,6 +249,7 @@ export const StorageTasksDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageActions/storageTasks/{storageTaskName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type StorageTasksDeleteInput = typeof StorageTasksDeleteInput.Type;
@@ -673,6 +675,7 @@ export const StorageTasksStopAllAssignmentsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageActions/storageTasks/{storageTaskName}/stopAllAssignments",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type StorageTasksStopAllAssignmentsInput =
@@ -798,6 +801,7 @@ export const StorageTasksUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageActions/storageTasks/{storageTaskName}",
       apiVersion: "2026-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type StorageTasksUpdateInput = typeof StorageTasksUpdateInput.Type;

--- a/packages/azure/src/services/storagecache.ts
+++ b/packages/azure/src/services/storagecache.ts
@@ -244,6 +244,7 @@ export const AmlFilesystemsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageCache/amlFilesystems/{amlFilesystemName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AmlFilesystemsCreateOrUpdateInput =
@@ -298,6 +299,7 @@ export const AmlFilesystemsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageCache/amlFilesystems/{amlFilesystemName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AmlFilesystemsDeleteInput = typeof AmlFilesystemsDeleteInput.Type;
@@ -560,6 +562,7 @@ export const AmlFilesystemsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageCache/amlFilesystems/{amlFilesystemName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AmlFilesystemsUpdateInput = typeof AmlFilesystemsUpdateInput.Type;
@@ -757,6 +760,7 @@ export const AutoExportJobsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageCache/amlFilesystems/{amlFilesystemName}/autoExportJobs/{autoExportJobName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AutoExportJobsCreateOrUpdateInput =
@@ -813,6 +817,7 @@ export const AutoExportJobsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageCache/amlFilesystems/{amlFilesystemName}/autoExportJobs/{autoExportJobName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AutoExportJobsDeleteInput = typeof AutoExportJobsDeleteInput.Type;
@@ -981,6 +986,7 @@ export const AutoExportJobsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageCache/amlFilesystems/{amlFilesystemName}/autoExportJobs/{autoExportJobName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AutoExportJobsUpdateInput = typeof AutoExportJobsUpdateInput.Type;
@@ -1111,6 +1117,7 @@ export const AutoImportJobsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageCache/amlFilesystems/{amlFilesystemName}/autoImportJobs/{autoImportJobName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AutoImportJobsCreateOrUpdateInput =
@@ -1167,6 +1174,7 @@ export const AutoImportJobsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageCache/amlFilesystems/{amlFilesystemName}/autoImportJobs/{autoImportJobName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AutoImportJobsDeleteInput = typeof AutoImportJobsDeleteInput.Type;
@@ -1335,6 +1343,7 @@ export const AutoImportJobsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageCache/amlFilesystems/{amlFilesystemName}/autoImportJobs/{autoImportJobName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AutoImportJobsUpdateInput = typeof AutoImportJobsUpdateInput.Type;
@@ -1615,6 +1624,7 @@ export const CachesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageCache/caches/{cacheName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CachesCreateOrUpdateInput = typeof CachesCreateOrUpdateInput.Type;
@@ -1667,6 +1677,7 @@ export const CachesDebugInfoInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageCache/caches/{cacheName}/debugInfo",
     apiVersion: "2026-01-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type CachesDebugInfoInput = typeof CachesDebugInfoInput.Type;
@@ -1698,6 +1709,7 @@ export const CachesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageCache/caches/{cacheName}",
     apiVersion: "2026-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type CachesDeleteInput = typeof CachesDeleteInput.Type;
@@ -1729,6 +1741,7 @@ export const CachesFlushInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageCache/caches/{cacheName}/flush",
     apiVersion: "2026-01-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type CachesFlushInput = typeof CachesFlushInput.Type;
@@ -1943,6 +1956,7 @@ export const CachesPausePrimingJobInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageCache/caches/{cacheName}/pausePrimingJob",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CachesPausePrimingJobInput = typeof CachesPausePrimingJobInput.Type;
@@ -1980,6 +1994,7 @@ export const CachesResumePrimingJobInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageCache/caches/{cacheName}/resumePrimingJob",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CachesResumePrimingJobInput =
@@ -2017,6 +2032,7 @@ export const CachesSpaceAllocationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageCache/caches/{cacheName}/spaceAllocation",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CachesSpaceAllocationInput = typeof CachesSpaceAllocationInput.Type;
@@ -2052,6 +2068,7 @@ export const CachesStartInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageCache/caches/{cacheName}/start",
     apiVersion: "2026-01-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type CachesStartInput = typeof CachesStartInput.Type;
@@ -2093,6 +2110,7 @@ export const CachesStartPrimingJobInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageCache/caches/{cacheName}/startPrimingJob",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CachesStartPrimingJobInput = typeof CachesStartPrimingJobInput.Type;
@@ -2128,6 +2146,7 @@ export const CachesStopInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageCache/caches/{cacheName}/stop",
     apiVersion: "2026-01-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type CachesStopInput = typeof CachesStopInput.Type;
@@ -2161,6 +2180,7 @@ export const CachesStopPrimingJobInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageCache/caches/{cacheName}/stopPrimingJob",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CachesStopPrimingJobInput = typeof CachesStopPrimingJobInput.Type;
@@ -2421,6 +2441,7 @@ export const CachesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageCache/caches/{cacheName}",
     apiVersion: "2026-01-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type CachesUpdateInput = typeof CachesUpdateInput.Type;
@@ -2471,6 +2492,7 @@ export const CachesUpgradeFirmwareInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageCache/caches/{cacheName}/upgrade",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CachesUpgradeFirmwareInput = typeof CachesUpgradeFirmwareInput.Type;
@@ -2580,6 +2602,7 @@ export const ExpansionJobsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageCache/amlFilesystems/{amlFilesystemName}/expansionJobs/{expansionJobName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ExpansionJobsCreateOrUpdateInput =
@@ -2637,6 +2660,7 @@ export const ExpansionJobsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageCache/amlFilesystems/{amlFilesystemName}/expansionJobs/{expansionJobName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ExpansionJobsDeleteInput = typeof ExpansionJobsDeleteInput.Type;
@@ -2797,6 +2821,7 @@ export const ExpansionJobsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageCache/amlFilesystems/{amlFilesystemName}/expansionJobs/{expansionJobName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ExpansionJobsUpdateInput = typeof ExpansionJobsUpdateInput.Type;
@@ -2947,6 +2972,7 @@ export const ImportJobsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageCache/amlFilesystems/{amlFilesystemName}/importJobs/{importJobName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ImportJobsCreateOrUpdateInput =
@@ -3003,6 +3029,7 @@ export const ImportJobsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageCache/amlFilesystems/{amlFilesystemName}/importJobs/{importJobName}",
     apiVersion: "2026-01-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ImportJobsDeleteInput = typeof ImportJobsDeleteInput.Type;
@@ -3164,6 +3191,7 @@ export const ImportJobsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageCache/amlFilesystems/{amlFilesystemName}/importJobs/{importJobName}",
     apiVersion: "2026-01-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type ImportJobsUpdateInput = typeof ImportJobsUpdateInput.Type;
@@ -3381,6 +3409,7 @@ export const StorageTargetFlushInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageCache/caches/{cacheName}/storageTargets/{storageTargetName}/flush",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type StorageTargetFlushInput = typeof StorageTargetFlushInput.Type;
@@ -3415,6 +3444,7 @@ export const StorageTargetInvalidateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageCache/caches/{cacheName}/storageTargets/{storageTargetName}/invalidate",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type StorageTargetInvalidateInput =
@@ -3454,6 +3484,7 @@ export const StorageTargetResumeInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageCache/caches/{cacheName}/storageTargets/{storageTargetName}/resume",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type StorageTargetResumeInput = typeof StorageTargetResumeInput.Type;
@@ -3547,6 +3578,7 @@ export const StorageTargetsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageCache/caches/{cacheName}/storageTargets/{storageTargetName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StorageTargetsCreateOrUpdateInput =
@@ -3604,6 +3636,7 @@ export const StorageTargetsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageCache/caches/{cacheName}/storageTargets/{storageTargetName}",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StorageTargetsDeleteInput = typeof StorageTargetsDeleteInput.Type;
@@ -3642,6 +3675,7 @@ export const StorageTargetsDnsRefreshInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageCache/caches/{cacheName}/storageTargets/{storageTargetName}/dnsRefresh",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type StorageTargetsDnsRefreshInput =
@@ -3807,6 +3841,7 @@ export const StorageTargetsRestoreDefaultsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageCache/caches/{cacheName}/storageTargets/{storageTargetName}/restoreDefaults",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StorageTargetsRestoreDefaultsInput =
@@ -3845,6 +3880,7 @@ export const StorageTargetSuspendInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageCache/caches/{cacheName}/storageTargets/{storageTargetName}/suspend",
       apiVersion: "2026-01-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type StorageTargetSuspendInput = typeof StorageTargetSuspendInput.Type;

--- a/packages/azure/src/services/storagediscovery.ts
+++ b/packages/azure/src/services/storagediscovery.ts
@@ -69,6 +69,7 @@ export const ReportGenerateReportInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageDiscovery/storageDiscoveryWorkspaces/{storageDiscoveryWorkspaceName}/reports/{discoveryResourceName}/generateReport",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ReportGenerateReportInput = typeof ReportGenerateReportInput.Type;
@@ -608,6 +609,7 @@ export const StorageDiscoveryWorkspacesReportInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageDiscovery/storageDiscoveryWorkspaces/{storageDiscoveryWorkspaceName}/report",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StorageDiscoveryWorkspacesReportInput =

--- a/packages/azure/src/services/storagemover.ts
+++ b/packages/azure/src/services/storagemover.ts
@@ -123,6 +123,7 @@ export const AgentsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageMover/storageMovers/{storageMoverName}/agents/{agentName}",
     apiVersion: "2025-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type AgentsDeleteInput = typeof AgentsDeleteInput.Type;
@@ -413,6 +414,7 @@ export const ConnectionsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageMover/storageMovers/{storageMoverName}/connections/{connectionName}",
     apiVersion: "2025-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ConnectionsDeleteInput = typeof ConnectionsDeleteInput.Type;
@@ -648,6 +650,7 @@ export const EndpointsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageMover/storageMovers/{storageMoverName}/endpoints/{endpointName}",
     apiVersion: "2025-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type EndpointsDeleteInput = typeof EndpointsDeleteInput.Type;
@@ -1024,6 +1027,7 @@ export const JobDefinitionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageMover/storageMovers/{storageMoverName}/projects/{projectName}/jobDefinitions/{jobDefinitionName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type JobDefinitionsDeleteInput = typeof JobDefinitionsDeleteInput.Type;
@@ -1589,6 +1593,7 @@ export const ProjectsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageMover/storageMovers/{storageMoverName}/projects/{projectName}",
     apiVersion: "2025-12-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ProjectsDeleteInput = typeof ProjectsDeleteInput.Type;
@@ -1848,6 +1853,7 @@ export const StorageMoversDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageMover/storageMovers/{storageMoverName}",
       apiVersion: "2025-12-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StorageMoversDeleteInput = typeof StorageMoversDeleteInput.Type;

--- a/packages/azure/src/services/storagepool.ts
+++ b/packages/azure/src/services/storagepool.ts
@@ -15,6 +15,7 @@ export const DiskPoolsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StoragePool/diskPools/{diskPoolName}",
       apiVersion: "2021-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DiskPoolsCreateOrUpdateInput =
@@ -47,6 +48,7 @@ export const DiskPoolsDeallocateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StoragePool/diskPools/{diskPoolName}/deallocate",
       apiVersion: "2021-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DiskPoolsDeallocateInput = typeof DiskPoolsDeallocateInput.Type;
@@ -72,6 +74,7 @@ export const DiskPoolsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StoragePool/diskPools/{diskPoolName}",
     apiVersion: "2021-08-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type DiskPoolsDeleteInput = typeof DiskPoolsDeleteInput.Type;
@@ -248,6 +251,7 @@ export const DiskPoolsStartInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StoragePool/diskPools/{diskPoolName}/start",
     apiVersion: "2021-08-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type DiskPoolsStartInput = typeof DiskPoolsStartInput.Type;
@@ -272,6 +276,7 @@ export const DiskPoolsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StoragePool/diskPools/{diskPoolName}",
     apiVersion: "2021-08-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type DiskPoolsUpdateInput = typeof DiskPoolsUpdateInput.Type;
@@ -300,6 +305,7 @@ export const DiskPoolsUpgradeInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StoragePool/diskPools/{diskPoolName}/upgrade",
     apiVersion: "2021-08-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type DiskPoolsUpgradeInput = typeof DiskPoolsUpgradeInput.Type;
@@ -364,6 +370,7 @@ export const IscsiTargetsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StoragePool/diskPools/{diskPoolName}/iscsiTargets/{iscsiTargetName}",
       apiVersion: "2021-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type IscsiTargetsCreateOrUpdateInput =
@@ -396,6 +403,7 @@ export const IscsiTargetsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StoragePool/diskPools/{diskPoolName}/iscsiTargets/{iscsiTargetName}",
       apiVersion: "2021-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type IscsiTargetsDeleteInput = typeof IscsiTargetsDeleteInput.Type;
@@ -484,6 +492,7 @@ export const IscsiTargetsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StoragePool/diskPools/{diskPoolName}/iscsiTargets/{iscsiTargetName}",
       apiVersion: "2021-08-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type IscsiTargetsUpdateInput = typeof IscsiTargetsUpdateInput.Type;

--- a/packages/azure/src/services/storagesync.ts
+++ b/packages/azure/src/services/storagesync.ts
@@ -72,6 +72,7 @@ export const CloudEndpointsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageSync/storageSyncServices/{storageSyncServiceName}/syncGroups/{syncGroupName}/cloudEndpoints/{cloudEndpointName}",
       apiVersion: "2022-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CloudEndpointsCreateInput = typeof CloudEndpointsCreateInput.Type;
@@ -129,6 +130,7 @@ export const CloudEndpointsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageSync/storageSyncServices/{storageSyncServiceName}/syncGroups/{syncGroupName}/cloudEndpoints/{cloudEndpointName}",
       apiVersion: "2022-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CloudEndpointsDeleteInput = typeof CloudEndpointsDeleteInput.Type;
@@ -298,6 +300,7 @@ export const CloudEndpointsPostBackupInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageSync/storageSyncServices/{storageSyncServiceName}/syncGroups/{syncGroupName}/cloudEndpoints/{cloudEndpointName}/postbackup",
       apiVersion: "2022-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CloudEndpointsPostBackupInput =
@@ -360,6 +363,7 @@ export const CloudEndpointsPostRestoreInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageSync/storageSyncServices/{storageSyncServiceName}/syncGroups/{syncGroupName}/cloudEndpoints/{cloudEndpointName}/postrestore",
       apiVersion: "2022-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CloudEndpointsPostRestoreInput =
@@ -402,6 +406,7 @@ export const CloudEndpointsPreBackupInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageSync/storageSyncServices/{storageSyncServiceName}/syncGroups/{syncGroupName}/cloudEndpoints/{cloudEndpointName}/prebackup",
       apiVersion: "2022-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CloudEndpointsPreBackupInput =
@@ -459,6 +464,7 @@ export const CloudEndpointsPreRestoreInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageSync/storageSyncServices/{storageSyncServiceName}/syncGroups/{syncGroupName}/cloudEndpoints/{cloudEndpointName}/prerestore",
       apiVersion: "2022-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CloudEndpointsPreRestoreInput =
@@ -545,6 +551,7 @@ export const CloudEndpointsTriggerChangeDetectionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageSync/storageSyncServices/{storageSyncServiceName}/syncGroups/{syncGroupName}/cloudEndpoints/{cloudEndpointName}/triggerChangeDetection",
       apiVersion: "2022-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CloudEndpointsTriggerChangeDetectionInput =
@@ -838,6 +845,7 @@ export const PrivateEndpointConnectionsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageSync/storageSyncServices/{storageSyncServiceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2022-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsCreateInput =
@@ -895,6 +903,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageSync/storageSyncServices/{storageSyncServiceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2022-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =
@@ -1145,6 +1154,7 @@ export const RegisteredServersCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageSync/storageSyncServices/{storageSyncServiceName}/registeredServers/{serverId}",
       apiVersion: "2022-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RegisteredServersCreateInput =
@@ -1202,6 +1212,7 @@ export const RegisteredServersDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageSync/storageSyncServices/{storageSyncServiceName}/registeredServers/{serverId}",
       apiVersion: "2022-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RegisteredServersDeleteInput =
@@ -1368,6 +1379,7 @@ export const RegisteredServersTriggerRolloverInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageSync/storageSyncServices/{storageSyncServiceName}/registeredServers/{serverId}/triggerRollover",
       apiVersion: "2022-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RegisteredServersTriggerRolloverInput =
@@ -1412,6 +1424,7 @@ export const RegisteredServersUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageSync/storageSyncServices/{storageSyncServiceName}/registeredServers/{serverId}",
       apiVersion: "2022-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type RegisteredServersUpdateInput =
@@ -1498,6 +1511,7 @@ export const ServerEndpointsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageSync/storageSyncServices/{storageSyncServiceName}/syncGroups/{syncGroupName}/serverEndpoints/{serverEndpointName}",
       apiVersion: "2022-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServerEndpointsCreateInput = typeof ServerEndpointsCreateInput.Type;
@@ -1556,6 +1570,7 @@ export const ServerEndpointsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageSync/storageSyncServices/{storageSyncServiceName}/syncGroups/{syncGroupName}/serverEndpoints/{serverEndpointName}",
       apiVersion: "2022-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServerEndpointsDeleteInput = typeof ServerEndpointsDeleteInput.Type;
@@ -1726,6 +1741,7 @@ export const ServerEndpointsRecallActionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageSync/storageSyncServices/{storageSyncServiceName}/syncGroups/{syncGroupName}/serverEndpoints/{serverEndpointName}/recallAction",
       apiVersion: "2022-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServerEndpointsRecallActionInput =
@@ -1782,6 +1798,7 @@ export const ServerEndpointsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageSync/storageSyncServices/{storageSyncServiceName}/syncGroups/{syncGroupName}/serverEndpoints/{serverEndpointName}",
       apiVersion: "2022-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServerEndpointsUpdateInput = typeof ServerEndpointsUpdateInput.Type;
@@ -1909,6 +1926,7 @@ export const StorageSyncServicesCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageSync/storageSyncServices/{storageSyncServiceName}",
       apiVersion: "2022-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StorageSyncServicesCreateInput =
@@ -1964,6 +1982,7 @@ export const StorageSyncServicesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageSync/storageSyncServices/{storageSyncServiceName}",
       apiVersion: "2022-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StorageSyncServicesDeleteInput =
@@ -2222,6 +2241,7 @@ export const StorageSyncServicesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StorageSync/storageSyncServices/{storageSyncServiceName}",
       apiVersion: "2022-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StorageSyncServicesUpdateInput =

--- a/packages/azure/src/services/streamanalytics.ts
+++ b/packages/azure/src/services/streamanalytics.ts
@@ -38,6 +38,7 @@ export const ClustersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StreamAnalytics/clusters/{clusterName}",
       apiVersion: "2020-03-01",
+      longRunning: {},
     }),
   );
 export type ClustersCreateOrUpdateInput =
@@ -78,6 +79,7 @@ export const ClustersDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StreamAnalytics/clusters/{clusterName}",
     apiVersion: "2020-03-01",
+    longRunning: {},
   }),
 );
 export type ClustersDeleteInput = typeof ClustersDeleteInput.Type;
@@ -309,6 +311,7 @@ export const ClustersUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StreamAnalytics/clusters/{clusterName}",
     apiVersion: "2020-03-01",
+    longRunning: {},
   }),
 );
 export type ClustersUpdateInput = typeof ClustersUpdateInput.Type;
@@ -606,6 +609,7 @@ export const FunctionsTestInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.StreamAnalytics/streamingjobs/{jobName}/functions/{functionName}/test",
     apiVersion: "2020-03-01",
+    longRunning: {},
   }),
 );
 export type FunctionsTestInput = typeof FunctionsTestInput.Type;
@@ -936,6 +940,7 @@ export const InputsTestInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.StreamAnalytics/streamingjobs/{jobName}/inputs/{inputName}/test",
     apiVersion: "2020-03-01",
+    longRunning: {},
   }),
 );
 export type InputsTestInput = typeof InputsTestInput.Type;
@@ -1313,6 +1318,7 @@ export const OutputsTestInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.StreamAnalytics/streamingjobs/{jobName}/outputs/{outputName}/test",
     apiVersion: "2020-03-01",
+    longRunning: {},
   }),
 );
 export type OutputsTestInput = typeof OutputsTestInput.Type;
@@ -1490,6 +1496,7 @@ export const PrivateEndpointsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.StreamAnalytics/clusters/{clusterName}/privateEndpoints/{privateEndpointName}",
       apiVersion: "2020-03-01",
+      longRunning: {},
     }),
   );
 export type PrivateEndpointsDeleteInput =
@@ -1700,6 +1707,7 @@ export const StreamingJobsCreateOrReplaceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.StreamAnalytics/streamingjobs/{jobName}",
       apiVersion: "2020-03-01",
+      longRunning: {},
     }),
   );
 export type StreamingJobsCreateOrReplaceInput =
@@ -1742,6 +1750,7 @@ export const StreamingJobsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.StreamAnalytics/streamingjobs/{jobName}",
       apiVersion: "2020-03-01",
+      longRunning: {},
     }),
   );
 export type StreamingJobsDeleteInput = typeof StreamingJobsDeleteInput.Type;
@@ -1905,6 +1914,7 @@ export const StreamingJobsScaleInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.StreamAnalytics/streamingjobs/{jobName}/scale",
       apiVersion: "2020-03-01",
+      longRunning: {},
     }),
   );
 export type StreamingJobsScaleInput = typeof StreamingJobsScaleInput.Type;
@@ -1941,6 +1951,7 @@ export const StreamingJobsStartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.StreamAnalytics/streamingjobs/{jobName}/start",
       apiVersion: "2020-03-01",
+      longRunning: {},
     }),
   );
 export type StreamingJobsStartInput = typeof StreamingJobsStartInput.Type;
@@ -1974,6 +1985,7 @@ export const StreamingJobsStopInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.StreamAnalytics/streamingjobs/{jobName}/stop",
     apiVersion: "2020-03-01",
+    longRunning: {},
   }),
 );
 export type StreamingJobsStopInput = typeof StreamingJobsStopInput.Type;

--- a/packages/azure/src/services/subscription.ts
+++ b/packages/azure/src/services/subscription.ts
@@ -32,6 +32,7 @@ export const AliasCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/providers/Microsoft.Subscription/aliases/{aliasName}",
     apiVersion: "2021-10-01",
+    longRunning: {},
   }),
 );
 export type AliasCreateInput = typeof AliasCreateInput.Type;
@@ -367,6 +368,7 @@ export const SubscriptionAcceptOwnershipInput =
       method: "POST",
       path: "/providers/Microsoft.Subscription/subscriptions/{subscriptionId}/acceptOwnership",
       apiVersion: "2021-10-01",
+      longRunning: {},
     }),
   );
 export type SubscriptionAcceptOwnershipInput =

--- a/packages/azure/src/services/support.ts
+++ b/packages/azure/src/services/support.ts
@@ -308,6 +308,7 @@ export const CommunicationsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.Support/supportTickets/{supportTicketName}/communications/{communicationName}",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CommunicationsCreateInput = typeof CommunicationsCreateInput.Type;
@@ -533,6 +534,7 @@ export const CommunicationsNoSubscriptionCreateInput =
       method: "PUT",
       path: "/providers/Microsoft.Support/supportTickets/{supportTicketName}/communications/{communicationName}",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CommunicationsNoSubscriptionCreateInput =
@@ -1725,6 +1727,7 @@ export const SupportTicketsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.Support/supportTickets/{supportTicketName}",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SupportTicketsCreateInput = typeof SupportTicketsCreateInput.Type;
@@ -2010,6 +2013,7 @@ export const SupportTicketsNoSubscriptionCreateInput =
       method: "PUT",
       path: "/providers/Microsoft.Support/supportTickets/{supportTicketName}",
       apiVersion: "2024-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SupportTicketsNoSubscriptionCreateInput =

--- a/packages/azure/src/services/synapse.ts
+++ b/packages/azure/src/services/synapse.ts
@@ -32,6 +32,7 @@ export const AzureADOnlyAuthenticationsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/azureADOnlyAuthentications/{azureADOnlyAuthenticationName}",
       apiVersion: "2021-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AzureADOnlyAuthenticationsCreateInput =
@@ -258,6 +259,7 @@ export const BigDataPoolsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/bigDataPools/{bigDataPoolName}",
       apiVersion: "2021-06-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type BigDataPoolsCreateOrUpdateInput =
@@ -304,6 +306,7 @@ export const BigDataPoolsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/bigDataPools/{bigDataPoolName}",
       apiVersion: "2021-06-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type BigDataPoolsDeleteInput = typeof BigDataPoolsDeleteInput.Type;
@@ -1382,6 +1385,7 @@ export const IntegrationRuntimeObjectMetadataRefreshInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/integrationRuntimes/{integrationRuntimeName}/refreshObjectMetadata",
       apiVersion: "2021-06-01",
+      longRunning: {},
     }),
   );
 export type IntegrationRuntimeObjectMetadataRefreshInput =
@@ -1429,6 +1433,7 @@ export const IntegrationRuntimesCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/integrationRuntimes/{integrationRuntimeName}",
       apiVersion: "2021-06-01",
+      longRunning: {},
     }),
   );
 export type IntegrationRuntimesCreateInput =
@@ -1473,6 +1478,7 @@ export const IntegrationRuntimesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/integrationRuntimes/{integrationRuntimeName}",
       apiVersion: "2021-06-01",
+      longRunning: {},
     }),
   );
 export type IntegrationRuntimesDeleteInput =
@@ -1512,6 +1518,7 @@ export const IntegrationRuntimesDisableInteractiveQueryInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/integrationRuntimes/{integrationRuntimeName}/disableInteractiveQuery",
       apiVersion: "2021-06-01",
+      longRunning: {},
     }),
   );
 export type IntegrationRuntimesDisableInteractiveQueryInput =
@@ -1548,6 +1555,7 @@ export const IntegrationRuntimesEnableInteractiveQueryInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/integrationRuntimes/{integrationRuntimeName}/enableInteractiveQuery",
       apiVersion: "2021-06-01",
+      longRunning: {},
     }),
   );
 export type IntegrationRuntimesEnableInteractiveQueryInput =
@@ -1737,6 +1745,7 @@ export const IntegrationRuntimesStartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/integrationRuntimes/{integrationRuntimeName}/start",
       apiVersion: "2021-06-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type IntegrationRuntimesStartInput =
@@ -1796,6 +1805,7 @@ export const IntegrationRuntimesStopInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/integrationRuntimes/{integrationRuntimeName}/stop",
       apiVersion: "2021-06-01",
+      longRunning: {},
     }),
   );
 export type IntegrationRuntimesStopInput =
@@ -1993,6 +2003,7 @@ export const IpFirewallRulesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/firewallRules/{ruleName}",
       apiVersion: "2021-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type IpFirewallRulesCreateOrUpdateInput =
@@ -2033,6 +2044,7 @@ export const IpFirewallRulesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/firewallRules/{ruleName}",
       apiVersion: "2021-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type IpFirewallRulesDeleteInput = typeof IpFirewallRulesDeleteInput.Type;
@@ -2175,6 +2187,7 @@ export const IpFirewallRulesReplaceAllInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/replaceAllIpFirewallRules",
       apiVersion: "2021-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type IpFirewallRulesReplaceAllInput =
@@ -2718,6 +2731,7 @@ export const PrivateEndpointConnectionsCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2021-06-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PrivateEndpointConnectionsCreateInput =
@@ -2750,6 +2764,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2021-06-01",
+      longRunning: {},
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =
@@ -3108,6 +3123,7 @@ export const PrivateLinkHubsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/privateLinkHubs/{privateLinkHubName}",
       apiVersion: "2021-06-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PrivateLinkHubsDeleteInput = typeof PrivateLinkHubsDeleteInput.Type;
@@ -4007,6 +4023,7 @@ export const SqlPoolOperationResultsGetLocationHeaderResultInput =
       method: "GET",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/sqlPools/{sqlPoolName}/operationResults/{operationId}",
       apiVersion: "2021-06-01",
+      longRunning: {},
     }),
   );
 export type SqlPoolOperationResultsGetLocationHeaderResultInput =
@@ -4249,6 +4266,7 @@ export const SqlPoolRestorePointsCreateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/sqlPools/{sqlPoolName}/restorePoints",
       apiVersion: "2021-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SqlPoolRestorePointsCreateInput =
@@ -4552,6 +4570,7 @@ export const SqlPoolsCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/sqlPools/{sqlPoolName}",
     apiVersion: "2021-06-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type SqlPoolsCreateInput = typeof SqlPoolsCreateInput.Type;
@@ -4591,6 +4610,7 @@ export const SqlPoolsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/sqlPools/{sqlPoolName}",
     apiVersion: "2021-06-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type SqlPoolsDeleteInput = typeof SqlPoolsDeleteInput.Type;
@@ -5292,6 +5312,7 @@ export const SqlPoolsPauseInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/sqlPools/{sqlPoolName}/pause",
     apiVersion: "2021-06-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type SqlPoolsPauseInput = typeof SqlPoolsPauseInput.Type;
@@ -5331,6 +5352,7 @@ export const SqlPoolsResumeInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/sqlPools/{sqlPoolName}/resume",
     apiVersion: "2021-06-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type SqlPoolsResumeInput = typeof SqlPoolsResumeInput.Type;
@@ -5401,6 +5423,7 @@ export const SqlPoolsUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/sqlPools/{sqlPoolName}",
     apiVersion: "2021-06-01",
+    longRunning: {},
   }),
 );
 export type SqlPoolsUpdateInput = typeof SqlPoolsUpdateInput.Type;
@@ -6057,6 +6080,7 @@ export const SqlPoolVulnerabilityAssessmentScansInitiateScanInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/sqlPools/{sqlPoolName}/vulnerabilityAssessments/{vulnerabilityAssessmentName}/scans/{scanId}/initiateScan",
       apiVersion: "2021-06-01",
+      longRunning: {},
     }),
   );
 export type SqlPoolVulnerabilityAssessmentScansInitiateScanInput =
@@ -6369,6 +6393,7 @@ export const SqlPoolWorkloadClassifierCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/sqlPools/{sqlPoolName}/workloadGroups/{workloadGroupName}/workloadClassifiers/{workloadClassifierName}",
       apiVersion: "2021-06-01",
+      longRunning: {},
     }),
   );
 export type SqlPoolWorkloadClassifierCreateOrUpdateInput =
@@ -6417,6 +6442,7 @@ export const SqlPoolWorkloadClassifierDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/sqlPools/{sqlPoolName}/workloadGroups/{workloadGroupName}/workloadClassifiers/{workloadClassifierName}",
       apiVersion: "2021-06-01",
+      longRunning: {},
     }),
   );
 export type SqlPoolWorkloadClassifierDeleteInput =
@@ -6571,6 +6597,7 @@ export const SqlPoolWorkloadGroupCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/sqlPools/{sqlPoolName}/workloadGroups/{workloadGroupName}",
       apiVersion: "2021-06-01",
+      longRunning: {},
     }),
   );
 export type SqlPoolWorkloadGroupCreateOrUpdateInput =
@@ -6617,6 +6644,7 @@ export const SqlPoolWorkloadGroupDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/sqlPools/{sqlPoolName}/workloadGroups/{workloadGroupName}",
       apiVersion: "2021-06-01",
+      longRunning: {},
     }),
   );
 export type SqlPoolWorkloadGroupDeleteInput =
@@ -6765,6 +6793,7 @@ export const WorkspaceAadAdminsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/administrators/activeDirectory",
       apiVersion: "2021-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkspaceAadAdminsCreateOrUpdateInput =
@@ -6805,6 +6834,7 @@ export const WorkspaceAadAdminsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/administrators/activeDirectory",
       apiVersion: "2021-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkspaceAadAdminsDeleteInput =
@@ -6902,6 +6932,7 @@ export const WorkspaceManagedIdentitySqlControlSettingsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/managedIdentitySqlControlSettings/default",
       apiVersion: "2021-06-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type WorkspaceManagedIdentitySqlControlSettingsCreateOrUpdateInput =
@@ -6998,6 +7029,7 @@ export const WorkspaceManagedSqlServerBlobAuditingPoliciesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/auditingSettings/{blobAuditingPolicyName}",
       apiVersion: "2021-06-01",
+      longRunning: {},
     }),
   );
 export type WorkspaceManagedSqlServerBlobAuditingPoliciesCreateOrUpdateInput =
@@ -7244,6 +7276,7 @@ export const WorkspaceManagedSqlServerDedicatedSQLMinimalTlsSettingsUpdateInput 
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/dedicatedSQLminimalTlsSettings/{dedicatedSQLminimalTlsSettingsName}",
       apiVersion: "2021-06-01",
+      longRunning: {},
     }),
   );
 export type WorkspaceManagedSqlServerDedicatedSQLMinimalTlsSettingsUpdateInput =
@@ -7301,6 +7334,7 @@ export const WorkspaceManagedSqlServerEncryptionProtectorCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/encryptionProtector/{encryptionProtectorName}",
       apiVersion: "2021-06-01",
+      longRunning: {},
     }),
   );
 export type WorkspaceManagedSqlServerEncryptionProtectorCreateOrUpdateInput =
@@ -7440,6 +7474,7 @@ export const WorkspaceManagedSqlServerEncryptionProtectorRevalidateInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/encryptionProtector/{encryptionProtectorName}/revalidate",
       apiVersion: "2021-06-01",
+      longRunning: {},
     }),
   );
 export type WorkspaceManagedSqlServerEncryptionProtectorRevalidateInput =
@@ -7495,6 +7530,7 @@ export const WorkspaceManagedSqlServerExtendedBlobAuditingPoliciesCreateOrUpdate
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/extendedAuditingSettings/{blobAuditingPolicyName}",
       apiVersion: "2021-06-01",
+      longRunning: {},
     }),
   );
 export type WorkspaceManagedSqlServerExtendedBlobAuditingPoliciesCreateOrUpdateInput =
@@ -7742,6 +7778,7 @@ export const WorkspaceManagedSqlServerSecurityAlertPolicyCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/securityAlertPolicies/{securityAlertPolicyName}",
       apiVersion: "2021-06-01",
+      longRunning: {},
     }),
   );
 export type WorkspaceManagedSqlServerSecurityAlertPolicyCreateOrUpdateInput =
@@ -8251,6 +8288,7 @@ export const WorkspacesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}",
       apiVersion: "2021-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkspacesCreateOrUpdateInput =
@@ -8291,6 +8329,7 @@ export const WorkspacesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}",
     apiVersion: "2021-06-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type WorkspacesDeleteInput = typeof WorkspacesDeleteInput.Type;
@@ -8455,6 +8494,7 @@ export const WorkspaceSqlAadAdminsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/sqlAdministrators/activeDirectory",
       apiVersion: "2021-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkspaceSqlAadAdminsCreateOrUpdateInput =
@@ -8495,6 +8535,7 @@ export const WorkspaceSqlAadAdminsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}/sqlAdministrators/activeDirectory",
       apiVersion: "2021-06-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkspaceSqlAadAdminsDeleteInput =
@@ -8653,6 +8694,7 @@ export const WorkspacesUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Synapse/workspaces/{workspaceName}",
     apiVersion: "2021-06-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type WorkspacesUpdateInput = typeof WorkspacesUpdateInput.Type;

--- a/packages/azure/src/services/timeseriesinsights.ts
+++ b/packages/azure/src/services/timeseriesinsights.ts
@@ -197,6 +197,7 @@ export const EnvironmentsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.TimeSeriesInsights/environments/{environmentName}",
       apiVersion: "2020-05-15",
+      longRunning: {},
     }),
   );
 export type EnvironmentsCreateOrUpdateInput =
@@ -359,6 +360,7 @@ export const EnvironmentsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.TimeSeriesInsights/environments/{environmentName}",
       apiVersion: "2020-05-15",
+      longRunning: {},
     }),
   );
 export type EnvironmentsUpdateInput = typeof EnvironmentsUpdateInput.Type;

--- a/packages/azure/src/services/vi.ts
+++ b/packages/azure/src/services/vi.ts
@@ -799,6 +799,7 @@ export const PrivateEndpointConnectionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.VideoIndexer/accounts/{accountName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PrivateEndpointConnectionsCreateOrUpdateInput =
@@ -854,6 +855,7 @@ export const PrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.VideoIndexer/accounts/{accountName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-04-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateEndpointConnectionsDeleteInput =

--- a/packages/azure/src/services/vmware.ts
+++ b/packages/azure/src/services/vmware.ts
@@ -37,6 +37,7 @@ export const AddonsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/addons/{addonName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AddonsCreateOrUpdateInput = typeof AddonsCreateOrUpdateInput.Type;
@@ -91,6 +92,7 @@ export const AddonsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/addons/{addonName}",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type AddonsDeleteInput = typeof AddonsDeleteInput.Type;
@@ -240,6 +242,7 @@ export const AuthorizationsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/authorizations/{authorizationName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type AuthorizationsCreateOrUpdateInput =
@@ -296,6 +299,7 @@ export const AuthorizationsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/authorizations/{authorizationName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AuthorizationsDeleteInput = typeof AuthorizationsDeleteInput.Type;
@@ -470,6 +474,7 @@ export const CloudLinksCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/cloudLinks/{cloudLinkName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CloudLinksCreateOrUpdateInput =
@@ -526,6 +531,7 @@ export const CloudLinksDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/cloudLinks/{cloudLinkName}",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type CloudLinksDeleteInput = typeof CloudLinksDeleteInput.Type;
@@ -692,6 +698,7 @@ export const ClustersCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/clusters/{clusterName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ClustersCreateOrUpdateInput =
@@ -748,6 +755,7 @@ export const ClustersDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/clusters/{clusterName}",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ClustersDeleteInput = typeof ClustersDeleteInput.Type;
@@ -948,6 +956,7 @@ export const ClustersUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/clusters/{clusterName}",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type ClustersUpdateInput = typeof ClustersUpdateInput.Type;
@@ -1052,6 +1061,7 @@ export const DatastoresCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/clusters/{clusterName}/datastores/{datastoreName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type DatastoresCreateOrUpdateInput =
@@ -1110,6 +1120,7 @@ export const DatastoresDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/clusters/{clusterName}/datastores/{datastoreName}",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type DatastoresDeleteInput = typeof DatastoresDeleteInput.Type;
@@ -1268,6 +1279,7 @@ export const GlobalReachConnectionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/globalReachConnections/{globalReachConnectionName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type GlobalReachConnectionsCreateOrUpdateInput =
@@ -1324,6 +1336,7 @@ export const GlobalReachConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/globalReachConnections/{globalReachConnectionName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type GlobalReachConnectionsDeleteInput =
@@ -1845,6 +1858,7 @@ export const IscsiPathsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/iscsiPaths/default",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type IscsiPathsCreateOrUpdateInput =
@@ -1899,6 +1913,7 @@ export const IscsiPathsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/iscsiPaths/default",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type IscsiPathsDeleteInput = typeof IscsiPathsDeleteInput.Type;
@@ -2058,6 +2073,7 @@ export const LicensesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/licenses/{licenseName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type LicensesCreateOrUpdateInput =
@@ -2114,6 +2130,7 @@ export const LicensesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/licenses/{licenseName}",
     apiVersion: "2025-09-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type LicensesDeleteInput = typeof LicensesDeleteInput.Type;
@@ -2758,6 +2775,7 @@ export const PlacementPoliciesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/clusters/{clusterName}/placementPolicies/{placementPolicyName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PlacementPoliciesCreateOrUpdateInput =
@@ -2816,6 +2834,7 @@ export const PlacementPoliciesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/clusters/{clusterName}/placementPolicies/{placementPolicyName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PlacementPoliciesDeleteInput =
@@ -2996,6 +3015,7 @@ export const PlacementPoliciesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/clusters/{clusterName}/placementPolicies/{placementPolicyName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PlacementPoliciesUpdateInput =
@@ -3198,6 +3218,7 @@ export const PrivateCloudsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PrivateCloudsCreateOrUpdateInput =
@@ -3253,6 +3274,7 @@ export const PrivateCloudsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateCloudsDeleteInput = typeof PrivateCloudsDeleteInput.Type;
@@ -3550,6 +3572,7 @@ export const PrivateCloudsRotateNsxtPasswordInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/rotateNsxtPassword",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateCloudsRotateNsxtPasswordInput =
@@ -3586,6 +3609,7 @@ export const PrivateCloudsRotateVcenterPasswordInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/rotateVcenterPassword",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateCloudsRotateVcenterPasswordInput =
@@ -3710,6 +3734,7 @@ export const PrivateCloudsUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PrivateCloudsUpdateInput = typeof PrivateCloudsUpdateInput.Type;
@@ -3904,6 +3929,7 @@ export const PureStoragePoliciesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/pureStoragePolicies/{storagePolicyName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type PureStoragePoliciesCreateOrUpdateInput =
@@ -3960,6 +3986,7 @@ export const PureStoragePoliciesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/pureStoragePolicies/{storagePolicyName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type PureStoragePoliciesDeleteInput =
@@ -4296,6 +4323,7 @@ export const ScriptExecutionsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/scriptExecutions/{scriptExecutionName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ScriptExecutionsCreateOrUpdateInput =
@@ -4352,6 +4380,7 @@ export const ScriptExecutionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/scriptExecutions/{scriptExecutionName}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ScriptExecutionsDeleteInput =
@@ -4687,6 +4716,7 @@ export const ServiceComponentsCheckAvailabilityInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/providers/Microsoft.AVS/locations/{location}/serviceComponents/{serviceComponentName}/checkAvailability",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type ServiceComponentsCheckAvailabilityInput =
@@ -4929,6 +4959,7 @@ export const VirtualMachinesRestrictMovementInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/clusters/{clusterName}/virtualMachines/{virtualMachineId}/restrictMovement",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type VirtualMachinesRestrictMovementInput =
@@ -4986,6 +5017,7 @@ export const WorkloadNetworksCreateDhcpInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/workloadNetworks/default/dhcpConfigurations/{dhcpId}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type WorkloadNetworksCreateDhcpInput =
@@ -5066,6 +5098,7 @@ export const WorkloadNetworksCreateDnsServiceInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/workloadNetworks/default/dnsServices/{dnsServiceId}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type WorkloadNetworksCreateDnsServiceInput =
@@ -5142,6 +5175,7 @@ export const WorkloadNetworksCreateDnsZoneInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/workloadNetworks/default/dnsZones/{dnsZoneId}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type WorkloadNetworksCreateDnsZoneInput =
@@ -5220,6 +5254,7 @@ export const WorkloadNetworksCreatePortMirroringInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/workloadNetworks/default/portMirroringProfiles/{portMirroringId}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type WorkloadNetworksCreatePortMirroringInput =
@@ -5293,6 +5328,7 @@ export const WorkloadNetworksCreatePublicIPInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/workloadNetworks/default/publicIPs/{publicIPId}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type WorkloadNetworksCreatePublicIPInput =
@@ -5380,6 +5416,7 @@ export const WorkloadNetworksCreateSegmentsInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/workloadNetworks/default/segments/{segmentId}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type WorkloadNetworksCreateSegmentsInput =
@@ -5454,6 +5491,7 @@ export const WorkloadNetworksCreateVMGroupInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/workloadNetworks/default/vmGroups/{vmGroupId}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type WorkloadNetworksCreateVMGroupInput =
@@ -5510,6 +5548,7 @@ export const WorkloadNetworksDeleteDhcpInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/workloadNetworks/default/dhcpConfigurations/{dhcpId}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkloadNetworksDeleteDhcpInput =
@@ -5547,6 +5586,7 @@ export const WorkloadNetworksDeleteDnsServiceInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/workloadNetworks/default/dnsServices/{dnsServiceId}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkloadNetworksDeleteDnsServiceInput =
@@ -5581,6 +5621,7 @@ export const WorkloadNetworksDeleteDnsZoneInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/workloadNetworks/default/dnsZones/{dnsZoneId}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkloadNetworksDeleteDnsZoneInput =
@@ -5615,6 +5656,7 @@ export const WorkloadNetworksDeletePortMirroringInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/workloadNetworks/default/portMirroringProfiles/{portMirroringId}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkloadNetworksDeletePortMirroringInput =
@@ -5649,6 +5691,7 @@ export const WorkloadNetworksDeletePublicIPInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/workloadNetworks/default/publicIPs/{publicIPId}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkloadNetworksDeletePublicIPInput =
@@ -5685,6 +5728,7 @@ export const WorkloadNetworksDeleteSegmentInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/workloadNetworks/default/segments/{segmentId}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkloadNetworksDeleteSegmentInput =
@@ -5721,6 +5765,7 @@ export const WorkloadNetworksDeleteVMGroupInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/workloadNetworks/default/vmGroups/{vmGroupId}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkloadNetworksDeleteVMGroupInput =
@@ -7022,6 +7067,7 @@ export const WorkloadNetworksUpdateDhcpInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/workloadNetworks/default/dhcpConfigurations/{dhcpId}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkloadNetworksUpdateDhcpInput =
@@ -7102,6 +7148,7 @@ export const WorkloadNetworksUpdateDnsServiceInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/workloadNetworks/default/dnsServices/{dnsServiceId}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkloadNetworksUpdateDnsServiceInput =
@@ -7178,6 +7225,7 @@ export const WorkloadNetworksUpdateDnsZoneInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/workloadNetworks/default/dnsZones/{dnsZoneId}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkloadNetworksUpdateDnsZoneInput =
@@ -7256,6 +7304,7 @@ export const WorkloadNetworksUpdatePortMirroringInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/workloadNetworks/default/portMirroringProfiles/{portMirroringId}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkloadNetworksUpdatePortMirroringInput =
@@ -7343,6 +7392,7 @@ export const WorkloadNetworksUpdateSegmentsInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/workloadNetworks/default/segments/{segmentId}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkloadNetworksUpdateSegmentsInput =
@@ -7417,6 +7467,7 @@ export const WorkloadNetworksUpdateVMGroupInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/workloadNetworks/default/vmGroups/{vmGroupId}",
       apiVersion: "2025-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkloadNetworksUpdateVMGroupInput =

--- a/packages/azure/src/services/vmwarecloudsimple.ts
+++ b/packages/azure/src/services/vmwarecloudsimple.ts
@@ -274,6 +274,7 @@ export const DedicatedCloudNodesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.VMwareCloudSimple/dedicatedCloudNodes/{dedicatedCloudNodeName}",
       apiVersion: "2019-04-01",
+      longRunning: {},
     }),
   );
 export type DedicatedCloudNodesCreateOrUpdateInput =
@@ -762,6 +763,7 @@ export const DedicatedCloudServicesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.VMwareCloudSimple/dedicatedCloudServices/{dedicatedCloudServiceName}",
       apiVersion: "2019-04-01",
+      longRunning: {},
     }),
   );
 export type DedicatedCloudServicesDeleteInput =
@@ -1858,6 +1860,7 @@ export const VirtualMachinesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.VMwareCloudSimple/virtualMachines/{virtualMachineName}",
       apiVersion: "2019-04-01",
+      longRunning: {},
     }),
   );
 export type VirtualMachinesCreateOrUpdateInput =
@@ -2021,6 +2024,7 @@ export const VirtualMachinesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.VMwareCloudSimple/virtualMachines/{virtualMachineName}",
       apiVersion: "2019-04-01",
+      longRunning: {},
     }),
   );
 export type VirtualMachinesDeleteInput = typeof VirtualMachinesDeleteInput.Type;
@@ -2566,6 +2570,7 @@ export const VirtualMachinesStartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.VMwareCloudSimple/virtualMachines/{virtualMachineName}/start",
       apiVersion: "2019-04-01",
+      longRunning: {},
     }),
   );
 export type VirtualMachinesStartInput = typeof VirtualMachinesStartInput.Type;
@@ -2601,6 +2606,7 @@ export const VirtualMachinesStopInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.VMwareCloudSimple/virtualMachines/{virtualMachineName}/stop",
       apiVersion: "2019-04-01",
+      longRunning: {},
     }),
   );
 export type VirtualMachinesStopInput = typeof VirtualMachinesStopInput.Type;
@@ -2633,6 +2639,7 @@ export const VirtualMachinesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.VMwareCloudSimple/virtualMachines/{virtualMachineName}",
       apiVersion: "2019-04-01",
+      longRunning: {},
     }),
   );
 export type VirtualMachinesUpdateInput = typeof VirtualMachinesUpdateInput.Type;

--- a/packages/azure/src/services/voiceservices.ts
+++ b/packages/azure/src/services/voiceservices.ts
@@ -148,6 +148,7 @@ export const CommunicationsGatewaysCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.VoiceServices/communicationsGateways/{communicationsGatewayName}",
       apiVersion: "2023-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type CommunicationsGatewaysCreateOrUpdateInput =
@@ -202,6 +203,7 @@ export const CommunicationsGatewaysDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.VoiceServices/communicationsGateways/{communicationsGatewayName}",
       apiVersion: "2023-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type CommunicationsGatewaysDeleteInput =
@@ -613,6 +615,7 @@ export const TestLinesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.VoiceServices/communicationsGateways/{communicationsGatewayName}/testLines/{testLineName}",
       apiVersion: "2023-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type TestLinesCreateOrUpdateInput =
@@ -669,6 +672,7 @@ export const TestLinesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.VoiceServices/communicationsGateways/{communicationsGatewayName}/testLines/{testLineName}",
     apiVersion: "2023-09-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type TestLinesDeleteInput = typeof TestLinesDeleteInput.Type;

--- a/packages/azure/src/services/web.ts
+++ b/packages/azure/src/services/web.ts
@@ -40,6 +40,7 @@ export const AppServiceEnvironmentsApproveOrRejectPrivateEndpointConnectionInput
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AppServiceEnvironmentsApproveOrRejectPrivateEndpointConnectionInput =
@@ -102,6 +103,7 @@ export const AppServiceEnvironmentsChangeVnetInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/changeVirtualNetwork",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AppServiceEnvironmentsChangeVnetInput =
@@ -288,6 +290,7 @@ export const AppServiceEnvironmentsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AppServiceEnvironmentsCreateOrUpdateInput =
@@ -384,6 +387,7 @@ export const AppServiceEnvironmentsCreateOrUpdateMultiRolePoolInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/multiRolePools/default",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AppServiceEnvironmentsCreateOrUpdateMultiRolePoolInput =
@@ -481,6 +485,7 @@ export const AppServiceEnvironmentsCreateOrUpdateWorkerPoolInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/workerPools/{workerPoolName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AppServiceEnvironmentsCreateOrUpdateWorkerPoolInput =
@@ -539,6 +544,7 @@ export const AppServiceEnvironmentsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AppServiceEnvironmentsDeleteInput =
@@ -617,6 +623,7 @@ export const AppServiceEnvironmentsDeletePrivateEndpointConnectionInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AppServiceEnvironmentsDeletePrivateEndpointConnectionInput =
@@ -2499,6 +2506,7 @@ export const AppServiceEnvironmentsResumeInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/resume",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AppServiceEnvironmentsResumeInput =
@@ -2570,6 +2578,7 @@ export const AppServiceEnvironmentsSuspendInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/suspend",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AppServiceEnvironmentsSuspendInput =
@@ -3185,6 +3194,7 @@ export const AppServiceEnvironmentsUpgradeInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/hostingEnvironments/{name}/upgrade",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AppServiceEnvironmentsUpgradeInput =
@@ -3409,6 +3419,7 @@ export const AppServicePlansCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/serverfarms/{name}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type AppServicePlansCreateOrUpdateInput =
@@ -7772,6 +7783,7 @@ export const KubeEnvironmentsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/kubeEnvironments/{name}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type KubeEnvironmentsCreateOrUpdateInput =
@@ -7828,6 +7840,7 @@ export const KubeEnvironmentsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/kubeEnvironments/{name}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type KubeEnvironmentsDeleteInput =
@@ -10950,6 +10963,7 @@ export const StaticSitesApproveOrRejectPrivateEndpointConnectionInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/staticSites/{name}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StaticSitesApproveOrRejectPrivateEndpointConnectionInput =
@@ -11458,6 +11472,7 @@ export const StaticSitesCreateOrUpdateStaticSiteInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/staticSites/{name}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StaticSitesCreateOrUpdateStaticSiteInput =
@@ -11670,6 +11685,7 @@ export const StaticSitesCreateOrUpdateStaticSiteCustomDomainInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/staticSites/{name}/customDomains/{domainName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StaticSitesCreateOrUpdateStaticSiteCustomDomainInput =
@@ -11841,6 +11857,7 @@ export const StaticSitesCreateZipDeploymentForStaticSiteInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/staticSites/{name}/zipdeploy",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StaticSitesCreateZipDeploymentForStaticSiteInput =
@@ -11892,6 +11909,7 @@ export const StaticSitesCreateZipDeploymentForStaticSiteBuildInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/staticSites/{name}/builds/{environmentName}/zipdeploy",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StaticSitesCreateZipDeploymentForStaticSiteBuildInput =
@@ -12010,6 +12028,7 @@ export const StaticSitesDeletePrivateEndpointConnectionInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/staticSites/{name}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StaticSitesDeletePrivateEndpointConnectionInput =
@@ -12049,6 +12068,7 @@ export const StaticSitesDeleteStaticSiteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/staticSites/{name}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StaticSitesDeleteStaticSiteInput =
@@ -12089,6 +12109,7 @@ export const StaticSitesDeleteStaticSiteBuildInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/staticSites/{name}/builds/{environmentName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StaticSitesDeleteStaticSiteBuildInput =
@@ -12129,6 +12150,7 @@ export const StaticSitesDeleteStaticSiteCustomDomainInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/staticSites/{name}/customDomains/{domainName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StaticSitesDeleteStaticSiteCustomDomainInput =
@@ -12207,6 +12229,7 @@ export const StaticSitesDetachStaticSiteInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/staticSites/{name}/detach",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StaticSitesDetachStaticSiteInput =
@@ -13918,6 +13941,7 @@ export const StaticSitesLinkBackendInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/staticSites/{name}/linkedBackends/{linkedBackendName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StaticSitesLinkBackendInput =
@@ -13985,6 +14009,7 @@ export const StaticSitesLinkBackendToBuildInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/staticSites/{name}/builds/{environmentName}/linkedBackends/{linkedBackendName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StaticSitesLinkBackendToBuildInput =
@@ -14719,6 +14744,7 @@ export const StaticSitesRegisterUserProvidedFunctionAppWithStaticSiteInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/staticSites/{name}/userProvidedFunctionApps/{functionAppName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StaticSitesRegisterUserProvidedFunctionAppWithStaticSiteInput =
@@ -14789,6 +14815,7 @@ export const StaticSitesRegisterUserProvidedFunctionAppWithStaticSiteBuildInput 
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/staticSites/{name}/builds/{environmentName}/userProvidedFunctionApps/{functionAppName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StaticSitesRegisterUserProvidedFunctionAppWithStaticSiteBuildInput =
@@ -15414,6 +15441,7 @@ export const StaticSitesValidateBackendInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/staticSites/{name}/linkedBackends/{linkedBackendName}/validate",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StaticSitesValidateBackendInput =
@@ -15463,6 +15491,7 @@ export const StaticSitesValidateBackendForBuildInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/staticSites/{name}/builds/{environmentName}/linkedBackends/{linkedBackendName}/validate",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StaticSitesValidateBackendForBuildInput =
@@ -15510,6 +15539,7 @@ export const StaticSitesValidateCustomDomainCanBeAddedToStaticSiteInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/staticSites/{name}/customDomains/{domainName}/validate",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type StaticSitesValidateCustomDomainCanBeAddedToStaticSiteInput =
@@ -16261,6 +16291,7 @@ export const WebAppsApproveOrRejectPrivateEndpointConnectionInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppsApproveOrRejectPrivateEndpointConnectionInput =
@@ -16339,6 +16370,7 @@ export const WebAppsApproveOrRejectPrivateEndpointConnectionSlotInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppsApproveOrRejectPrivateEndpointConnectionSlotInput =
@@ -16741,6 +16773,7 @@ export const WebAppsCreateFunctionInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/functions/{functionName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppsCreateFunctionInput = typeof WebAppsCreateFunctionInput.Type;
@@ -16818,6 +16851,7 @@ export const WebAppsCreateInstanceFunctionSlotInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/functions/{functionName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppsCreateInstanceFunctionSlotInput =
@@ -16893,6 +16927,7 @@ export const WebAppsCreateInstanceMSDeployOperationInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/instances/{instanceId}/extensions/MSDeploy",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppsCreateInstanceMSDeployOperationInput =
@@ -16968,6 +17003,7 @@ export const WebAppsCreateInstanceMSDeployOperationSlotInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/instances/{instanceId}/extensions/MSDeploy",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppsCreateInstanceMSDeployOperationSlotInput =
@@ -17042,6 +17078,7 @@ export const WebAppsCreateMSDeployOperationInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/extensions/MSDeploy",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppsCreateMSDeployOperationInput =
@@ -17115,6 +17152,7 @@ export const WebAppsCreateMSDeployOperationSlotInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/extensions/MSDeploy",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppsCreateMSDeployOperationSlotInput =
@@ -17854,6 +17892,7 @@ export const WebAppsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppsCreateOrUpdateInput = typeof WebAppsCreateOrUpdateInput.Type;
@@ -20520,6 +20559,7 @@ export const WebAppsCreateOrUpdateSlotInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppsCreateOrUpdateSlotInput =
@@ -20609,6 +20649,7 @@ export const WebAppsCreateOrUpdateSourceControlInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/sourcecontrols/web",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppsCreateOrUpdateSourceControlInput =
@@ -20697,6 +20738,7 @@ export const WebAppsCreateOrUpdateSourceControlSlotInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/sourcecontrols/web",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppsCreateOrUpdateSourceControlSlotInput =
@@ -22263,6 +22305,7 @@ export const WebAppsDeletePrivateEndpointConnectionInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppsDeletePrivateEndpointConnectionInput =
@@ -22304,6 +22347,7 @@ export const WebAppsDeletePrivateEndpointConnectionSlotInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppsDeletePrivateEndpointConnectionSlotInput =
@@ -27997,6 +28041,7 @@ export const WebAppsGetProductionSiteDeploymentStatusInput =
       method: "GET",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/deploymentStatus/{deploymentStatusId}",
       apiVersion: "2025-05-01",
+      longRunning: {},
     }),
   );
 export type WebAppsGetProductionSiteDeploymentStatusInput =
@@ -29039,6 +29084,7 @@ export const WebAppsGetSlotSiteDeploymentStatusSlotInput =
       method: "GET",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/deploymentStatus/{deploymentStatusId}",
       apiVersion: "2025-05-01",
+      longRunning: {},
     }),
   );
 export type WebAppsGetSlotSiteDeploymentStatusSlotInput =
@@ -30053,6 +30099,7 @@ export const WebAppsInstallSiteExtensionInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/siteextensions/{siteExtensionId}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppsInstallSiteExtensionInput =
@@ -30113,6 +30160,7 @@ export const WebAppsInstallSiteExtensionSlotInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/siteextensions/{siteExtensionId}",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppsInstallSiteExtensionSlotInput =
@@ -34309,6 +34357,7 @@ export const WebAppsListPublishingCredentialsInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/config/publishingcredentials/list",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppsListPublishingCredentialsInput =
@@ -34366,6 +34415,7 @@ export const WebAppsListPublishingCredentialsSlotInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/config/publishingcredentials/list",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppsListPublishingCredentialsSlotInput =
@@ -36653,6 +36703,7 @@ export const WebAppsMigrateMySqlInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/migratemysql",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppsMigrateMySqlInput = typeof WebAppsMigrateMySqlInput.Type;
@@ -36730,6 +36781,7 @@ export const WebAppsMigrateStorageInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/migrate",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppsMigrateStorageInput = typeof WebAppsMigrateStorageInput.Type;
@@ -37212,6 +37264,7 @@ export const WebAppsRestoreInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/backups/{backupId}/restore",
     apiVersion: "2025-05-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type WebAppsRestoreInput = typeof WebAppsRestoreInput.Type;
@@ -37287,6 +37340,7 @@ export const WebAppsRestoreFromBackupBlobInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/restoreFromBackupBlob",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppsRestoreFromBackupBlobInput =
@@ -37366,6 +37420,7 @@ export const WebAppsRestoreFromBackupBlobSlotInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/restoreFromBackupBlob",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppsRestoreFromBackupBlobSlotInput =
@@ -37416,6 +37471,7 @@ export const WebAppsRestoreFromDeletedAppInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/restoreFromDeletedApp",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppsRestoreFromDeletedAppInput =
@@ -37466,6 +37522,7 @@ export const WebAppsRestoreFromDeletedAppSlotInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/restoreFromDeletedApp",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppsRestoreFromDeletedAppSlotInput =
@@ -37547,6 +37604,7 @@ export const WebAppsRestoreSlotInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/backups/{backupId}/restore",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppsRestoreSlotInput = typeof WebAppsRestoreSlotInput.Type;
@@ -37601,6 +37659,7 @@ export const WebAppsRestoreSnapshotInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/restoreSnapshot",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppsRestoreSnapshotInput =
@@ -37659,6 +37718,7 @@ export const WebAppsRestoreSnapshotSlotInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/restoreSnapshot",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppsRestoreSnapshotSlotInput =
@@ -37900,6 +37960,7 @@ export const WebAppsStartNetworkTraceInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/startNetworkTrace",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppsStartNetworkTraceInput =
@@ -37952,6 +38013,7 @@ export const WebAppsStartNetworkTraceSlotInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/startNetworkTrace",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppsStartNetworkTraceSlotInput =
@@ -38082,6 +38144,7 @@ export const WebAppsStartWebSiteNetworkTraceOperationInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/networkTrace/startOperation",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppsStartWebSiteNetworkTraceOperationInput =
@@ -38133,6 +38196,7 @@ export const WebAppsStartWebSiteNetworkTraceOperationSlotInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/networkTrace/startOperation",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppsStartWebSiteNetworkTraceOperationSlotInput =
@@ -38539,6 +38603,7 @@ export const WebAppsSwapSlotSlotInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slots/{slot}/slotsswap",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppsSwapSlotSlotInput = typeof WebAppsSwapSlotSlotInput.Type;
@@ -38577,6 +38642,7 @@ export const WebAppsSwapSlotWithProductionInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/slotsswap",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebAppsSwapSlotWithProductionInput =
@@ -45736,6 +45802,7 @@ export const WorkflowTriggerHistoriesResubmitInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/hostruntime/runtime/webhooks/workflow/api/management/workflows/{workflowName}/triggers/{triggerName}/histories/{historyName}/resubmit",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkflowTriggerHistoriesResubmitInput =
@@ -46004,6 +46071,7 @@ export const WorkflowTriggersRunInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/hostruntime/runtime/webhooks/workflow/api/management/workflows/{workflowName}/triggers/{triggerName}/run",
       apiVersion: "2025-05-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WorkflowTriggersRunInput = typeof WorkflowTriggersRunInput.Type;

--- a/packages/azure/src/services/webpubsub.ts
+++ b/packages/azure/src/services/webpubsub.ts
@@ -415,6 +415,7 @@ export const WebPubSubCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/webPubSub/{resourceName}",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type WebPubSubCreateOrUpdateInput =
@@ -487,6 +488,7 @@ export const WebPubSubCustomCertificatesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/webPubSub/{resourceName}/customCertificates/{certificateName}",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type WebPubSubCustomCertificatesCreateOrUpdateInput =
@@ -719,6 +721,7 @@ export const WebPubSubCustomDomainsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/webPubSub/{resourceName}/customDomains/{name}",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type WebPubSubCustomDomainsCreateOrUpdateInput =
@@ -773,6 +776,7 @@ export const WebPubSubCustomDomainsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/webPubSub/{resourceName}/customDomains/{name}",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebPubSubCustomDomainsDeleteInput =
@@ -932,6 +936,7 @@ export const WebPubSubDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/webPubSub/{resourceName}",
     apiVersion: "2024-03-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type WebPubSubDeleteInput = typeof WebPubSubDeleteInput.Type;
@@ -1047,6 +1052,7 @@ export const WebPubSubHubsCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/webPubSub/{resourceName}/hubs/{hubName}",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type WebPubSubHubsCreateOrUpdateInput =
@@ -1102,6 +1108,7 @@ export const WebPubSubHubsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/webPubSub/{resourceName}/hubs/{hubName}",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebPubSubHubsDeleteInput = typeof WebPubSubHubsDeleteInput.Type;
@@ -1556,6 +1563,7 @@ export const WebPubSubPrivateEndpointConnectionsDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/webPubSub/{resourceName}/privateEndpointConnections/{privateEndpointConnectionName}",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebPubSubPrivateEndpointConnectionsDeleteInput =
@@ -1875,6 +1883,7 @@ export const WebPubSubRegenerateKeyInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/webPubSub/{resourceName}/regenerateKey",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebPubSubRegenerateKeyInput =
@@ -1947,6 +1956,7 @@ export const WebPubSubReplicasCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/webPubSub/{resourceName}/replicas/{replicaName}",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type WebPubSubReplicasCreateOrUpdateInput =
@@ -2114,6 +2124,7 @@ export const WebPubSubReplicaSharedPrivateLinkResourcesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/webPubSub/{resourceName}/replicas/{replicaName}/sharedPrivateLinkResources/{sharedPrivateLinkResourceName}",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type WebPubSubReplicaSharedPrivateLinkResourcesCreateOrUpdateInput =
@@ -2357,6 +2368,7 @@ export const WebPubSubReplicasRestartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/webPubSub/{resourceName}/replicas/{replicaName}/restart",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebPubSubReplicasRestartInput =
@@ -2424,6 +2436,7 @@ export const WebPubSubReplicasUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/webPubSub/{resourceName}/replicas/{replicaName}",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebPubSubReplicasUpdateInput =
@@ -2476,6 +2489,7 @@ export const WebPubSubRestartInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "POST",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/webPubSub/{resourceName}/restart",
     apiVersion: "2024-03-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type WebPubSubRestartInput = typeof WebPubSubRestartInput.Type;
@@ -2535,6 +2549,7 @@ export const WebPubSubSharedPrivateLinkResourcesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/webPubSub/{resourceName}/sharedPrivateLinkResources/{sharedPrivateLinkResourceName}",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type WebPubSubSharedPrivateLinkResourcesCreateOrUpdateInput =
@@ -2587,6 +2602,7 @@ export const WebPubSubSharedPrivateLinkResourcesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/webPubSub/{resourceName}/sharedPrivateLinkResources/{sharedPrivateLinkResourceName}",
       apiVersion: "2024-03-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type WebPubSubSharedPrivateLinkResourcesDeleteInput =
@@ -2965,6 +2981,7 @@ export const WebPubSubUpdateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PATCH",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/webPubSub/{resourceName}",
     apiVersion: "2024-03-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type WebPubSubUpdateInput = typeof WebPubSubUpdateInput.Type;

--- a/packages/azure/src/services/widget.ts
+++ b/packages/azure/src/services/widget.ts
@@ -39,6 +39,7 @@ export const EmployeesCreateOrUpdateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Widget/employees/{employeeName}",
       apiVersion: "2021-11-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type EmployeesCreateOrUpdateInput =
@@ -93,6 +94,7 @@ export const EmployeesDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Widget/employees/{employeeName}",
     apiVersion: "2021-11-01",
+    longRunning: { finalStateVia: "location" },
   }),
 );
 export type EmployeesDeleteInput = typeof EmployeesDeleteInput.Type;

--- a/packages/azure/src/services/workloads.ts
+++ b/packages/azure/src/services/workloads.ts
@@ -17,6 +17,7 @@ export const MonitorsCreateInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "PUT",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Workloads/monitors/{monitorName}",
     apiVersion: "2023-04-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type MonitorsCreateInput = typeof MonitorsCreateInput.Type;
@@ -66,6 +67,7 @@ export const MonitorsDeleteInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     method: "DELETE",
     path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Workloads/monitors/{monitorName}",
     apiVersion: "2023-04-01",
+    longRunning: { finalStateVia: "azure-async-operation" },
   }),
 );
 export type MonitorsDeleteInput = typeof MonitorsDeleteInput.Type;
@@ -449,6 +451,7 @@ export const ProviderInstancesCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Workloads/monitors/{monitorName}/providerInstances/{providerInstanceName}",
       apiVersion: "2023-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ProviderInstancesCreateInput =
@@ -504,6 +507,7 @@ export const ProviderInstancesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Workloads/monitors/{monitorName}/providerInstances/{providerInstanceName}",
       apiVersion: "2023-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type ProviderInstancesDeleteInput =
@@ -788,6 +792,7 @@ export const SAPApplicationServerInstancesCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Workloads/sapVirtualInstances/{sapVirtualInstanceName}/applicationInstances/{applicationInstanceName}",
       apiVersion: "2023-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SAPApplicationServerInstancesCreateInput =
@@ -840,6 +845,7 @@ export const SAPApplicationServerInstancesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Workloads/sapVirtualInstances/{sapVirtualInstanceName}/applicationInstances/{applicationInstanceName}",
       apiVersion: "2023-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SAPApplicationServerInstancesDeleteInput =
@@ -1050,6 +1056,7 @@ export const SapApplicationServerInstancesStartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Workloads/sapVirtualInstances/{sapVirtualInstanceName}/applicationInstances/{applicationInstanceName}/start",
       apiVersion: "2024-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SapApplicationServerInstancesStartInput =
@@ -1140,6 +1147,7 @@ export const SAPApplicationServerInstancesStartInstanceInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Workloads/sapVirtualInstances/{sapVirtualInstanceName}/applicationInstances/{applicationInstanceName}/start",
       apiVersion: "2023-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SAPApplicationServerInstancesStartInstanceInput =
@@ -1230,6 +1238,7 @@ export const SapApplicationServerInstancesStopInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Workloads/sapVirtualInstances/{sapVirtualInstanceName}/applicationInstances/{applicationInstanceName}/stop",
       apiVersion: "2024-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SapApplicationServerInstancesStopInput =
@@ -1321,6 +1330,7 @@ export const SAPApplicationServerInstancesStopInstanceInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Workloads/sapVirtualInstances/{sapVirtualInstanceName}/applicationInstances/{applicationInstanceName}/stop",
       apiVersion: "2023-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SAPApplicationServerInstancesStopInstanceInput =
@@ -1408,6 +1418,7 @@ export const SAPApplicationServerInstancesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Workloads/sapVirtualInstances/{sapVirtualInstanceName}/applicationInstances/{applicationInstanceName}",
       apiVersion: "2023-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SAPApplicationServerInstancesUpdateInput =
@@ -1627,6 +1638,7 @@ export const SAPCentralInstancesCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Workloads/sapVirtualInstances/{sapVirtualInstanceName}/centralInstances/{centralInstanceName}",
       apiVersion: "2023-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SAPCentralInstancesCreateInput =
@@ -1680,6 +1692,7 @@ export const SAPCentralInstancesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Workloads/sapVirtualInstances/{sapVirtualInstanceName}/centralInstances/{centralInstanceName}",
       apiVersion: "2023-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SAPCentralInstancesDeleteInput =
@@ -1890,6 +1903,7 @@ export const SAPCentralInstancesStartInstanceInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Workloads/sapVirtualInstances/{sapVirtualInstanceName}/centralInstances/{centralInstanceName}/start",
       apiVersion: "2023-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SAPCentralInstancesStartInstanceInput =
@@ -1977,6 +1991,7 @@ export const SAPCentralInstancesStopInstanceInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Workloads/sapVirtualInstances/{sapVirtualInstanceName}/centralInstances/{centralInstanceName}/stop",
       apiVersion: "2023-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SAPCentralInstancesStopInstanceInput =
@@ -2064,6 +2079,7 @@ export const SAPCentralInstancesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Workloads/sapVirtualInstances/{sapVirtualInstanceName}/centralInstances/{centralInstanceName}",
       apiVersion: "2023-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SAPCentralInstancesUpdateInput =
@@ -2240,6 +2256,7 @@ export const SapCentralServerInstancesCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Workloads/sapVirtualInstances/{sapVirtualInstanceName}/centralInstances/{centralInstanceName}",
       apiVersion: "2024-09-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SapCentralServerInstancesCreateInput =
@@ -2296,6 +2313,7 @@ export const SapCentralServerInstancesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Workloads/sapVirtualInstances/{sapVirtualInstanceName}/centralInstances/{centralInstanceName}",
       apiVersion: "2024-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SapCentralServerInstancesDeleteInput =
@@ -2460,6 +2478,7 @@ export const SapCentralServerInstancesStartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Workloads/sapVirtualInstances/{sapVirtualInstanceName}/centralInstances/{centralInstanceName}/start",
       apiVersion: "2024-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SapCentralServerInstancesStartInput =
@@ -2554,6 +2573,7 @@ export const SapCentralServerInstancesStopInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Workloads/sapVirtualInstances/{sapVirtualInstanceName}/centralInstances/{centralInstanceName}/stop",
       apiVersion: "2024-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SapCentralServerInstancesStopInput =
@@ -2772,6 +2792,7 @@ export const SAPDatabaseInstancesCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Workloads/sapVirtualInstances/{sapVirtualInstanceName}/databaseInstances/{databaseInstanceName}",
       apiVersion: "2023-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SAPDatabaseInstancesCreateInput =
@@ -2825,6 +2846,7 @@ export const SAPDatabaseInstancesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Workloads/sapVirtualInstances/{sapVirtualInstanceName}/databaseInstances/{databaseInstanceName}",
       apiVersion: "2023-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SAPDatabaseInstancesDeleteInput =
@@ -3038,6 +3060,7 @@ export const SapDatabaseInstancesStartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Workloads/sapVirtualInstances/{sapVirtualInstanceName}/databaseInstances/{databaseInstanceName}/start",
       apiVersion: "2024-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SapDatabaseInstancesStartInput =
@@ -3129,6 +3152,7 @@ export const SAPDatabaseInstancesStartInstanceInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Workloads/sapVirtualInstances/{sapVirtualInstanceName}/databaseInstances/{databaseInstanceName}/start",
       apiVersion: "2023-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SAPDatabaseInstancesStartInstanceInput =
@@ -3219,6 +3243,7 @@ export const SapDatabaseInstancesStopInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Workloads/sapVirtualInstances/{sapVirtualInstanceName}/databaseInstances/{databaseInstanceName}/stop",
       apiVersion: "2024-09-01",
+      longRunning: { finalStateVia: "location" },
     }),
   );
 export type SapDatabaseInstancesStopInput =
@@ -3311,6 +3336,7 @@ export const SAPDatabaseInstancesStopInstanceInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Workloads/sapVirtualInstances/{sapVirtualInstanceName}/databaseInstances/{databaseInstanceName}/stop",
       apiVersion: "2023-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SAPDatabaseInstancesStopInstanceInput =
@@ -3398,6 +3424,7 @@ export const SAPDatabaseInstancesUpdateInput =
       method: "PATCH",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Workloads/sapVirtualInstances/{sapVirtualInstanceName}/databaseInstances/{databaseInstanceName}",
       apiVersion: "2023-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SAPDatabaseInstancesUpdateInput =
@@ -4000,6 +4027,7 @@ export const SAPVirtualInstancesCreateInput =
       method: "PUT",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Workloads/sapVirtualInstances/{sapVirtualInstanceName}",
       apiVersion: "2023-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SAPVirtualInstancesCreateInput =
@@ -4053,6 +4081,7 @@ export const SAPVirtualInstancesDeleteInput =
       method: "DELETE",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Workloads/sapVirtualInstances/{sapVirtualInstanceName}",
       apiVersion: "2023-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SAPVirtualInstancesDeleteInput =
@@ -4570,6 +4599,7 @@ export const SAPVirtualInstancesStartInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Workloads/sapVirtualInstances/{sapVirtualInstanceName}/start",
       apiVersion: "2023-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SAPVirtualInstancesStartInput =
@@ -4658,6 +4688,7 @@ export const SAPVirtualInstancesStopInput =
       method: "POST",
       path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Workloads/sapVirtualInstances/{sapVirtualInstanceName}/stop",
       apiVersion: "2023-04-01",
+      longRunning: { finalStateVia: "azure-async-operation" },
     }),
   );
 export type SAPVirtualInstancesStopInput =

--- a/packages/azure/test/fake-http.ts
+++ b/packages/azure/test/fake-http.ts
@@ -1,0 +1,56 @@
+/**
+ * Recording, scripted fake `HttpClient` for account-free Azure client tests.
+ *
+ * `mockHttp(handler)` returns a `Layer` plus a `calls` log. The handler maps
+ * each outbound request (and its 0-based index) to a canned response, letting a
+ * test script a full ARM long-running-operation sequence
+ * (`202` ack → monitor poll → final GET) and then assert on the URLs/methods the
+ * poller actually hit.
+ */
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import type * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
+
+export interface FakeResponse {
+  status: number;
+  /** JSON-serialized into the response body. Omit for an empty body. */
+  body?: unknown;
+  headers?: Record<string, string>;
+}
+
+export interface RecordedCall {
+  method: string;
+  url: string;
+}
+
+export type FakeHandler = (
+  request: HttpClientRequest.HttpClientRequest,
+  index: number,
+) => FakeResponse;
+
+export const mockHttp = (
+  handler: FakeHandler,
+): { layer: Layer.Layer<HttpClient.HttpClient>; calls: RecordedCall[] } => {
+  const calls: RecordedCall[] = [];
+  const layer = Layer.succeed(
+    HttpClient.HttpClient,
+    HttpClient.make((request) => {
+      const index = calls.length;
+      calls.push({ method: request.method, url: request.url });
+      const res = handler(request, index);
+      const body = res.body === undefined ? null : JSON.stringify(res.body);
+      return Effect.succeed(
+        HttpClientResponse.fromWeb(
+          request,
+          new Response(body, {
+            status: res.status,
+            headers: { "content-type": "application/json", ...res.headers },
+          }),
+        ),
+      );
+    }),
+  );
+  return { layer, calls };
+};

--- a/packages/azure/test/lro-poller.test.ts
+++ b/packages/azure/test/lro-poller.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Azure ARM long-running-operation poller (layer 3).
+ *
+ * ARM mutating ops return a `201`/`202` ack and finish asynchronously. The
+ * poller drives the protocol to a terminal state and resolves the final
+ * resource, so callers see a provisioned resource — not the intermediate ack.
+ *
+ * These tests script the HTTP exchange (no network, no account) and assert both
+ * the resolved value and the exact poll sequence the poller performed.
+ */
+import { Effect, Fiber, Layer, Redacted } from "effect";
+import * as Schema from "effect/Schema";
+import { TestClock } from "effect/testing";
+import { describe, expect, it } from "vitest";
+import { API } from "../src/client.ts";
+import { Credentials } from "../src/credentials.ts";
+import { AzureLongRunningOperationFailed } from "../src/errors.ts";
+import * as T from "../src/traits.ts";
+import { mockHttp } from "./fake-http.ts";
+
+const STORAGE_PATH =
+  "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}";
+
+const ACCOUNT_INPUT = Schema.Struct({
+  subscriptionId: Schema.String.pipe(T.PathParam()),
+  resourceGroupName: Schema.String.pipe(T.PathParam()),
+  accountName: Schema.String.pipe(T.PathParam()),
+});
+
+const ACCOUNT_INPUT_VALUE = {
+  subscriptionId: "sub",
+  resourceGroupName: "rg",
+  accountName: "acct",
+};
+
+const BASE = "https://fake.test";
+
+const CredsLayer = Layer.succeed(
+  Credentials,
+  Effect.succeed({
+    bearerToken: Redacted.make("test-token"),
+    subscriptionId: "sub",
+    apiBaseUrl: BASE,
+  }),
+);
+
+const StorageAccount = Schema.Struct({
+  id: Schema.String,
+  properties: Schema.Struct({ provisioningState: Schema.String }),
+});
+
+/** An LRO operation over a storage account, varying only method/path/final-state. */
+const lroOp = (
+  method: "PUT" | "POST",
+  finalStateVia: string,
+  path: string = STORAGE_PATH,
+) =>
+  API.make(() => ({
+    inputSchema: ACCOUNT_INPUT.pipe(
+      T.Http({
+        method,
+        path,
+        apiVersion: "2021-09-01",
+        longRunning: { finalStateVia },
+      }),
+    ),
+    outputSchema: StorageAccount,
+  }));
+
+const StorageAccountsCreate = lroOp("PUT", "azure-async-operation");
+
+const ACCOUNT_PATH =
+  "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct";
+const OP_URL = `${BASE}/operations/op-123`;
+
+describe("ARM LRO poller", () => {
+  it("azure-async-operation: polls the monitor to Succeeded, then GETs the original URI", async () => {
+    const { layer, calls } = mockHttp((_req, i) => {
+      switch (i) {
+        case 0: // PUT ack
+          return {
+            status: 202,
+            body: {},
+            headers: { "azure-asyncoperation": OP_URL, "retry-after": "0" },
+          };
+        case 1: // monitor poll → terminal success
+          return { status: 200, body: { status: "Succeeded" } };
+        default: // final GET on the original resource URI
+          return {
+            status: 200,
+            body: {
+              id: ACCOUNT_PATH,
+              properties: { provisioningState: "Succeeded" },
+            },
+          };
+      }
+    });
+
+    const result = await Effect.runPromise(
+      StorageAccountsCreate({
+        subscriptionId: "sub",
+        resourceGroupName: "rg",
+        accountName: "acct",
+      }).pipe(Effect.provide(Layer.merge(CredsLayer, layer))),
+    );
+
+    expect(result.properties.provisioningState).toBe("Succeeded");
+    expect(result.id).toBe(ACCOUNT_PATH);
+
+    // Exact poll sequence: PUT → GET monitor → GET original URI.
+    expect(calls.map((c) => c.method)).toEqual(["PUT", "GET", "GET"]);
+    expect(calls[1].url).toBe(OP_URL);
+    expect(calls[2].url).toBe(BASE + ACCOUNT_PATH);
+  });
+
+  it("location: polls the Location URL until it stops returning 202, then resolves that body", async () => {
+    const LOC_URL = `${BASE}/locations/loc-456`;
+    const RunAction = lroOp("POST", "location", `${STORAGE_PATH}/failover`);
+
+    const { layer, calls } = mockHttp((_req, i) => {
+      switch (i) {
+        case 0: // POST ack with a Location monitor (no Azure-AsyncOperation)
+          return {
+            status: 202,
+            body: {},
+            headers: { location: LOC_URL, "retry-after": "0" },
+          };
+        case 1: // still running
+          return { status: 202, body: {}, headers: { "retry-after": "0" } };
+        default: // 200 → the Location response body IS the final resource
+          return {
+            status: 200,
+            body: {
+              id: ACCOUNT_PATH,
+              properties: { provisioningState: "Succeeded" },
+            },
+          };
+      }
+    });
+
+    const result = await Effect.runPromise(
+      RunAction({
+        subscriptionId: "sub",
+        resourceGroupName: "rg",
+        accountName: "acct",
+      }).pipe(Effect.provide(Layer.merge(CredsLayer, layer))),
+    );
+
+    expect(result.properties.provisioningState).toBe("Succeeded");
+    expect(result.id).toBe(ACCOUNT_PATH);
+
+    // POST → GET Location (202) → GET Location (200). No GET on the original URI.
+    expect(calls.map((c) => c.method)).toEqual(["POST", "GET", "GET"]);
+    expect(calls[1].url).toBe(LOC_URL);
+    expect(calls[2].url).toBe(LOC_URL);
+  });
+
+  it("original-uri: polls the monitor, then GETs the original URI (ignoring the monitor body)", async () => {
+    const Create = lroOp("PUT", "original-uri");
+
+    const { layer, calls } = mockHttp((_req, i) => {
+      switch (i) {
+        case 0: // PUT ack
+          return {
+            status: 202,
+            body: {},
+            headers: { "azure-asyncoperation": OP_URL, "retry-after": "0" },
+          };
+        case 1: // monitor → Succeeded, but the monitor body is NOT the resource
+          return { status: 200, body: { status: "Succeeded" } };
+        default: // original URI carries the provisioned resource
+          return {
+            status: 200,
+            body: {
+              id: ACCOUNT_PATH,
+              properties: { provisioningState: "Succeeded" },
+            },
+          };
+      }
+    });
+
+    const result = await Effect.runPromise(
+      Create(ACCOUNT_INPUT_VALUE).pipe(
+        Effect.provide(Layer.merge(CredsLayer, layer)),
+      ),
+    );
+
+    expect(result.id).toBe(ACCOUNT_PATH);
+    // PUT → GET monitor → GET original URI.
+    expect(calls.map((c) => c.method)).toEqual(["PUT", "GET", "GET"]);
+    expect(calls[2].url).toBe(BASE + ACCOUNT_PATH);
+  });
+
+  it("async-operation Failed → AzureLongRunningOperationFailed (no final GET)", async () => {
+    const Create = lroOp("PUT", "azure-async-operation");
+
+    const { layer, calls } = mockHttp((_req, i) =>
+      i === 0
+        ? {
+            status: 202,
+            body: {},
+            headers: { "azure-asyncoperation": OP_URL, "retry-after": "0" },
+          }
+        : {
+            status: 200,
+            body: {
+              status: "Failed",
+              error: { code: "DeploymentFailed", message: "boom" },
+            },
+          },
+    );
+
+    const error = await Effect.runPromise(
+      Create(ACCOUNT_INPUT_VALUE).pipe(
+        Effect.flip,
+        Effect.provide(Layer.merge(CredsLayer, layer)),
+      ),
+    );
+
+    expect(error).toBeInstanceOf(AzureLongRunningOperationFailed);
+    expect(error).toMatchObject({
+      _tag: "AzureLongRunningOperationFailed",
+      status: "Failed",
+      code: "DeploymentFailed",
+      message: "boom",
+    });
+    // PUT + one monitor poll only — it fails before any final GET.
+    expect(calls.map((c) => c.method)).toEqual(["PUT", "GET"]);
+  });
+
+  it("honors each poll's Retry-After before the next poll (TestClock)", async () => {
+    const Create = lroOp("PUT", "azure-async-operation");
+
+    const { layer, calls } = mockHttp((_req, i) => {
+      switch (i) {
+        case 0: // PUT ack
+          return {
+            status: 202,
+            body: {},
+            headers: { "azure-asyncoperation": OP_URL },
+          };
+        case 1: // still running, asks us to wait an hour before polling again
+          return {
+            status: 200,
+            body: { status: "InProgress" },
+            headers: { "retry-after": "3600" },
+          };
+        case 2: // terminal success
+          return { status: 200, body: { status: "Succeeded" } };
+        default: // final resource
+          return {
+            status: 200,
+            body: {
+              id: ACCOUNT_PATH,
+              properties: { provisioningState: "Succeeded" },
+            },
+          };
+      }
+    });
+
+    const program = Effect.gen(function* () {
+      const fiber = yield* Effect.forkChild(Create(ACCOUNT_INPUT_VALUE));
+
+      // The immediate PUT + first poll run; the poller is now sleeping on the
+      // 3600s Retry-After before the second poll.
+      yield* TestClock.adjust("1 second");
+      expect(calls.map((c) => c.method)).toEqual(["PUT", "GET"]);
+      expect(fiber.pollUnsafe()).toBeUndefined();
+
+      // Advancing less than the Retry-After does not release the next poll.
+      yield* TestClock.adjust("59 minutes");
+      expect(calls.length).toBe(2);
+      expect(fiber.pollUnsafe()).toBeUndefined();
+
+      // Crossing the hour boundary releases poll #2 (Succeeded) + the final GET.
+      yield* TestClock.adjust("1 minute");
+      const result = yield* Fiber.join(fiber);
+      expect(result.properties.provisioningState).toBe("Succeeded");
+      expect(calls.map((c) => c.method)).toEqual(["PUT", "GET", "GET", "GET"]);
+    });
+
+    await Effect.runPromise(
+      program.pipe(
+        Effect.scoped,
+        Effect.provide(Layer.mergeAll(CredsLayer, layer, TestClock.layer())),
+      ),
+    );
+  });
+});

--- a/packages/azure/test/storage-lro.test.ts
+++ b/packages/azure/test/storage-lro.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Live long-running-operation smoke test (non-profit account, free resources).
+ *
+ * Creating a storage account is an ARM long-running operation: the PUT returns a
+ * `202` ack and the resource provisions asynchronously. This exercises the full
+ * LRO path end-to-end against real ARM — if the poller works, the call resolves
+ * to a provisioned resource (`provisioningState: "Succeeded"`) instead of the
+ * intermediate ack. An empty `Standard_LRS` account is negligible at rest and is
+ * torn down immediately.
+ */
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+import {
+  ResourceGroupsCreateOrUpdate,
+  ResourceGroupsDelete,
+} from "../src/services/resources";
+import {
+  StorageAccountsCreate,
+  StorageAccountsDelete,
+} from "../src/services/storage";
+import { runEffect, testRunId } from "./setup";
+
+const LOCATION = "eastus";
+const subscriptionId = process.env.AZURE_SUBSCRIPTION_ID ?? "";
+
+describe("StorageAccounts (live LRO smoke test)", () => {
+  it("creates a Standard_LRS account; the poller resolves the provisioned resource (not the 202 ack)", async () => {
+    const resourceGroupName = `distilled-azure-lro-${testRunId}`;
+    const accountName = `distilledlro${testRunId}`;
+
+    const effect = Effect.gen(function* () {
+      yield* ResourceGroupsCreateOrUpdate({
+        resourceGroupName,
+        location: LOCATION,
+      });
+
+      const created = yield* StorageAccountsCreate({
+        subscriptionId,
+        resourceGroupName,
+        accountName,
+        sku: { name: "Standard_LRS" },
+        kind: "StorageV2",
+        location: LOCATION,
+      });
+
+      // The poller drove the `202` ack to completion and resolved the
+      // provisioned resource at the original URI (a `PUT` create) — so we get
+      // the real account, not the empty ack body.
+      //
+      // NOTE: `provisioningState` can't be asserted here yet — the generated
+      // `StorageAccountsCreateOutput` is `{ id, name, type, systemData }`
+      // because the response schema's `allOf` (which contributes `properties`,
+      // `sku`, `kind`) isn't flattened. That's a separate output-schema gap
+      // (PR #324 flattened `allOf` for request bodies, not responses).
+      expect(created.name).toBe(accountName);
+      expect(created.id).toContain(`/storageAccounts/${accountName}`);
+    }).pipe(
+      Effect.ensuring(
+        StorageAccountsDelete({
+          subscriptionId,
+          resourceGroupName,
+          accountName,
+        }).pipe(Effect.ignore),
+      ),
+      Effect.ensuring(
+        ResourceGroupsDelete({ resourceGroupName }).pipe(Effect.ignore),
+      ),
+    );
+
+    await runEffect(effect);
+  }, 240_000);
+});

--- a/packages/core/scripts/generate-openapi.ts
+++ b/packages/core/scripts/generate-openapi.ts
@@ -69,6 +69,11 @@ interface Operation2 {
   parameters?: Parameter2[];
   responses: Record<string, Response2>;
   deprecated?: boolean;
+  /** Azure ARM: marks the operation as a long-running (async) operation. */
+  "x-ms-long-running-operation"?: boolean;
+  "x-ms-long-running-operation-options"?: {
+    "final-state-via"?: string;
+  };
 }
 
 interface Parameter2 {
@@ -695,6 +700,23 @@ interface GeneratedOperation {
   exports: string[];
 }
 
+/**
+ * Extract the long-running-operation marker from a Swagger operation. Returns
+ * `undefined` for synchronous operations; otherwise `{ finalStateVia }` where
+ * `finalStateVia` comes from `x-ms-long-running-operation-options` (absent for
+ * ARM's default resolution). Emitted into the `T.Http` trait so the client
+ * polls the operation to completion.
+ */
+function getLongRunning(
+  operation: Operation2,
+): { finalStateVia?: string } | undefined {
+  if (operation["x-ms-long-running-operation"] !== true) return undefined;
+  return {
+    finalStateVia:
+      operation["x-ms-long-running-operation-options"]?.["final-state-via"],
+  };
+}
+
 function generateInputSchemaSwagger(
   operationId: string,
   method: string,
@@ -703,6 +725,7 @@ function generateInputSchemaSwagger(
   spec: Swagger2Spec,
   ctx?: SchemaGenerationContext,
   apiVersion?: string,
+  longRunning?: { finalStateVia?: string },
 ): { inputSchemaCode: string; inputSchemaName: string } {
   const inputSchemaName = `${toPascalCase(operationId)}Input`;
   const pathParams = parameters.filter((p) => p.in === "path");
@@ -808,6 +831,13 @@ function generateInputSchemaSwagger(
   ];
   if (apiVersion) {
     swaggerHttpTraitParts.push(`apiVersion: "${apiVersion}"`);
+  }
+  if (longRunning) {
+    swaggerHttpTraitParts.push(
+      longRunning.finalStateVia
+        ? `longRunning: { finalStateVia: "${longRunning.finalStateVia}" }`
+        : "longRunning: {}",
+    );
   }
   const inputSchemaCode =
     annotatePureExportConst(`export const ${inputSchemaName} = Schema.Struct({
@@ -1309,6 +1339,7 @@ export function generateFromOpenAPI(config: GeneratorConfig): void {
               swagger,
               sensitiveCtx,
               config.apiVersion,
+              getLongRunning(operation),
             );
 
           const responseSchema = getResponseSchema(

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -41,6 +41,7 @@ import * as HttpBody from "effect/unstable/http/HttpBody";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientError from "effect/unstable/http/HttpClientError";
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import type * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
 import { SingleShotGen } from "effect/Utils";
 import {
   extractItems,
@@ -176,6 +177,24 @@ export interface ClientConfig<Creds> {
     pathTemplate: string;
     parts: Traits.RequestParts;
   }) => Traits.RequestParts;
+
+  /**
+   * Optional hook for asynchronous long-running operations (LROs). When an
+   * operation's `Http` trait carries a `longRunning` marker and the server
+   * returns an async ack (`201`/`202`), the core client delegates to this hook
+   * instead of decoding the ack body. The hook drives the SDK-specific polling
+   * protocol (e.g. ARM's `Azure-AsyncOperation` / `Location` monitors) to a
+   * terminal state and returns the final raw resource body, which the core
+   * client then decodes through the operation's output schema.
+   */
+  pollLongRunning?: (args: {
+    response: HttpClientResponse.HttpClientResponse;
+    request: HttpClientRequest.HttpClientRequest;
+    client: HttpClient.HttpClient;
+    method: string;
+    authHeaders: Record<string, string>;
+    finalStateVia?: string;
+  }) => Effect.Effect<unknown, unknown>;
 
   /**
    * The SDK's `Retry` Context.Service tag. Each per-SDK client wires its
@@ -509,6 +528,17 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
 
       const spanName = `${method} ${httpTrait.path}`;
 
+      // Decode a response body through the output schema, wrapping schema
+      // failures in the SDK's ParseError. `errorBody` is what the ParseError
+      // reports — it defaults to the decoded body and differs only when the
+      // raw body is more useful than a transformed one.
+      const decodeOutput = (body: unknown, errorBody: unknown = body) =>
+        Schema.decodeUnknownEffect(outputSchema)(body).pipe(
+          Effect.catchTag("SchemaError", (cause) =>
+            Effect.fail(new config.ParseError({ body: errorBody, cause })),
+          ),
+        );
+
       const innerFn = (input: Input): Effect.Effect<any, any, any> =>
         Effect.gen(function* () {
           const credentials = yield* config.credentials;
@@ -694,15 +724,7 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
               const synthBody = {
                 [noFollowRedirect.locationField ?? "url"]: location,
               };
-              return yield* Schema.decodeUnknownEffect(outputSchema)(
-                synthBody,
-              ).pipe(
-                Effect.catchTag("SchemaError", (cause) =>
-                  Effect.fail(
-                    new config.ParseError({ body: synthBody, cause }),
-                  ),
-                ),
-              );
+              return yield* decodeOutput(synthBody);
             }
           }
 
@@ -734,6 +756,27 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
               opConfig.errors,
               response.headers,
             );
+          }
+
+          // Long-running operation: an async ack (`201`/`202`) for an op whose
+          // `Http` trait carries a `longRunning` marker. Hand the response to the
+          // SDK's poller, which drives the protocol to a terminal state and
+          // returns the final raw resource body; decode that through the output
+          // schema (skipping the immediate-response decode path below).
+          if (
+            httpTrait.longRunning &&
+            config.pollLongRunning &&
+            (response.status === 201 || response.status === 202)
+          ) {
+            const finalBody = yield* config.pollLongRunning({
+              response,
+              request,
+              client,
+              method,
+              authHeaders,
+              finalStateVia: httpTrait.longRunning.finalStateVia,
+            });
+            return yield* decodeOutput(finalBody);
           }
 
           // For void-returning operations (e.g. DELETE 204 No Content)
@@ -840,13 +883,7 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
             responseBody = (responseBody as Record<string, unknown>).items;
           }
 
-          return yield* Schema.decodeUnknownEffect(outputSchema)(
-            responseBody,
-          ).pipe(
-            Effect.catchTag("SchemaError", (cause) =>
-              Effect.fail(new config.ParseError({ body: rawBody, cause })),
-            ),
-          );
+          return yield* decodeOutput(responseBody, rawBody);
         });
 
       // Auto-retry every operation using the SDK's per-client `Retry`

--- a/packages/core/src/traits.ts
+++ b/packages/core/src/traits.ts
@@ -146,6 +146,17 @@ export interface HttpTrait {
    * and differs per resource provider.
    */
   apiVersion?: string;
+  /**
+   * Marks an operation as an asynchronous long-running operation (LRO). When
+   * set, an async ack response (`201`/`202`) is handed to the SDK client's
+   * `pollLongRunning` hook, which drives the operation to a terminal state
+   * before the result is decoded. `finalStateVia` is an opaque, SDK-defined
+   * hint for where the final resource lives once polling completes (e.g. Azure
+   * ARM's `x-ms-long-running-operation-options.final-state-via`).
+   */
+  longRunning?: {
+    finalStateVia?: string;
+  };
 }
 
 /**
@@ -686,7 +697,7 @@ const unwrapRedactedDeep = (value: unknown): unknown => {
  * RFC 6570 §3.2.3 reserved-expansion: encode everything outside the RFC 3986
  * unreserved (`A-Za-z0-9-._~`) and reserved (`:/?#[]@!$&'()*+,;=`) sets.
  */
-const RFC3986_NEEDS_ENCODING = /[^A-Za-z0-9\-._~:/?#\[\]@!$&'()*+,;=]/g;
+const RFC3986_NEEDS_ENCODING = /[^A-Za-z0-9\-._~:/?#[\]@!$&'()*+,;=]/g;
 const encodeReserved = (v: string): string =>
   v.replace(RFC3986_NEEDS_ENCODING, encodeURIComponent);
 

--- a/packages/core/test/fake-http.ts
+++ b/packages/core/test/fake-http.ts
@@ -1,0 +1,48 @@
+/**
+ * Scripted fake `HttpClient` layer for account-free client tests.
+ *
+ * Each test provides a handler that maps an outbound request to a canned
+ * response (status + JSON body + headers). This lets us exercise the full
+ * `makeAPI` request/response pipeline — including multi-step flows like
+ * long-running-operation polling — without any network or credentials.
+ */
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import type * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
+
+export interface FakeResponse {
+  status: number;
+  /** JSON-serialized into the response body. Omit for an empty body. */
+  body?: unknown;
+  headers?: Record<string, string>;
+}
+
+export type FakeHandler = (
+  request: HttpClientRequest.HttpClientRequest,
+) => FakeResponse;
+
+/** A `Layer` providing an `HttpClient` whose responses come from `handler`. */
+export const fakeHttpLayer = (
+  handler: FakeHandler,
+): Layer.Layer<HttpClient.HttpClient> =>
+  Layer.succeed(
+    HttpClient.HttpClient,
+    HttpClient.make((request) => {
+      const res = handler(request);
+      const body = res.body === undefined ? null : JSON.stringify(res.body);
+      return Effect.succeed(
+        HttpClientResponse.fromWeb(
+          request,
+          new Response(body, {
+            status: res.status,
+            headers: {
+              "content-type": "application/json",
+              ...res.headers,
+            },
+          }),
+        ),
+      );
+    }),
+  );

--- a/packages/core/test/lro-delegation.test.ts
+++ b/packages/core/test/lro-delegation.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Core long-running-operation gate (layers 1–2).
+ *
+ * The core client doesn't know ARM's polling protocol — that's the SDK's job.
+ * Core's responsibility is narrow: when an operation's `Http` trait carries a
+ * `longRunning` marker AND the response is an async ack (`201`/`202`), delegate
+ * to the SDK-provided `pollLongRunning` hook and decode *its* result through the
+ * output schema. Otherwise, decode the immediate response as usual.
+ *
+ * These tests prove that gate with a stub poller — no ARM semantics, no network.
+ */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
+import { describe, expect, it } from "vitest";
+import { makeAPI } from "../src/client.ts";
+import type { Policy } from "../src/retry.ts";
+import * as T from "../src/traits.ts";
+import { fakeHttpLayer } from "./fake-http.ts";
+
+interface TestConfig {
+  apiBaseUrl: string;
+}
+
+class TestCreds extends Context.Service<TestCreds, Effect.Effect<TestConfig>>()(
+  "TestCreds",
+) {}
+class TestRetry extends Context.Service<TestRetry, Policy>()("TestRetry") {}
+
+const CredsLayer = Layer.succeed(
+  TestCreds,
+  Effect.succeed({ apiBaseUrl: "https://fake.test" }),
+);
+
+class TestParseError {
+  readonly _tag = "TestParseError";
+  constructor(readonly props: { body: unknown; cause: unknown }) {}
+}
+
+const Resource = Schema.Struct({
+  id: Schema.String,
+  provisioningState: Schema.String,
+});
+
+/** Build a client whose `pollLongRunning` hook records whether it was called. */
+const makeClient = (
+  pollLongRunning: (args: {
+    finalStateVia?: string;
+  }) => Effect.Effect<unknown, unknown>,
+) =>
+  makeAPI<TestConfig>({
+    credentials: TestCreds,
+    getBaseUrl: (c) => c.apiBaseUrl,
+    getAuthHeaders: () => ({}),
+    matchError: (_status, body) => Effect.fail(body),
+    ParseError: TestParseError,
+    retry: TestRetry,
+    pollLongRunning,
+  });
+
+describe("core LRO gate", () => {
+  it("delegates to pollLongRunning on a 202 for a longRunning op, and decodes its result", async () => {
+    let polled = false;
+    const API = makeClient(({ finalStateVia }) => {
+      polled = true;
+      expect(finalStateVia).toBe("azure-async-operation");
+      return Effect.succeed({ id: "/final", provisioningState: "Succeeded" });
+    });
+
+    const Input = Schema.Struct({}).pipe(
+      T.Http({
+        method: "PUT",
+        path: "/r",
+        longRunning: { finalStateVia: "azure-async-operation" },
+      }),
+    );
+    const createResource = API.make(() => ({
+      inputSchema: Input,
+      outputSchema: Resource,
+    }));
+
+    // Server acks with 202 + an intermediate body that does NOT satisfy the
+    // output schema — so if core decoded it directly the test would fail.
+    const http = fakeHttpLayer(() => ({
+      status: 202,
+      body: { provisioningState: "Creating" },
+      headers: { "azure-asyncoperation": "https://fake.test/op/1" },
+    }));
+
+    const result = await Effect.runPromise(
+      createResource({}).pipe(Effect.provide(Layer.merge(CredsLayer, http))),
+    );
+
+    expect(polled).toBe(true);
+    expect(result).toEqual({ id: "/final", provisioningState: "Succeeded" });
+  });
+
+  it("does NOT poll a synchronous 200, even for a longRunning op", async () => {
+    let polled = false;
+    const API = makeClient(() => {
+      polled = true;
+      return Effect.succeed({
+        id: "/should-not-be-used",
+        provisioningState: "x",
+      });
+    });
+
+    const Input = Schema.Struct({}).pipe(
+      T.Http({
+        method: "PUT",
+        path: "/r",
+        longRunning: { finalStateVia: "azure-async-operation" },
+      }),
+    );
+    const createResource = API.make(() => ({
+      inputSchema: Input,
+      outputSchema: Resource,
+    }));
+
+    // The op completed synchronously: a 200 with the fully-provisioned body.
+    const http = fakeHttpLayer(() => ({
+      status: 200,
+      body: { id: "/sync", provisioningState: "Succeeded" },
+    }));
+
+    const result = await Effect.runPromise(
+      createResource({}).pipe(Effect.provide(Layer.merge(CredsLayer, http))),
+    );
+
+    expect(polled).toBe(false);
+    expect(result).toEqual({ id: "/sync", provisioningState: "Succeeded" });
+  });
+
+  it("does NOT poll a 202 for a non-longRunning op (no trait marker)", async () => {
+    let polled = false;
+    const API = makeClient(() => {
+      polled = true;
+      return Effect.succeed({ id: "/nope", provisioningState: "x" });
+    });
+
+    // No `longRunning` marker on the trait.
+    const Input = Schema.Struct({}).pipe(T.Http({ method: "PUT", path: "/r" }));
+    const createResource = API.make(() => ({
+      inputSchema: Input,
+      outputSchema: Resource,
+    }));
+
+    const http = fakeHttpLayer(() => ({
+      status: 202,
+      body: { id: "/accepted", provisioningState: "Accepted" },
+    }));
+
+    const result = await Effect.runPromise(
+      createResource({}).pipe(Effect.provide(Layer.merge(CredsLayer, http))),
+    );
+
+    expect(polled).toBe(false);
+    expect(result).toEqual({ id: "/accepted", provisioningState: "Accepted" });
+  });
+});


### PR DESCRIPTION
Adds Azure ARM long-running-operation (LRO) polling so async mutating operations resolve to the provisioned resource instead of the intermediate `202` ack.

ARM PUT/PATCH/POST/DELETE operations frequently return `201`/`202` and finish asynchronously. Before this change the SDK decoded that ack body and returned it — so e.g. `StorageAccountsCreate` handed back an un-provisioned resource. Now the operation polls to completion transparently.

```diff
- const account = yield* StorageAccountsCreate({ ... }) // resolved the 202 ack
+ const account = yield* StorageAccountsCreate({ ... }) // polls, resolves the provisioned resource
```

### How it works

Two layers, keeping `core` protocol-agnostic and the ARM specifics in `azure`:

- **core** gains an opaque `longRunning` marker on the `Http` trait and an optional `pollLongRunning` client hook. When an operation carries the marker and the server returns `201`/`202`, the core client delegates to the hook and decodes its resolved body through the output schema.
- **azure** implements the hook as an Effect-native ARM poller (`packages/azure/src/lro.ts`): `Effect.repeat` + `Schedule` honoring each response's `Retry-After`, a `Data.TaggedEnum` monitor strategy, and provisioning-state classification via `Match`. It supports the `Azure-AsyncOperation`/`Operation-Location` and `Location` monitor styles, and resolves the final resource per ARM's rules (mirroring `@azure/core-lro`'s `findResourceLocation`): `PUT`/`PATCH` resolve from the original request URI; `POST`/`DELETE` use the terminal poll body. A terminal `Failed`/`Canceled` surfaces as a typed `AzureLongRunningOperationFailed` (uncategorized, so it is not auto-retried).

### Generated change

The shared Swagger emitter now detects `x-ms-long-running-operation` (+ `-options.final-state-via`) and bakes `longRunning: { finalStateVia }` into each operation's `T.Http` trait — the same place `apiVersion` is injected. Regenerated all Azure services: **3783** long-running operations across 182 service files now poll to completion.

### Testing

- 8 account-free unit tests: the core gate (`packages/core/test/lro-delegation.test.ts`) and the ARM poller (`packages/azure/test/lro-poller.test.ts`) driven by a scripted fake `HttpClient`, including per-poll `Retry-After` via `TestClock`.
- A live smoke test (`packages/azure/test/storage-lro.test.ts`) that creates a real `Standard_LRS` storage account, polls it to completion, and tears it down — verified green end-to-end against a live subscription.
