### PR TITLE
fix(core): treat empty 2xx response bodies as no-content

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -779,6 +779,19 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
               () => response.text.pipe(Effect.map((text) => text as unknown)),
             ),
           );
+
+          // Some endpoints return a success status with an empty body instead
+          // of `204 No Content` — e.g. Cloudflare's Workers custom-domain
+          // DELETE (`DELETE /accounts/{id}/workers/domains/{id}`) replies
+          // `200` with no body. The generated output schema still declares a
+          // JSON envelope, so decoding the empty body fails — and a retrying
+          // caller treats that decode failure as a transient error and retries
+          // with backoff, hanging for a very long time. Treat an empty success
+          // body as "no content", mirroring the 204 handling above.
+          if (rawBody === "" || rawBody === undefined || rawBody === null) {
+            return outputSchema.ast._tag === "Unknown" ? "" : undefined;
+          }
+
           let responseBody = config.transformResponse
             ? config.transformResponse(rawBody)
             : rawBody;

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -780,15 +780,31 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
             ),
           );
 
-          // Some endpoints return a success status with an empty body instead
-          // of `204 No Content` — e.g. Cloudflare's Workers custom-domain
-          // DELETE (`DELETE /accounts/{id}/workers/domains/{id}`) replies
-          // `200` with no body. The generated output schema still declares a
-          // JSON envelope, so decoding the empty body fails — and a retrying
-          // caller treats that decode failure as a transient error and retries
-          // with backoff, hanging for a very long time. Treat an empty success
-          // body as "no content", mirroring the 204 handling above.
-          if (rawBody === "" || rawBody === undefined || rawBody === null) {
+          // Some DELETE endpoints return a success status with an empty body
+          // instead of `204 No Content`. Cloudflare's Workers custom-domain
+          // DELETE (`DELETE /accounts/{account_id}/workers/domains/{domain_id}`)
+          // is documented as returning `200` with a `{ errors, messages,
+          // success }` envelope, but the live endpoint replies `200` with no
+          // body. The generated output schema faithfully encodes the documented
+          // envelope, so decoding the empty body fails the declared schema, and
+          // a retrying caller (e.g. alchemy's default retry policy) classifies
+          // that decode failure as transient and retries with backoff, turning
+          // it into a multi-hour silent hang on every deploy/destroy that
+          // detaches a custom domain.
+          //
+          // Scope this to DELETE so an unexpectedly-empty GET/POST/PUT response
+          // still fails loudly and retries, rather than being silently swallowed
+          // as no-content. DELETE callers already receive `undefined` on the
+          // existing `204`/`Void` paths, and this gate only fires on an empty
+          // body, so DELETEs that do return a real envelope (e.g. DNS record
+          // delete -> `{ result: { id } }`) are unaffected.
+          //
+          // Docs (declared 200 + envelope):
+          //   https://developers.cloudflare.com/api/resources/workers/subresources/domains/methods/delete/
+          if (
+            method === "DELETE" &&
+            (rawBody === "" || rawBody === undefined || rawBody === null)
+          ) {
             return outputSchema.ast._tag === "Unknown" ? "" : undefined;
           }
 


### PR DESCRIPTION
Some Cloudflare endpoints return a success status with an empty body instead of `204 No Content`. The clearest case is the Workers custom-domain delete (`DELETE /accounts/{account_id}/workers/domains/{domain_id}`), which replies `200` with no body — but the OpenAPI-generated `DeleteDomainResponse` schema still declares a `{ errors, messages, success: true }` envelope (per the [documented response](https://developers.cloudflare.com/api/resources/workers/subresources/domains/methods/delete/)). The client only short-circuits the response decode for `204` and for `Void`-typed operations, so an empty `200` falls through to the JSON decode and fails to satisfy the declared schema.

On its own that is an instant, deterministic error — but a caller that retries on transient errors (for example alchemy's default retry policy) classifies the decode failure as retryable and retries it with exponential backoff, turning it into a multi-hour silent hang on every deploy or destroy that attaches or detaches a custom domain. A direct request to the same endpoint returns a clean `200` with an empty body, confirming the API is healthy and the gap is purely client-side.

### Fix

Treat an empty body on a successful **`DELETE`** response as no-content, mirroring the existing `204` handling, before attempting to decode it.

Scoped to `DELETE` (see review discussion) so that an unexpectedly-empty `GET`/`POST`/`PUT` still fails the decode and retries, rather than being silently swallowed — that is the transient-error case we do *not* want to mask. `DELETE` callers already receive `undefined` on the `204`/`Void` paths, so the behavior is consistent, and because the gate only fires on an empty body, `DELETE`s that legitimately return an envelope (e.g. DNS record delete -> `{ result: { id } }`) are unaffected.

```ts
if (
  method === "DELETE" &&
  (rawBody === "" || rawBody === undefined || rawBody === null)
) {
  return outputSchema.ast._tag === "Unknown" ? "" : undefined;
}
```

#### References

- Cloudflare API — Workers custom-domain delete (documents `200` + `{ errors, messages, success }`, while the live endpoint returns an empty `200`): https://developers.cloudflare.com/api/resources/workers/subresources/domains/methods/delete/