### PR TITLE
feat(stripe): add webhook signature verification

### DIFF
--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -40,6 +40,11 @@
       "bun": "./src/errors.ts",
       "default": "./lib/errors.js"
     },
+    "./Webhooks": {
+      "types": "./lib/webhooks.d.ts",
+      "bun": "./src/webhooks.ts",
+      "default": "./lib/webhooks.js"
+    },
     "./Operations": {
       "types": "./lib/operations/index.d.ts",
       "bun": "./src/operations/index.ts",

--- a/packages/stripe/src/errors.ts
+++ b/packages/stripe/src/errors.ts
@@ -148,3 +148,28 @@ export class StripeParseError extends Schema.TaggedErrorClass<StripeParseError>(
     cause: Schema.Unknown,
   },
 ).pipe(Category.withParseError) {}
+
+/**
+ * Stripe webhook signature verification failed.
+ *
+ * This is raised by the local webhook helpers when the Stripe-Signature header
+ * is missing, malformed, expired, or does not match the raw request payload.
+ */
+export class StripeWebhookSignatureError extends Schema.TaggedErrorClass<StripeWebhookSignatureError>()(
+  "StripeWebhookSignatureError",
+  {
+    message: Schema.String,
+    cause: Schema.optional(Schema.Unknown),
+  },
+).pipe(Category.withAuthError) {}
+
+/**
+ * Stripe webhook payload JSON parsing failed after signature verification.
+ */
+export class StripeWebhookPayloadParseError extends Schema.TaggedErrorClass<StripeWebhookPayloadParseError>()(
+  "StripeWebhookPayloadParseError",
+  {
+    message: Schema.String,
+    cause: Schema.optional(Schema.Unknown),
+  },
+).pipe(Category.withParseError) {}

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -10,6 +10,7 @@ export * from "./credentials.ts";
 export * as Category from "./category.ts";
 export * as T from "./traits.ts";
 export * as Retry from "./retry.ts";
+export * as Webhooks from "./webhooks.ts";
 export { API } from "./client.ts";
 export * from "./errors.ts";
 export * from "./operations/index.ts";

