### PR TITLE
fix(core,cloudflare): page-mode pagination loops forever on current-page echoes and dropped page params

### DIFF
--- a/packages/cloudflare/src/client/api.ts
+++ b/packages/cloudflare/src/client/api.ts
@@ -510,6 +510,24 @@ const paginatePageByItems: PaginationStrategy = (
               | undefined)
           : undefined;
 
+      // Guard against request schemas that don't carry the page param
+      // (schema encoding silently drops it, so every request returns
+      // page 1 and the empty-page terminator never fires). If the
+      // server reports a page other than the one we asked for, the
+      // param didn't take effect — stop without re-emitting the
+      // duplicate page.
+      const reportedPage = getPath(response, "resultInfo.page") as
+        | number
+        | null
+        | undefined;
+      if (
+        state.page !== startPage &&
+        typeof reportedPage === "number" &&
+        reportedPage !== state.page
+      ) {
+        return undefined;
+      }
+
       return [
         response,
         {

--- a/packages/core/src/pagination.ts
+++ b/packages/core/src/pagination.ts
@@ -120,9 +120,27 @@ export const paginatePageNumber = <
         | null
         | undefined;
 
+      // Some APIs report the CURRENT page at `outputToken` rather than
+      // the next one (e.g. Cloudflare's `result_info.page`). Taking that
+      // value as the next page re-requests the same page forever. Only
+      // accept an *advancing* page number; otherwise advance by one and
+      // terminate when a page comes back with no items (or the token is
+      // absent).
+      const items = pagination.items
+        ? (getPath(response, pagination.items) as
+            | readonly unknown[]
+            | undefined)
+        : undefined;
+
       const nextState: State = {
-        page: nextPage ?? state.page + 1,
-        done: nextPage === null || nextPage === undefined,
+        page:
+          typeof nextPage === "number" && nextPage > state.page
+            ? nextPage
+            : state.page + 1,
+        done:
+          nextPage === null ||
+          nextPage === undefined ||
+          (items !== undefined && items.length === 0),
       };
 
       return [response, nextState] as const;

--- a/packages/core/test/pagination.test.ts
+++ b/packages/core/test/pagination.test.ts
@@ -1,0 +1,83 @@
+import * as Effect from "effect/Effect";
+import * as Stream from "effect/Stream";
+import { describe, expect, test } from "vitest";
+import { paginatePageNumber } from "../src/pagination.ts";
+
+const trait = {
+  mode: "page",
+  inputToken: "page",
+  outputToken: "resultInfo.page",
+  items: "result",
+  pageSize: "perPage",
+} as const;
+
+describe("paginatePageNumber", () => {
+  test("terminates when the API echoes the CURRENT page (Cloudflare style)", async () => {
+    // Cloudflare's `result_info.page` reports the page that was just
+    // served, not the next one. Naively following it re-requests page 1
+    // forever.
+    let calls = 0;
+    const op = (input: { page?: number }) =>
+      Effect.sync(() => {
+        calls++;
+        if (calls > 10) throw new Error("infinite pagination loop");
+        const page = input.page ?? 1;
+        return {
+          result:
+            page === 1
+              ? [{ id: "a" }, { id: "b" }]
+              : page === 2
+                ? [{ id: "c" }]
+                : [],
+          resultInfo: { page, perPage: 2 },
+        };
+      });
+
+    const items = await Effect.runPromise(
+      Stream.runCollect(
+        paginatePageNumber(op as never, {}, trait).pipe(
+          Stream.flatMap((p) =>
+            Stream.fromIterable((p as { result: { id: string }[] }).result),
+          ),
+        ),
+      ),
+    );
+
+    expect(Array.from(items).map((i) => i.id)).toEqual(["a", "b", "c"]);
+    // pages 1 and 2 with items, page 3 empty → done
+    expect(calls).toBe(3);
+  });
+
+  test("still follows a genuine next-page token and stops when it is absent", async () => {
+    let calls = 0;
+    const op = (input: { page?: number }) =>
+      Effect.sync(() => {
+        calls++;
+        if (calls > 10) throw new Error("infinite pagination loop");
+        const page = input.page ?? 1;
+        return {
+          result: [{ id: `item-${page}` }],
+          // next-page semantics: points at the page AFTER this one,
+          // absent on the final page
+          resultInfo: { page: page < 3 ? page + 1 : undefined },
+        };
+      });
+
+    const items = await Effect.runPromise(
+      Stream.runCollect(
+        paginatePageNumber(op as never, {}, trait).pipe(
+          Stream.flatMap((p) =>
+            Stream.fromIterable((p as { result: { id: string }[] }).result),
+          ),
+        ),
+      ),
+    );
+
+    expect(Array.from(items).map((i) => i.id)).toEqual([
+      "item-1",
+      "item-2",
+      "item-3",
+    ]);
+    expect(calls).toBe(3);
+  });
+});


### PR DESCRIPTION
Two page-mode pagination loops that never terminate, found while debugging an `alchemy deploy` that wedged at 100% CPU inside `listAccessApplicationsForAccount.items()`.

**core `paginatePageNumber`**: the value at `outputToken` is taken as the *next* page number. APIs that report the *current* page there (Cloudflare's `result_info.page` style) make the unfold re-request the same page forever — `nextPage` is always present, so `done` never fires, and `page` never advances.

- only follow `outputToken` when it actually advances past the current page; otherwise advance by one
- terminate when the token is absent (unchanged) or when a page comes back with zero items at `pagination.items`
- regression tests for both semantics (current-page echo and genuine next-page token)

```diff
       const nextState: State = {
-        page: nextPage ?? state.page + 1,
-        done: nextPage === null || nextPage === undefined,
+        page:
+          typeof nextPage === "number" && nextPage > state.page
+            ? nextPage
+            : state.page + 1,
+        done:
+          nextPage === null ||
+          nextPage === undefined ||
+          (items !== undefined && items.length === 0),
       };
```

**cloudflare `paginatePageByItems`**: the generated zero-trust list request schemas (e.g. `ListAccessApplicationsForAccountRequest`) carry no `page`/`perPage` fields, so schema encoding silently drops the paginator's advancing `page` param — every request returns page 1 and the empty-page terminator never fires. Verified against the live API: the endpoint itself honors `page=2` (returns 0 items); the param just never reaches the URL. Now terminates (without re-emitting the duplicate page) when the server reports a page other than the one requested.

The schema gap itself (missing `page`/`per_page` query fields on the zero-trust list requests) is a generator issue worth fixing separately; this PR makes both paginators safe against that class of response regardless.
