### PR TITLE
feat(stripe): add per-call request options

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -70,12 +70,12 @@ const distilledDebugConfig: Effect.Effect<boolean> = Config.string(
  * 1. Direct call: `yield* operation(input)` - returns Effect with requirements
  * 2. Yield first: `const fn = yield* operation` - captures services, returns requirement-free function
  */
-export type OperationMethod<I, A, E, R> = Effect.Effect<
-  (input: I) => Effect.Effect<A, E, never>,
+export type OperationMethod<I, A, E, R, RequestOptions = never> = Effect.Effect<
+  (input: I, requestOptions?: RequestOptions) => Effect.Effect<A, E, never>,
   never,
   R
 > &
-  ((input: I) => Effect.Effect<A, E, R>);
+  ((input: I, requestOptions?: RequestOptions) => Effect.Effect<A, E, R>);
 
 /**
  * A paginated operation that additionally has `.pages()` and `.items()` methods.
@@ -100,14 +100,18 @@ type PaginatedItem<A> =
             ? Item
             : unknown;
 
-export type PaginatedOperationMethod<I, A, E, R> = OperationMethod<
+export type PaginatedOperationMethod<
   I,
   A,
   E,
-  R
-> & {
-  pages: (input: I) => Stream.Stream<A, E, R>;
-  items: (input: I) => Stream.Stream<PaginatedItem<A>, E, R>;
+  R,
+  RequestOptions = never,
+> = OperationMethod<I, A, E, R, RequestOptions> & {
+  pages: (input: I, requestOptions?: RequestOptions) => Stream.Stream<A, E, R>;
+  items: (
+    input: I,
+    requestOptions?: RequestOptions,
+  ) => Stream.Stream<PaginatedItem<A>, E, R>;
 };
 
 type ResolvedClientCredentials<Creds> =
@@ -124,7 +128,7 @@ const isEffectLike = (value: unknown): value is Effect.Effect<unknown> =>
  * Configuration for the API client factory.
  * SDKs provide this to customize how errors are matched and credentials are applied.
  */
-export interface ClientConfig<Creds> {
+export interface ClientConfig<Creds, RequestOptions = never> {
   /** The credentials service tag */
   credentials: Context.ServiceClass<any, any, Effect.Effect<Creds>>;
 
@@ -134,6 +138,22 @@ export interface ClientConfig<Creds> {
   /** Get authorization header(s) from credentials */
   getAuthHeaders: (
     creds: ResolvedClientCredentials<Creds>,
+  ) => Record<string, string>;
+
+  /**
+   * Map provider-specific per-call request options into transport headers.
+   * Request options are intentionally separate from the operation input and
+   * are never passed through the body/query/path schema encoder.
+   */
+  getRequestHeaders?: (
+    requestOptions: RequestOptions | undefined,
+    context: {
+      input: Record<string, unknown>;
+      method: string;
+      pathTemplate: string;
+      parts: Traits.RequestParts;
+      credentials: ResolvedClientCredentials<Creds>;
+    },
   ) => Record<string, string>;
 
   /** Match an error response body to a typed error.
@@ -175,6 +195,7 @@ export interface ClientConfig<Creds> {
     method: string;
     pathTemplate: string;
     parts: Traits.RequestParts;
+    requestOptions: RequestOptions | undefined;
   }) => Traits.RequestParts;
 
   /**
@@ -486,7 +507,9 @@ function setBinaryBody(
  * });
  * ```
  */
-export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
+export const makeAPI = <Creds, RequestOptions = never>(
+  config: ClientConfig<Creds, RequestOptions>,
+) => {
   type _ClientErrors = HttpClientError.HttpClientError | HttpBody.HttpBodyError;
   type ResolvedCreds = ResolvedClientCredentials<Creds>;
 
@@ -501,7 +524,8 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
       Schema.Schema.Type<I>,
       Schema.Schema.Type<O>,
       InstanceType<E[number]>,
-      Creds
+      Creds,
+      RequestOptions
     > => {
       type Input = Schema.Schema.Type<I>;
 
@@ -558,7 +582,10 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
         return prepared;
       };
 
-      const innerFn = (input: Input): Effect.Effect<any, any, any> =>
+      const innerFn = (
+        input: Input,
+        requestOptions?: RequestOptions,
+      ): Effect.Effect<any, any, any> =>
         Effect.gen(function* () {
           const {
             opConfig,
@@ -617,6 +644,7 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
               method,
               pathTemplate: httpTrait.path,
               parts,
+              requestOptions,
             });
           }
 
@@ -634,11 +662,21 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
             };
           }
 
+          const requestHeaders =
+            config.getRequestHeaders?.(requestOptions, {
+              input: input as Record<string, unknown>,
+              method,
+              pathTemplate: httpTrait.path,
+              parts,
+              credentials: creds as ResolvedCreds,
+            }) ?? {};
+
           let request = HttpClientRequest.make(method)(
             baseUrl + parts.path,
           ).pipe(
             HttpClientRequest.setHeaders(authHeaders),
             HttpClientRequest.setHeaders(parts.headers),
+            HttpClientRequest.setHeaders(requestHeaders),
             HttpClientRequest.setHeader("Accept", "application/json"),
           );
 
@@ -919,7 +957,10 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
       // install a blanket policy at the layer level instead of wrapping
       // every call site with `Effect.retry(...)`.
       const retryTag = config.retry;
-      const fn = (input: Input): Effect.Effect<any, any, any> => {
+      const fn = (
+        input: Input,
+        requestOptions?: RequestOptions,
+      ): Effect.Effect<any, any, any> => {
         const { spanName, method, httpTrait } = prepare();
         const withRetry = Effect.gen(function* () {
           const lastError = yield* Ref.make<unknown>(undefined);
@@ -931,7 +972,7 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
           );
 
           return yield* pipe(
-            innerFn(input),
+            innerFn(input, requestOptions),
             Effect.tapError((error) => Ref.set(lastError, error)),
             policy.while
               ? (eff) =>
@@ -968,8 +1009,8 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
         asEffect() {
           return Effect.map(
             Effect.context(),
-            (context) => (input: Input) =>
-              Effect.provideContext(fn(input), context),
+            (context) => (input: Input, requestOptions?: RequestOptions) =>
+              Effect.provideContext(fn(input, requestOptions), context),
           );
         },
       };
@@ -988,7 +1029,8 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
       Schema.Schema.Type<I>,
       Schema.Schema.Type<O>,
       InstanceType<E[number]>,
-      Creds
+      Creds,
+      RequestOptions
     > => {
       const opConfig = configFn();
       const pagination = opConfig.pagination!;
@@ -1005,14 +1047,19 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
       const paginate = paginateFn ?? paginateWithDefaults;
 
       // Stream all pages
-      const pagesFn = (input: Omit<Input, string>) =>
-        paginate(baseFn as any, input, pagination);
+      const pagesFn = (
+        input: Omit<Input, string>,
+        requestOptions?: RequestOptions,
+      ) => paginate(baseFn as any, input, pagination, requestOptions);
 
       // Stream individual items
-      const itemsFn = (input: Omit<Input, string>) =>
+      const itemsFn = (
+        input: Omit<Input, string>,
+        requestOptions?: RequestOptions,
+      ) =>
         pagination.items
-          ? extractItems(pagesFn(input), pagination.items)
-          : pagesFn(input);
+          ? extractItems(pagesFn(input, requestOptions), pagination.items)
+          : pagesFn(input, requestOptions);
 
       const result = baseFn as typeof baseFn & {
         pages: typeof pagesFn;

--- a/packages/core/src/pagination.ts
+++ b/packages/core/src/pagination.ts
@@ -50,10 +50,15 @@ export type PaginationStrategy = <
   Output,
   E,
   R,
+  RequestOptions = never,
 >(
-  operation: (input: Input) => Effect.Effect<Output, E, R>,
+  operation: (
+    input: Input,
+    requestOptions?: RequestOptions,
+  ) => Effect.Effect<Output, E, R>,
   input: Input,
   pagination: PaginatedTrait,
+  requestOptions?: RequestOptions,
 ) => Stream.Stream<Output, E, R>;
 
 const missingPaginationConfig = (kind: string) => Stream.die(new Error(kind));
@@ -61,9 +66,16 @@ const missingPaginationConfig = (kind: string) => Stream.die(new Error(kind));
 /**
  * Creates a stream for single-shot list endpoints that still expose the paginated API surface.
  */
-export const paginateSingle: PaginationStrategy = (operation, input) =>
+export const paginateSingle: PaginationStrategy = (
+  operation,
+  input,
+  _pagination,
+  requestOptions,
+) =>
   Stream.make(input).pipe(
-    Stream.mapEffect((requestPayload) => operation(requestPayload)),
+    Stream.mapEffect((requestPayload) =>
+      operation(requestPayload, requestOptions),
+    ),
   );
 
 // ============================================================================
@@ -83,10 +95,15 @@ export const paginatePageNumber = <
   Output,
   E,
   R,
+  RequestOptions = never,
 >(
-  operation: (input: Input) => Effect.Effect<Output, E, R>,
+  operation: (
+    input: Input,
+    requestOptions?: RequestOptions,
+  ) => Effect.Effect<Output, E, R>,
   input: Omit<Input, string>,
   pagination: PaginatedTrait,
+  requestOptions?: RequestOptions,
 ): Stream.Stream<Output, E, R> => {
   const inputToken = pagination.inputToken;
   const outputToken = pagination.outputToken;
@@ -113,7 +130,7 @@ export const paginatePageNumber = <
         [inputToken]: state.page,
       } as Input;
 
-      const response = yield* operation(requestPayload);
+      const response = yield* operation(requestPayload, requestOptions);
 
       const nextPage = getPath(response, outputToken) as
         | number
@@ -166,10 +183,15 @@ export const paginateCursor = <
   Output,
   E,
   R,
+  RequestOptions = never,
 >(
-  operation: (input: Input) => Effect.Effect<Output, E, R>,
+  operation: (
+    input: Input,
+    requestOptions?: RequestOptions,
+  ) => Effect.Effect<Output, E, R>,
   input: Omit<Input, string>,
   pagination: PaginatedTrait,
+  requestOptions?: RequestOptions,
 ): Stream.Stream<Output, E, R> => {
   const inputToken = pagination.inputToken;
   const outputToken = pagination.outputToken;
@@ -196,7 +218,7 @@ export const paginateCursor = <
         ...(state.cursor ? { [inputToken]: state.cursor } : {}),
       } as Input;
 
-      const response = yield* operation(requestPayload);
+      const response = yield* operation(requestPayload, requestOptions);
 
       const nextCursor = getPath(response, outputToken) as
         | string
@@ -231,10 +253,15 @@ export const paginateToken = <
   Output,
   E,
   R,
+  RequestOptions = never,
 >(
-  operation: (input: Input) => Effect.Effect<Output, E, R>,
+  operation: (
+    input: Input,
+    requestOptions?: RequestOptions,
+  ) => Effect.Effect<Output, E, R>,
   input: Input,
   pagination: PaginatedTrait,
+  requestOptions?: RequestOptions,
 ): Stream.Stream<Output, E, R> => {
   const inputToken = pagination.inputToken;
   const outputToken = pagination.outputToken;
@@ -258,7 +285,10 @@ export const paginateToken = <
           ? { ...input, [inputToken]: state.token }
           : input;
 
-      const response = yield* operation(requestPayload as Input);
+      const response = yield* operation(
+        requestPayload as Input,
+        requestOptions,
+      );
 
       const nextToken = getPath(response, outputToken);
 
@@ -280,21 +310,22 @@ export const paginateWithDefaults: PaginationStrategy = (
   operation,
   input,
   pagination,
+  requestOptions,
 ) => {
   const mode = pagination.mode ?? "token";
 
   switch (mode) {
     case "page":
-      return paginatePageNumber(operation, input, pagination);
+      return paginatePageNumber(operation, input, pagination, requestOptions);
     case "cursor":
-      return paginateCursor(operation, input, pagination);
+      return paginateCursor(operation, input, pagination, requestOptions);
     case "single":
       return missingPaginationConfig(
         "Single-page pagination requires a provider-specific pagination strategy",
       );
     case "token":
     default:
-      return paginateToken(operation, input, pagination);
+      return paginateToken(operation, input, pagination, requestOptions);
   }
 };
 

--- a/packages/core/test/pagination.test.ts
+++ b/packages/core/test/pagination.test.ts
@@ -1,7 +1,7 @@
 import * as Effect from "effect/Effect";
 import * as Stream from "effect/Stream";
 import { describe, expect, test } from "vitest";
-import { paginatePageNumber } from "../src/pagination.ts";
+import { paginatePageNumber, paginateWithDefaults } from "../src/pagination.ts";
 
 const trait = {
   mode: "page",
@@ -79,5 +79,45 @@ describe("paginatePageNumber", () => {
       "item-3",
     ]);
     expect(calls).toBe(3);
+  });
+
+  test("forwards request options to each page request", async () => {
+    const options = { requestId: "req_123" };
+    const seenOptions: Array<typeof options | undefined> = [];
+    const op = (input: { page?: number }, requestOptions?: typeof options) =>
+      Effect.sync(() => {
+        seenOptions.push(requestOptions);
+        const page = input.page ?? 1;
+        return {
+          result: page === 1 ? [{ id: "a" }] : [],
+          resultInfo: { page, perPage: 1 },
+        };
+      });
+
+    await Effect.runPromise(
+      Stream.runCollect(paginatePageNumber(op, {}, trait, options)),
+    );
+
+    expect(seenOptions).toEqual([options, options]);
+  });
+
+  test("default pagination forwards request options", async () => {
+    const options = { requestId: "req_456" };
+    const seenOptions: Array<typeof options | undefined> = [];
+    const op = (input: { page?: number }, requestOptions?: typeof options) =>
+      Effect.sync(() => {
+        seenOptions.push(requestOptions);
+        const page = input.page ?? 1;
+        return {
+          result: page === 1 ? [{ id: "a" }] : [],
+          resultInfo: { page, perPage: 1 },
+        };
+      });
+
+    await Effect.runPromise(
+      Stream.runCollect(paginateWithDefaults(op, {}, trait, options)),
+    );
+
+    expect(seenOptions).toEqual([options, options]);
   });
 });

--- a/packages/stripe/src/client.ts
+++ b/packages/stripe/src/client.ts
@@ -25,6 +25,40 @@ import { Credentials } from "./credentials.ts";
 // Re-export for convenience
 export { UnknownStripeError } from "./errors.ts";
 
+type StripeConnectRequestOptions =
+  | {
+      readonly stripeAccount?: string | undefined;
+      readonly stripeContext?: never;
+    }
+  | {
+      readonly stripeAccount?: never;
+      readonly stripeContext?: string | undefined;
+    };
+
+export type StripeRequestOptions = {
+  readonly idempotencyKey?: string | undefined;
+  readonly apiVersion?: string | undefined;
+} & StripeConnectRequestOptions;
+
+const stripeRequestHeaders = (
+  options: StripeRequestOptions | undefined,
+): Record<string, string> => {
+  const headers: Record<string, string> = {};
+  if (options?.idempotencyKey !== undefined) {
+    headers["Idempotency-Key"] = options.idempotencyKey;
+  }
+  if (options?.stripeAccount !== undefined) {
+    headers["Stripe-Account"] = options.stripeAccount;
+  }
+  if (options?.stripeContext !== undefined) {
+    headers["Stripe-Context"] = options.stripeContext;
+  }
+  if (options?.apiVersion !== undefined) {
+    headers["Stripe-Version"] = options.apiVersion;
+  }
+  return headers;
+};
+
 // Stripe API Error Response Schema
 // Stripe wraps errors in { error: { type, code, message, ... } }
 const StripeErrorInner = Schema.Struct({
@@ -160,12 +194,13 @@ const matchError = (
 /**
  * Stripe API client.
  */
-export const API = makeAPI<Credentials>({
+export const API = makeAPI<Credentials, StripeRequestOptions>({
   credentials: Credentials as any,
   getBaseUrl: (creds: any) => creds.apiBaseUrl,
   getAuthHeaders: (creds: any) => ({
     Authorization: `Bearer ${Redacted.value(creds.apiKey)}`,
   }),
+  getRequestHeaders: stripeRequestHeaders,
   matchError,
   ParseError: StripeParseError as any,
   retry: Retry as any,

--- a/packages/stripe/tests/request-options.test.ts
+++ b/packages/stripe/tests/request-options.test.ts
@@ -1,0 +1,156 @@
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Redacted from "effect/Redacted";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
+import { describe, expect, it } from "vitest";
+import { Credentials } from "../src/credentials.ts";
+import { PostCustomers } from "../src/operations/PostCustomers.ts";
+
+const fakeCredentials = Layer.succeed(
+  Credentials,
+  Effect.succeed({
+    apiKey: Redacted.make("sk_test_fake"),
+    apiBaseUrl: "https://api.stripe.test",
+  }),
+);
+
+const customerResponse = {
+  created: 1_700_000_000,
+  default_source: null,
+  description: null,
+  email: null,
+  id: "cus_test",
+  livemode: false,
+  object: "customer",
+  shipping: null,
+};
+
+interface CapturedRequest {
+  request?: HttpClientRequest.HttpClientRequest;
+}
+
+const captureRequest = (
+  captured: CapturedRequest,
+): Layer.Layer<HttpClient.HttpClient> =>
+  Layer.succeed(
+    HttpClient.HttpClient,
+    HttpClient.make((request) => {
+      captured.request = request;
+      return Effect.succeed(
+        HttpClientResponse.fromWeb(
+          request,
+          new Response(JSON.stringify(customerResponse), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        ),
+      );
+    }),
+  );
+
+const runWithMockStripe = <A, E>(
+  effect: Effect.Effect<A, E, Credentials | HttpClient.HttpClient>,
+  captured: CapturedRequest,
+) =>
+  Effect.runPromise(
+    effect.pipe(
+      Effect.provide(captureRequest(captured)),
+      Effect.provide(fakeCredentials),
+    ) as Effect.Effect<A, E, never>,
+  );
+
+const textBody = (request: HttpClientRequest.HttpClientRequest): string => {
+  const body = request.body;
+  if (body._tag !== "Uint8Array") {
+    throw new Error(`Expected Uint8Array body, received ${body._tag}`);
+  }
+  return new TextDecoder().decode(body.body);
+};
+
+const header = (
+  request: HttpClientRequest.HttpClientRequest,
+  name: string,
+): string | undefined => request.headers[name.toLowerCase()];
+
+describe("Stripe request options", () => {
+  it("preserves existing one-argument operation calls", async () => {
+    const captured: CapturedRequest = {};
+
+    await runWithMockStripe(
+      PostCustomers({
+        email: "one-arg@example.com",
+      }),
+      captured,
+    );
+
+    expect(captured.request?.method).toBe("POST");
+    expect(captured.request?.url).toBe("https://api.stripe.test/v1/customers");
+    expect(header(captured.request!, "Authorization")).toBe(
+      "Bearer sk_test_fake",
+    );
+    expect(header(captured.request!, "Idempotency-Key")).toBeUndefined();
+    expect(textBody(captured.request!)).toBe("email=one-arg%40example.com");
+  });
+
+  it("maps per-call Stripe request options to headers outside the form body", async () => {
+    const captured: CapturedRequest = {};
+
+    await runWithMockStripe(
+      PostCustomers(
+        {
+          email: "request-options@example.com",
+          metadata: { order: "order_123" },
+        },
+        {
+          idempotencyKey: "idem_123",
+          stripeAccount: "acct_123",
+          apiVersion: "2025-01-27.acacia",
+        },
+      ),
+      captured,
+    );
+
+    expect(header(captured.request!, "Idempotency-Key")).toBe("idem_123");
+    expect(header(captured.request!, "Stripe-Account")).toBe("acct_123");
+    expect(header(captured.request!, "Stripe-Context")).toBeUndefined();
+    expect(header(captured.request!, "Stripe-Version")).toBe(
+      "2025-01-27.acacia",
+    );
+
+    const body = textBody(captured.request!);
+    expect(body).toContain("email=request-options%40example.com");
+    expect(body).toContain("metadata%5Border%5D=order_123");
+    expect(body).not.toContain("idempotencyKey");
+    expect(body).not.toContain("stripeAccount");
+    expect(body).not.toContain("stripeContext");
+    expect(body).not.toContain("apiVersion");
+    expect(body).not.toContain("Idempotency-Key");
+    expect(body).not.toContain("Stripe-Account");
+    expect(body).not.toContain("Stripe-Context");
+    expect(body).not.toContain("Stripe-Version");
+  });
+
+  it("maps stripeContext separately from stripeAccount", async () => {
+    const captured: CapturedRequest = {};
+
+    await runWithMockStripe(
+      PostCustomers(
+        {
+          email: "stripe-context@example.com",
+        },
+        {
+          stripeContext: "ctx_123",
+        },
+      ),
+      captured,
+    );
+
+    expect(header(captured.request!, "Stripe-Account")).toBeUndefined();
+    expect(header(captured.request!, "Stripe-Context")).toBe("ctx_123");
+    expect(textBody(captured.request!)).toBe(
+      "email=stripe-context%40example.com",
+    );
+  });
+});


### PR DESCRIPTION
Add a typed per-call request options path for generated REST operations, then use it in Stripe to send request metadata as headers instead of endpoint params.

Stripe supports `Idempotency-Key` as a real HTTP header for POST requests, but Stripe's OpenAPI operation schemas do not model it as an operation/header parameter. Generated SDKs therefore omit it if they only emit endpoint body/query/path input from the spec. Official Stripe SDKs treat these values as request options separate from endpoint params, and Distilled's automatic retry behavior makes first-class idempotency support important for Stripe mutations.

This keeps request metadata separate from body/query/path input:

```ts
yield* PostCustomers(
  { email: "customer@example.com" },
  { idempotencyKey: "idem_123", apiVersion: "2025-01-27.acacia" },
);
```

### What changed

- Add an optional second `requestOptions` argument to core generated operation methods while preserving existing `operation(input)` calls.
- Thread request options through yielded operations and paginated `.pages()` / `.items()` helpers.
- Add a provider hook for mapping request options to transport headers without merging them into encoded request parts.
- Add Stripe `StripeRequestOptions` with `idempotencyKey`, `stripeAccount`, `stripeContext`, and `apiVersion`.
- Map those to `Idempotency-Key`, `Stripe-Account`, `Stripe-Context`, and `Stripe-Version`.
- Type `stripeAccount` and `stripeContext` as mutually exclusive request options, matching stripe-node's public request option behavior.

### Stripe option decisions

- `apiVersion` follows stripe-node's request option naming and maps to `Stripe-Version`.
- `stripeContext` is included because Stripe documents the `Stripe-Context` header for related account context.
- Per-call `apiKey` is deferred because Distilled already models authentication through provider credentials, and adding a second auth path needs a broader credentials design.
- `maxNetworkRetries` is deferred because Distilled retry behavior is modeled through Effect retry policies, and this PR does not add per-call retry overrides.

### Validation

- `bunx vitest run test/pagination.test.ts` from `packages/core`
- `bun --filter '@distilled.cloud/stripe' test -- request-options.test.ts`
- `bun --filter '@distilled.cloud/core' typecheck`
- `bun --filter '@distilled.cloud/stripe' typecheck`
- `bun --filter '@distilled.cloud/core' build`
- `bun --filter '@distilled.cloud/stripe' build`
- `bunx oxfmt --check packages/core/src/pagination.ts packages/core/test/pagination.test.ts packages/stripe/src/client.ts packages/stripe/tests/request-options.test.ts`
- `git diff --check upstream/main...HEAD`

During commit, the repository pre-commit formatter also completed successfully across packages. One earlier broad `bun --filter '@distilled.cloud/core' test -- request-options.test.ts` attempt ran the full core suite instead of a focused file and hit two existing env-sensitive failures in `test/server-retry-hint-cap.test.ts`; the focused pagination test and package typechecks/builds pass.