--- a/packages/stripe/src/webhooks.ts
+++ b/packages/stripe/src/webhooks.ts
@@ -1,0 +1,307 @@
+import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
+import {
+  StripeWebhookPayloadParseError,
+  StripeWebhookSignatureError,
+} from "./errors.ts";
+
+export const DEFAULT_WEBHOOK_TOLERANCE_SECONDS = 300;
+
+export type WebhookPayload = string | Uint8Array | ArrayBuffer;
+export type WebhookSecret = string | Redacted.Redacted<string>;
+
+export interface StripeEvent {
+  readonly id?: string;
+  readonly object?: string;
+  readonly api_version?: string;
+  readonly created?: number;
+  readonly data?: unknown;
+  readonly livemode?: boolean;
+  readonly pending_webhooks?: number;
+  readonly request?: unknown;
+  readonly type?: string;
+  readonly [key: string]: unknown;
+}
+
+export interface VerifySignatureOptions {
+  /**
+   * Raw request body exactly as Stripe sent it. Do not pass parsed or
+   * reserialized JSON.
+   */
+  readonly payload: WebhookPayload;
+  readonly signature: string | null | undefined;
+  readonly secret: WebhookSecret;
+  /**
+   * Maximum allowed webhook age in seconds. Pass `0` to skip timestamp
+   * tolerance verification for tests or offline reprocessing.
+   */
+  readonly toleranceSeconds?: number | undefined;
+}
+
+export interface ConstructEventOptions extends VerifySignatureOptions {}
+
+interface ParsedSignatureHeader {
+  readonly timestamp: string;
+  readonly timestampSeconds: number;
+  readonly signatures: ReadonlyArray<string>;
+}
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder("utf-8", { fatal: true });
+
+const payloadToBytes = (payload: WebhookPayload): Uint8Array => {
+  if (typeof payload === "string") {
+    return textEncoder.encode(payload);
+  }
+
+  if (payload instanceof ArrayBuffer) {
+    return new Uint8Array(payload);
+  }
+
+  return payload;
+};
+
+const payloadToString = (payload: WebhookPayload): string => {
+  if (typeof payload === "string") {
+    return payload;
+  }
+
+  return textDecoder.decode(payloadToBytes(payload));
+};
+
+const secretToString = (secret: WebhookSecret): string =>
+  Redacted.isRedacted(secret) ? (Redacted.value(secret) as string) : secret;
+
+const parseSignatureHeader = (
+  signature: string | null | undefined,
+): ParsedSignatureHeader | StripeWebhookSignatureError => {
+  if (signature == null || signature.trim() === "") {
+    return new StripeWebhookSignatureError({
+      message: "Stripe-Signature header is required",
+    });
+  }
+
+  let timestamp: string | undefined;
+  const signatures: Array<string> = [];
+
+  for (const part of signature.split(",")) {
+    const separatorIndex = part.indexOf("=");
+    if (separatorIndex === -1) {
+      continue;
+    }
+
+    const key = part.slice(0, separatorIndex).trim();
+    const value = part.slice(separatorIndex + 1).trim();
+
+    if (key === "t" && timestamp === undefined) {
+      timestamp = value;
+    } else if (key === "v1") {
+      signatures.push(value);
+    }
+  }
+
+  if (timestamp === undefined || timestamp === "") {
+    return new StripeWebhookSignatureError({
+      message: "Stripe-Signature header is missing a timestamp",
+    });
+  }
+
+  const timestampSeconds = Number(timestamp);
+  if (
+    !Number.isSafeInteger(timestampSeconds) ||
+    timestampSeconds < 0 ||
+    String(timestampSeconds) !== timestamp
+  ) {
+    return new StripeWebhookSignatureError({
+      message: "Stripe-Signature header timestamp is invalid",
+    });
+  }
+
+  if (signatures.length === 0) {
+    return new StripeWebhookSignatureError({
+      message: "Stripe-Signature header is missing a v1 signature",
+    });
+  }
+
+  return { timestamp, timestampSeconds, signatures };
+};
+
+const signedPayloadBytes = (
+  timestamp: string,
+  payload: WebhookPayload,
+): ArrayBuffer => {
+  const timestampBytes = textEncoder.encode(`${timestamp}.`);
+  const bodyBytes = payloadToBytes(payload);
+  const signedPayload = new Uint8Array(
+    timestampBytes.byteLength + bodyBytes.byteLength,
+  );
+
+  signedPayload.set(timestampBytes, 0);
+  signedPayload.set(bodyBytes, timestampBytes.byteLength);
+
+  return signedPayload.buffer;
+};
+
+const hmacSha256 = (
+  secret: string,
+  timestamp: string,
+  payload: WebhookPayload,
+): Effect.Effect<Uint8Array, StripeWebhookSignatureError> =>
+  Effect.tryPromise({
+    try: async () => {
+      const key = await crypto.subtle.importKey(
+        "raw",
+        textEncoder.encode(secret),
+        { name: "HMAC", hash: "SHA-256" },
+        false,
+        ["sign"],
+      );
+      const signature = await crypto.subtle.sign(
+        "HMAC",
+        key,
+        signedPayloadBytes(timestamp, payload),
+      );
+
+      return new Uint8Array(signature);
+    },
+    catch: (cause) =>
+      new StripeWebhookSignatureError({
+        message: "Unable to compute Stripe webhook signature",
+        cause,
+      }),
+  });
+
+const hexToBytes = (hex: string): Uint8Array | undefined => {
+  if (hex.length % 2 !== 0 || !/^[0-9a-fA-F]+$/.test(hex)) {
+    return undefined;
+  }
+
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let index = 0; index < bytes.length; index += 1) {
+    bytes[index] = Number.parseInt(hex.slice(index * 2, index * 2 + 2), 16);
+  }
+  return bytes;
+};
+
+const constantTimeEqual = (
+  expected: Uint8Array,
+  candidate: Uint8Array,
+): boolean => {
+  // JavaScript cannot guarantee CPU-level constant time, but length mismatches
+  // are folded into the accumulator so a matching prefix can never succeed.
+  let difference = expected.byteLength ^ candidate.byteLength;
+  const byteLength = Math.max(expected.byteLength, candidate.byteLength);
+
+  for (let index = 0; index < byteLength; index += 1) {
+    const expectedByte = index < expected.byteLength ? expected[index] : 0;
+    const candidateByte = index < candidate.byteLength ? candidate[index] : 0;
+    difference |= expectedByte ^ candidateByte;
+  }
+
+  return difference === 0;
+};
+
+const hasMatchingSignature = (
+  expectedSignature: Uint8Array,
+  signatures: ReadonlyArray<string>,
+): boolean => {
+  let matched = false;
+
+  for (const signature of signatures) {
+    const candidate = hexToBytes(signature) ?? new Uint8Array(0);
+    matched = constantTimeEqual(expectedSignature, candidate) || matched;
+  }
+
+  return matched;
+};
+
+const validateTolerance = (
+  timestampSeconds: number,
+  toleranceSeconds: number,
+): StripeWebhookSignatureError | undefined => {
+  if (!Number.isFinite(toleranceSeconds) || toleranceSeconds < 0) {
+    return new StripeWebhookSignatureError({
+      message: "Stripe webhook tolerance must be a non-negative number",
+    });
+  }
+
+  if (toleranceSeconds === 0) {
+    return undefined;
+  }
+
+  const ageSeconds = Math.abs(Math.floor(Date.now() / 1000) - timestampSeconds);
+  if (ageSeconds > toleranceSeconds) {
+    return new StripeWebhookSignatureError({
+      message: `Stripe webhook timestamp is outside the tolerance window of ${toleranceSeconds} seconds`,
+    });
+  }
+
+  return undefined;
+};
+
+export const verifySignature = ({
+  payload,
+  signature,
+  secret,
+  toleranceSeconds = DEFAULT_WEBHOOK_TOLERANCE_SECONDS,
+}: VerifySignatureOptions): Effect.Effect<void, StripeWebhookSignatureError> =>
+  Effect.gen(function* () {
+    const parsed = parseSignatureHeader(signature);
+    if (parsed instanceof StripeWebhookSignatureError) {
+      return yield* Effect.fail(parsed);
+    }
+
+    const expectedSignature = yield* hmacSha256(
+      secretToString(secret),
+      parsed.timestamp,
+      payload,
+    );
+
+    if (!hasMatchingSignature(expectedSignature, parsed.signatures)) {
+      return yield* Effect.fail(
+        new StripeWebhookSignatureError({
+          message:
+            "No v1 signature matches the expected Stripe webhook signature",
+        }),
+      );
+    }
+
+    const toleranceError = validateTolerance(
+      parsed.timestampSeconds,
+      toleranceSeconds,
+    );
+    if (toleranceError !== undefined) {
+      return yield* Effect.fail(toleranceError);
+    }
+  });
+
+const isRecord = (value: unknown): value is StripeEvent =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+export const constructEvent = ({
+  payload,
+  signature,
+  secret,
+  toleranceSeconds,
+}: ConstructEventOptions): Effect.Effect<
+  StripeEvent,
+  StripeWebhookSignatureError | StripeWebhookPayloadParseError
+> =>
+  verifySignature({ payload, signature, secret, toleranceSeconds }).pipe(
+    Effect.flatMap(() =>
+      Effect.try({
+        try: () => {
+          const parsed = JSON.parse(payloadToString(payload)) as unknown;
+          if (!isRecord(parsed)) {
+            throw new Error("Stripe webhook payload must be a JSON object");
+          }
+          return parsed;
+        },
+        catch: (cause) =>
+          new StripeWebhookPayloadParseError({
+            message: "Unable to parse Stripe webhook payload as JSON",
+            cause,
+          }),
+      }),
+    ),
+  );

