### PR TITLE
fix(cloudflare): allow missing edge preview tail url

### DIFF
--- a/packages/cloudflare/specs/cloudflare-patch/edge-preview.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare-patch/edge-preview.openapi.yml
@@ -185,7 +185,6 @@ components:
       type: object
       required:
         - preview_token
-        - tail_url
       properties:
         preview_token:
           type: string

--- a/packages/cloudflare/specs/cloudflare/workers.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/workers.openapi.yml
@@ -15180,7 +15180,6 @@ paths:
                     description: URL for tailing live logs from the preview worker.
                 required:
                   - preview_token
-                  - tail_url
       x-distilled-response-path: result
       x-distilled-errors:
         InvalidRoute:
@@ -23122,7 +23121,6 @@ paths:
                     description: URL for tailing live logs from the preview worker.
                 required:
                   - preview_token
-                  - tail_url
       x-distilled-response-path: result
       x-distilled-errors:
         InvalidRoute:

--- a/packages/cloudflare/src/services/workers.ts
+++ b/packages/cloudflare/src/services/workers.ts
@@ -15560,13 +15560,13 @@ export interface CreateScriptEdgePreviewResponse {
   /** Token to send as cf-workers-preview-token header when making requests to the preview host. */
   previewToken: string;
   /** URL for tailing live logs from the preview worker. */
-  tailUrl: string;
+  tailUrl?: string;
 }
 
 export const CreateScriptEdgePreviewResponse =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     previewToken: Schema.String,
-    tailUrl: Schema.String,
+    tailUrl: Schema.optional(Schema.String),
   })
     .pipe(
       Schema.encodeKeys({ previewToken: "preview_token", tailUrl: "tail_url" }),
@@ -22606,13 +22606,13 @@ export interface CreateServiceEdgePreviewResponse {
   /** Token to send as cf-workers-preview-token header when making requests to the preview host. */
   previewToken: string;
   /** URL for tailing live logs from the preview worker. */
-  tailUrl: string;
+  tailUrl?: string;
 }
 
 export const CreateServiceEdgePreviewResponse =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     previewToken: Schema.String,
-    tailUrl: Schema.String,
+    tailUrl: Schema.optional(Schema.String),
   })
     .pipe(
       Schema.encodeKeys({ previewToken: "preview_token", tailUrl: "tail_url" }),

--- a/packages/cloudflare/test/workers.test.ts
+++ b/packages/cloudflare/test/workers.test.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
 import { test, getAccountId, getZoneId, testRunId } from "./test.ts";
 import * as Workers from "~/services/workers";
 import * as Queues from "~/services/queues";
@@ -2386,6 +2387,24 @@ describe("Workers", () => {
   });
 
   describe("createScriptEdgePreview", () => {
+    it("decodes preview responses when tail_url is omitted", () => {
+      expect(
+        Schema.decodeUnknownSync(Workers.CreateScriptEdgePreviewResponse)({
+          preview_token: "preview-token",
+        }),
+      ).toEqual({
+        previewToken: "preview-token",
+      });
+
+      expect(
+        Schema.decodeUnknownSync(Workers.CreateServiceEdgePreviewResponse)({
+          preview_token: "preview-token",
+        }),
+      ).toEqual({
+        previewToken: "preview-token",
+      });
+    });
+
     test("happy path - uploads worker and gets preview token", () =>
       withScript(scriptName("edge-preview"), (name) =>
         Effect.gen(function* () {


### PR DESCRIPTION
Cloudflare edge preview upload responses can omit `tail_url` while still returning a usable `preview_token`. This updates the Cloudflare edge-preview patch spec so `tail_url` is optional, regenerates the emitted workers spec and TypeScript schemas, and adds a decode regression test for preview responses without that field.

### Testing

- `bun --filter '@distilled.cloud/core' build`
- `bun --filter '@distilled.cloud/cloudflare' check`
- `bunx vitest run test/workers.test.ts -t "decodes preview responses when tail_url is omitted"`
