### PR TITLE
fix(aws): make Route53 + CloudFront list-response members optional

### DIFF
--- a/packages/aws/patches/cloudfront.json
+++ b/packages/aws/patches/cloudfront.json
@@ -2,7 +2,12 @@
   "operations": {},
   "enums": {
     "HttpVersion": {
-      "add": ["HTTP1.1", "HTTP2", "HTTP3", "HTTP2AND3"]
+      "add": [
+        "HTTP1.1",
+        "HTTP2",
+        "HTTP3",
+        "HTTP2AND3"
+      ]
     }
   },
   "structures": {
@@ -79,6 +84,15 @@
     "VpcOriginList": {
       "members": {
         "Marker": {
+          "optional": true
+        },
+        "IsTruncated": {
+          "optional": true
+        },
+        "MaxItems": {
+          "optional": true
+        },
+        "Quantity": {
           "optional": true
         }
       }

--- a/packages/aws/patches/route-53.json
+++ b/packages/aws/patches/route-53.json
@@ -2,5 +2,41 @@
   "errorCategories": {
     "PriorRequestNotComplete": ["ConflictError", "RetryableError"],
     "ThrottlingException": ["ThrottlingError", "RetryableError"]
+  },
+  "structures": {
+    "ListResourceRecordSetsResponse": {
+      "members": {
+        "ResourceRecordSets": {
+          "optional": true
+        }
+      }
+    },
+    "ListHostedZonesResponse": {
+      "members": {
+        "HostedZones": {
+          "optional": true
+        },
+        "Marker": {
+          "optional": true
+        }
+      }
+    },
+    "ListHealthChecksResponse": {
+      "members": {
+        "HealthChecks": {
+          "optional": true
+        },
+        "Marker": {
+          "optional": true
+        }
+      }
+    },
+    "ListHostedZonesByNameResponse": {
+      "members": {
+        "HostedZones": {
+          "optional": true
+        }
+      }
+    }
   }
 }

--- a/packages/aws/src/services/cloudfront.ts
+++ b/packages/aws/src/services/cloudfront.ts
@@ -8781,18 +8781,18 @@ export const VpcOriginSummaryList = /*@__PURE__*/ /*#__PURE__*/ S.Array(
 export interface VpcOriginList {
   Marker?: string;
   NextMarker?: string;
-  MaxItems: number;
-  IsTruncated: boolean;
-  Quantity: number;
+  MaxItems?: number;
+  IsTruncated?: boolean;
+  Quantity?: number;
   Items?: VpcOriginSummary[];
 }
 export const VpcOriginList = /*@__PURE__*/ /*#__PURE__*/ S.suspend(() =>
   S.Struct({
     Marker: S.optional(S.String),
     NextMarker: S.optional(S.String),
-    MaxItems: S.Number,
-    IsTruncated: S.Boolean,
-    Quantity: S.Number,
+    MaxItems: S.optional(S.Number),
+    IsTruncated: S.optional(S.Boolean),
+    Quantity: S.optional(S.Number),
     Items: S.optional(VpcOriginSummaryList),
   }),
 ).annotate({ identifier: "VpcOriginList" }) as any as S.Schema<VpcOriginList>;

--- a/packages/aws/src/services/route-53.ts
+++ b/packages/aws/src/services/route-53.ts
@@ -2935,8 +2935,8 @@ export const HealthChecks = /*@__PURE__*/ /*#__PURE__*/ S.Array(
   }),
 );
 export interface ListHealthChecksResponse {
-  HealthChecks: HealthCheck[];
-  Marker: string;
+  HealthChecks?: HealthCheck[];
+  Marker?: string;
   IsTruncated: boolean;
   NextMarker?: string;
   MaxItems: number;
@@ -2944,8 +2944,8 @@ export interface ListHealthChecksResponse {
 export const ListHealthChecksResponse = /*@__PURE__*/ /*#__PURE__*/ S.suspend(
   () =>
     S.Struct({
-      HealthChecks: HealthChecks,
-      Marker: S.String,
+      HealthChecks: S.optional(HealthChecks),
+      Marker: S.optional(S.String),
       IsTruncated: S.Boolean,
       NextMarker: S.optional(S.String),
       MaxItems: S.Number,
@@ -2993,8 +2993,8 @@ export const HostedZones = /*@__PURE__*/ /*#__PURE__*/ S.Array(
   }),
 );
 export interface ListHostedZonesResponse {
-  HostedZones: HostedZone[];
-  Marker: string;
+  HostedZones?: HostedZone[];
+  Marker?: string;
   IsTruncated: boolean;
   NextMarker?: string;
   MaxItems: number;
@@ -3002,8 +3002,8 @@ export interface ListHostedZonesResponse {
 export const ListHostedZonesResponse = /*@__PURE__*/ /*#__PURE__*/ S.suspend(
   () =>
     S.Struct({
-      HostedZones: HostedZones,
-      Marker: S.String,
+      HostedZones: S.optional(HostedZones),
+      Marker: S.optional(S.String),
       IsTruncated: S.Boolean,
       NextMarker: S.optional(S.String),
       MaxItems: S.Number,
@@ -3037,7 +3037,7 @@ export const ListHostedZonesByNameRequest =
     identifier: "ListHostedZonesByNameRequest",
   }) as any as S.Schema<ListHostedZonesByNameRequest>;
 export interface ListHostedZonesByNameResponse {
-  HostedZones: HostedZone[];
+  HostedZones?: HostedZone[];
   DNSName?: string;
   HostedZoneId?: string;
   IsTruncated: boolean;
@@ -3048,7 +3048,7 @@ export interface ListHostedZonesByNameResponse {
 export const ListHostedZonesByNameResponse =
   /*@__PURE__*/ /*#__PURE__*/ S.suspend(() =>
     S.Struct({
-      HostedZones: HostedZones,
+      HostedZones: S.optional(HostedZones),
       DNSName: S.optional(S.String),
       HostedZoneId: S.optional(S.String),
       IsTruncated: S.Boolean,
@@ -3214,7 +3214,7 @@ export const ResourceRecordSets = /*@__PURE__*/ /*#__PURE__*/ S.Array(
   }),
 );
 export interface ListResourceRecordSetsResponse {
-  ResourceRecordSets: ResourceRecordSet[];
+  ResourceRecordSets?: ResourceRecordSet[];
   IsTruncated: boolean;
   NextRecordName?: string;
   NextRecordType?: RRType;
@@ -3224,7 +3224,7 @@ export interface ListResourceRecordSetsResponse {
 export const ListResourceRecordSetsResponse =
   /*@__PURE__*/ /*#__PURE__*/ S.suspend(() =>
     S.Struct({
-      ResourceRecordSets: ResourceRecordSets,
+      ResourceRecordSets: S.optional(ResourceRecordSets),
       IsTruncated: S.Boolean,
       NextRecordName: S.optional(S.String),
       NextRecordType: S.optional(RRType),


### PR DESCRIPTION
Two AWS list operations return responses whose Smithy-required members are omitted by the service in common cases, so decoding failed. Patch them optional via the `structures` override.

Route 53 — omits the list element entirely when a page is empty (`ResourceRecordSets`, `HostedZones`, `HealthChecks`), and `Marker` when not paginating:

```diff
 export interface ListHostedZonesResponse {
-  HostedZones: HostedZone[];
-  Marker: string;
+  HostedZones?: HostedZone[];
+  Marker?: string;
 }
```

CloudFront — omits `IsTruncated` / `MaxItems` / `Quantity` on an empty `ListVpcOrigins` page (it already omitted `Marker` / `Items`):

```diff
 export interface VpcOriginList {
-  MaxItems: number;
-  IsTruncated: boolean;
-  Quantity: number;
+  MaxItems?: number;
+  IsTruncated?: boolean;
+  Quantity?: number;
 }
```

Both surfaced by alchemy AWS Route53 (HostedZone/HealthCheck/Record) and CloudFront (VpcOrigin) live tests.