--- a/packages/stripe/tests/webhooks.test.ts
+++ b/packages/stripe/tests/webhooks.test.ts
@@ -1,0 +1,214 @@
+import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
+import { describe, expect, it } from "vitest";
+import {
+  constructEvent,
+  verifySignature,
+  type WebhookPayload,
+} from "../src/webhooks.ts";
+
+const encoder = new TextEncoder();
+
+const payloadToBytes = (payload: WebhookPayload): Uint8Array => {
+  if (typeof payload === "string") {
+    return encoder.encode(payload);
+  }
+  if (payload instanceof ArrayBuffer) {
+    return new Uint8Array(payload);
+  }
+  return payload;
+};
+
+const toHex = (bytes: Uint8Array): string =>
+  Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+
+const signatureFor = async (
+  payload: WebhookPayload,
+  secret: string,
+  timestamp: number,
+): Promise<string> => {
+  const timestampBytes = encoder.encode(`${timestamp}.`);
+  const payloadBytes = payloadToBytes(payload);
+  const signedPayload = new Uint8Array(
+    timestampBytes.byteLength + payloadBytes.byteLength,
+  );
+  signedPayload.set(timestampBytes);
+  signedPayload.set(payloadBytes, timestampBytes.byteLength);
+
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign("HMAC", key, signedPayload);
+
+  return toHex(new Uint8Array(signature));
+};
+
+const headerFor = async (
+  payload: WebhookPayload,
+  secret: string,
+  timestamp = Math.floor(Date.now() / 1000),
+): Promise<string> => {
+  const signature = await signatureFor(payload, secret, timestamp);
+  return `t=${timestamp},v1=${signature}`;
+};
+
+const expectSignatureError = async (
+  effect: Effect.Effect<unknown, unknown, never>,
+): Promise<void> => {
+  const error = await Effect.runPromise(Effect.flip(effect));
+  expect((error as { _tag?: string })._tag).toBe("StripeWebhookSignatureError");
+};
+
+describe("Stripe Webhooks", () => {
+  const secret = "whsec_test_secret";
+  const payload =
+    '{"id":"evt_test_webhook","object":"event","type":"payment_intent.succeeded"}';
+
+  it("returns the parsed event for a valid signature", async () => {
+    const signature = await headerFor(payload, secret);
+
+    const event = await Effect.runPromise(
+      constructEvent({ payload, signature, secret }),
+    );
+
+    expect(event.id).toBe("evt_test_webhook");
+    expect(event.object).toBe("event");
+    expect(event.type).toBe("payment_intent.succeeded");
+  });
+
+  it("accepts raw Uint8Array and ArrayBuffer payloads", async () => {
+    const bytes = encoder.encode(payload);
+    const signature = await headerFor(bytes, secret);
+
+    await Effect.runPromise(
+      verifySignature({ payload: bytes, signature, secret }),
+    );
+
+    const arrayBuffer = bytes.buffer.slice(
+      bytes.byteOffset,
+      bytes.byteOffset + bytes.byteLength,
+    );
+    await Effect.runPromise(
+      verifySignature({ payload: arrayBuffer, signature, secret }),
+    );
+  });
+
+  it("accepts redacted webhook secrets", async () => {
+    const signature = await headerFor(payload, secret);
+
+    const event = await Effect.runPromise(
+      constructEvent({
+        payload,
+        signature,
+        secret: Redacted.make(secret),
+      }),
+    );
+
+    expect(event.id).toBe("evt_test_webhook");
+  });
+
+  it("fails when the signature header is missing", async () => {
+    await expectSignatureError(
+      constructEvent({ payload, signature: undefined, secret }),
+    );
+  });
+
+  it("fails when the signature header is malformed or missing a timestamp", async () => {
+    await expectSignatureError(
+      constructEvent({ payload, signature: "not-a-signature", secret }),
+    );
+    await expectSignatureError(
+      constructEvent({ payload, signature: "v1=abcd", secret }),
+    );
+  });
+
+  it("fails when the secret or payload does not match the signature", async () => {
+    const signature = await headerFor(payload, secret);
+
+    await expectSignatureError(
+      constructEvent({
+        payload,
+        signature,
+        secret: "whsec_wrong_secret",
+      }),
+    );
+    await expectSignatureError(
+      constructEvent({
+        payload: `${payload}\n`,
+        signature,
+        secret,
+      }),
+    );
+  });
+
+  it("fails old timestamps with the default tolerance", async () => {
+    const oldTimestamp = Math.floor(Date.now() / 1000) - 1_000;
+    const signature = await headerFor(payload, secret, oldTimestamp);
+
+    await expectSignatureError(constructEvent({ payload, signature, secret }));
+  });
+
+  it("can skip timestamp tolerance for offline verification", async () => {
+    const oldTimestamp = Math.floor(Date.now() / 1000) - 10_000;
+    const signature = await headerFor(payload, secret, oldTimestamp);
+
+    const event = await Effect.runPromise(
+      constructEvent({
+        payload,
+        signature,
+        secret,
+        toleranceSeconds: 0,
+      }),
+    );
+
+    expect(event.id).toBe("evt_test_webhook");
+  });
+
+  it("fails future timestamps outside the tolerance window", async () => {
+    const futureTimestamp = Math.floor(Date.now() / 1000) + 1_000;
+    const signature = await headerFor(payload, secret, futureTimestamp);
+
+    await expectSignatureError(constructEvent({ payload, signature, secret }));
+  });
+
+  it("succeeds when any v1 signature matches", async () => {
+    const timestamp = Math.floor(Date.now() / 1000);
+    const validSignature = await signatureFor(payload, secret, timestamp);
+    const signature = `t=${timestamp},v1=000000,v0=ignored,v1=${validSignature}`;
+
+    const event = await Effect.runPromise(
+      constructEvent({ payload, signature, secret }),
+    );
+
+    expect(event.id).toBe("evt_test_webhook");
+  });
+
+  it("signs the exact raw JSON payload instead of reserialized JSON", async () => {
+    const rawPayload =
+      '{ "id": "evt_raw", "object": "event", "type": "checkout.session.completed" }';
+    const signature = await headerFor(rawPayload, secret);
+
+    const event = await Effect.runPromise(
+      constructEvent({ payload: rawPayload, signature, secret }),
+    );
+    expect(event.id).toBe("evt_raw");
+
+    const reserializedPayload = JSON.stringify(JSON.parse(rawPayload));
+    await expectSignatureError(
+      constructEvent({ payload: reserializedPayload, signature, secret }),
+    );
+  });
+
+  it("matches the public HMAC-SHA256 signed payload algorithm", async () => {
+    const fixtureTimestamp = 1_700_000_000;
+    const signature = await signatureFor(payload, secret, fixtureTimestamp);
+
+    expect(signature).toBe(
+      "130dc37d5a27b1b232a61e4f2ff00ed245f498112c11e8b747aff3d0fb754056",
+    );
+  });
+});


### PR DESCRIPTION
Adds local Stripe webhook verification helpers to `@distilled.cloud/stripe`. This is hand-written package code, not an OpenAPI-generated REST operation, because webhook signature validation is local cryptographic work rather than a Stripe API call.

- Exposes `Stripe.Webhooks.constructEvent(...)` and `Stripe.Webhooks.verifySignature(...)`
- Requires callers to pass the raw request body, `Stripe-Signature` header, and endpoint secret
- Computes HMAC-SHA256 over `${timestamp}.${rawPayload}`, checks all `v1` signatures, and enforces a 300-second default tolerance
- Supports `toleranceSeconds: 0` for tests/offline reprocessing where timestamp freshness should be skipped
- Parses the JSON payload only after signature verification and returns a minimal `StripeEvent`
- Adds focused local tests; no live Stripe API key is required

```ts
const event = yield* Stripe.Webhooks.constructEvent({
  payload: rawBody,
  signature: request.headers.get("Stripe-Signature"),
  secret: env.STRIPE_WEBHOOK_SECRET,
});
```

### Notes

The helper follows Stripe's documented signed payload format instead of adding `stripe` / `stripe-node` as a runtime dependency. It preserves raw body semantics so formatted, parsed, or reserialized JSON does not verify accidentally.

### Validation

- `bun --filter '@distilled.cloud/stripe' test`
- `bun --filter '@distilled.cloud/stripe' typecheck`
- `bun --filter '@distilled.cloud/stripe' build`
- `bun --filter '@distilled.cloud/stripe' check`
- `git diff --check upstream/main...HEAD`

The branch also passed the repository pre-commit formatting hook during amend.
