### PR TITLE
fix(cloudflare): make error classes tree-shakeable out of Worker bundles

### DIFF
--- a/packages/cloudflare/scripts/generate.ts
+++ b/packages/cloudflare/scripts/generate.ts
@@ -3219,11 +3219,19 @@ function generateServiceFile(
           `T.applyErrorMatchers(${tag}, ${JSON.stringify(matchers)});`,
         );
       } else {
-        lines.push(`export class ${tag} extends Schema.TaggedErrorClass<${tag}>()(
-  "${tag}",
-  { code: Schema.Number, message: Schema.String },
-) {}
-T.applyErrorMatchers(${tag}, ${JSON.stringify(matchers)});`);
+        // Wrap the base class with `applyErrorMatchers` inside the `extends`
+        // clause rather than emitting a separate top-level
+        // `applyErrorMatchers(Tag, ...)` statement. A bare top-level call is a
+        // module side effect that keeps the whole service module (and its
+        // distilled imports) alive in Worker bundles even when none of its
+        // exports are used; wrapping keeps the module tree-shakeable.
+        lines.push(`export class ${tag} extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<${tag}>()(
+    "${tag}",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  ${JSON.stringify(matchers)},
+) {}`);
       }
       lines.push("");
     }

--- a/packages/cloudflare/src/services/abuse-reports.ts
+++ b/packages/cloudflare/src/services/abuse-reports.ts
@@ -16,23 +16,29 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class AbuseReportNotFound extends Schema.TaggedErrorClass<AbuseReportNotFound>()(
-  "AbuseReportNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class AbuseReportNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<AbuseReportNotFound>()("AbuseReportNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 0 }],
 ) {}
-T.applyErrorMatchers(AbuseReportNotFound, [{ code: 0 }]);
 
-export class InvalidAccountId extends Schema.TaggedErrorClass<InvalidAccountId>()(
-  "InvalidAccountId",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidAccountId extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidAccountId>()("InvalidAccountId", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7003 }],
 ) {}
-T.applyErrorMatchers(InvalidAccountId, [{ code: 7003 }]);
 
-export class InvalidRequest extends Schema.TaggedErrorClass<InvalidRequest>()(
-  "InvalidRequest",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidRequest extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidRequest>()("InvalidRequest", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7003 }],
 ) {}
-T.applyErrorMatchers(InvalidRequest, [{ code: 7003 }]);
 
 // =============================================================================
 // AbuseReport

--- a/packages/cloudflare/src/services/accounts.ts
+++ b/packages/cloudflare/src/services/accounts.ts
@@ -16,123 +16,141 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class AccountCreationForbidden extends Schema.TaggedErrorClass<AccountCreationForbidden>()(
-  "AccountCreationForbidden",
-  { code: Schema.Number, message: Schema.String },
+export class AccountCreationForbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<AccountCreationForbidden>()(
+    "AccountCreationForbidden",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1002 }],
 ) {}
-T.applyErrorMatchers(AccountCreationForbidden, [{ code: 1002 }]);
 
-export class AccountMemberAlreadyExists extends Schema.TaggedErrorClass<AccountMemberAlreadyExists>()(
-  "AccountMemberAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class AccountMemberAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<AccountMemberAlreadyExists>()(
+    "AccountMemberAlreadyExists",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 400, message: { includes: "already exists" } }],
 ) {}
-T.applyErrorMatchers(AccountMemberAlreadyExists, [
-  { status: 400, message: { includes: "already exists" } },
-]);
 
-export class AccountNameTooLong extends Schema.TaggedErrorClass<AccountNameTooLong>()(
-  "AccountNameTooLong",
-  { code: Schema.Number, message: Schema.String },
+export class AccountNameTooLong extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<AccountNameTooLong>()("AccountNameTooLong", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1001, message: { includes: "too long" } }],
 ) {}
-T.applyErrorMatchers(AccountNameTooLong, [
-  { code: 1001, message: { includes: "too long" } },
-]);
 
-export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
-  "BadRequest",
-  { code: Schema.Number, message: Schema.String },
+export class BadRequest extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<BadRequest>()("BadRequest", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 400 }],
 ) {}
-T.applyErrorMatchers(BadRequest, [{ code: 400 }]);
 
-export class EndpointNotFound extends Schema.TaggedErrorClass<EndpointNotFound>()(
-  "EndpointNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class EndpointNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<EndpointNotFound>()("EndpointNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1199 }],
 ) {}
-T.applyErrorMatchers(EndpointNotFound, [{ code: 1199 }]);
 
-export class InvalidAccountName extends Schema.TaggedErrorClass<InvalidAccountName>()(
-  "InvalidAccountName",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidAccountName extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidAccountName>()("InvalidAccountName", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1001, message: { includes: "invalid character" } }],
 ) {}
-T.applyErrorMatchers(InvalidAccountName, [
-  { code: 1001, message: { includes: "invalid character" } },
-]);
 
-export class InvalidRoute extends Schema.TaggedErrorClass<InvalidRoute>()(
-  "InvalidRoute",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidRoute extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidRoute>()("InvalidRoute", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7003 }],
 ) {}
-T.applyErrorMatchers(InvalidRoute, [{ code: 7003 }]);
 
-export class InvalidTokenName extends Schema.TaggedErrorClass<InvalidTokenName>()(
-  "InvalidTokenName",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidTokenName extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidTokenName>()("InvalidTokenName", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 400, message: { includes: "name must have a length" } }],
 ) {}
-T.applyErrorMatchers(InvalidTokenName, [
-  { code: 400, message: { includes: "name must have a length" } },
-]);
 
-export class JsonDecodeFailure extends Schema.TaggedErrorClass<JsonDecodeFailure>()(
-  "JsonDecodeFailure",
-  { code: Schema.Number, message: Schema.String },
+export class JsonDecodeFailure extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<JsonDecodeFailure>()("JsonDecodeFailure", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1198 }],
 ) {}
-T.applyErrorMatchers(JsonDecodeFailure, [{ code: 1198 }]);
 
-export class MemberNotFound extends Schema.TaggedErrorClass<MemberNotFound>()(
-  "MemberNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class MemberNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<MemberNotFound>()("MemberNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1003 }],
 ) {}
-T.applyErrorMatchers(MemberNotFound, [{ code: 1003 }]);
 
-export class MethodNotAllowed extends Schema.TaggedErrorClass<MethodNotAllowed>()(
-  "MethodNotAllowed",
-  { code: Schema.Number, message: Schema.String },
+export class MethodNotAllowed extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<MethodNotAllowed>()("MethodNotAllowed", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7001 }, { code: 10000 }, { code: 10405 }],
 ) {}
-T.applyErrorMatchers(MethodNotAllowed, [
-  { code: 7001 },
-  { code: 10000 },
-  { code: 10405 },
-]);
 
-export class MissingAuthenticationToken extends Schema.TaggedErrorClass<MissingAuthenticationToken>()(
-  "MissingAuthenticationToken",
-  { code: Schema.Number, message: Schema.String },
+export class MissingAuthenticationToken extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<MissingAuthenticationToken>()(
+    "MissingAuthenticationToken",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1001 }],
 ) {}
-T.applyErrorMatchers(MissingAuthenticationToken, [{ code: 1001 }]);
 
-export class MissingName extends Schema.TaggedErrorClass<MissingName>()(
-  "MissingName",
-  { code: Schema.Number, message: Schema.String },
+export class MissingName extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<MissingName>()("MissingName", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1001 }],
 ) {}
-T.applyErrorMatchers(MissingName, [{ code: 1001 }]);
 
-export class PermissionGroupNotFound extends Schema.TaggedErrorClass<PermissionGroupNotFound>()(
-  "PermissionGroupNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class PermissionGroupNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<PermissionGroupNotFound>()(
+    "PermissionGroupNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1001, message: { includes: "Permission group" } }],
 ) {}
-T.applyErrorMatchers(PermissionGroupNotFound, [
-  { code: 1001, message: { includes: "Permission group" } },
-]);
 
-export class TokenNotFound extends Schema.TaggedErrorClass<TokenNotFound>()(
-  "TokenNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class TokenNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<TokenNotFound>()("TokenNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1003 }],
 ) {}
-T.applyErrorMatchers(TokenNotFound, [{ code: 1003 }]);
 
-export class UpdateAccountTypeNotSupported extends Schema.TaggedErrorClass<UpdateAccountTypeNotSupported>()(
-  "UpdateAccountTypeNotSupported",
-  { code: Schema.Number, message: Schema.String },
+export class UpdateAccountTypeNotSupported extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<UpdateAccountTypeNotSupported>()(
+    "UpdateAccountTypeNotSupported",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1001, message: { includes: "account type is not supported" } }],
 ) {}
-T.applyErrorMatchers(UpdateAccountTypeNotSupported, [
-  { code: 1001, message: { includes: "account type is not supported" } },
-]);
 
-export class ValidationError extends Schema.TaggedErrorClass<ValidationError>()(
-  "ValidationError",
-  { code: Schema.Number, message: Schema.String },
+export class ValidationError extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ValidationError>()("ValidationError", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1001 }],
 ) {}
-T.applyErrorMatchers(ValidationError, [{ code: 1001 }]);
 
 // =============================================================================
 // Account

--- a/packages/cloudflare/src/services/acm.ts
+++ b/packages/cloudflare/src/services/acm.ts
@@ -16,41 +16,53 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class AdvancedCertificateManagerRequired extends Schema.TaggedErrorClass<AdvancedCertificateManagerRequired>()(
-  "AdvancedCertificateManagerRequired",
-  { code: Schema.Number, message: Schema.String },
+export class AdvancedCertificateManagerRequired extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<AdvancedCertificateManagerRequired>()(
+    "AdvancedCertificateManagerRequired",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1450 }],
 ) {}
-T.applyErrorMatchers(AdvancedCertificateManagerRequired, [{ code: 1450 }]);
 
-export class CustomTrustStoreNotFound extends Schema.TaggedErrorClass<CustomTrustStoreNotFound>()(
-  "CustomTrustStoreNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class CustomTrustStoreNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<CustomTrustStoreNotFound>()(
+    "CustomTrustStoreNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(CustomTrustStoreNotFound, [{ status: 404 }]);
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class InvalidObjectIdentifier extends Schema.TaggedErrorClass<InvalidObjectIdentifier>()(
-  "InvalidObjectIdentifier",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidObjectIdentifier extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidObjectIdentifier>()(
+    "InvalidObjectIdentifier",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 7003 }],
 ) {}
-T.applyErrorMatchers(InvalidObjectIdentifier, [{ code: 7003 }]);
 
-export class NoStateChange extends Schema.TaggedErrorClass<NoStateChange>()(
-  "NoStateChange",
-  { code: Schema.Number, message: Schema.String },
+export class NoStateChange extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<NoStateChange>()("NoStateChange", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1467 }],
 ) {}
-T.applyErrorMatchers(NoStateChange, [{ code: 1467 }]);
 
-export class PreviousJobInProgress extends Schema.TaggedErrorClass<PreviousJobInProgress>()(
-  "PreviousJobInProgress",
-  { code: Schema.Number, message: Schema.String },
+export class PreviousJobInProgress extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<PreviousJobInProgress>()("PreviousJobInProgress", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1482 }],
 ) {}
-T.applyErrorMatchers(PreviousJobInProgress, [{ code: 1482 }]);
 
 // =============================================================================
 // CustomTrustStore

--- a/packages/cloudflare/src/services/addressing.ts
+++ b/packages/cloudflare/src/services/addressing.ts
@@ -16,154 +16,172 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class AddressMapNotFound extends Schema.TaggedErrorClass<AddressMapNotFound>()(
-  "AddressMapNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class AddressMapNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<AddressMapNotFound>()("AddressMapNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1000 }, { code: 1000, message: { includes: "not_found" } }],
 ) {}
-T.applyErrorMatchers(AddressMapNotFound, [
-  { code: 1000 },
-  { code: 1000, message: { includes: "not_found" } },
-]);
 
-export class BgpPrefixNotFound extends Schema.TaggedErrorClass<BgpPrefixNotFound>()(
-  "BgpPrefixNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class BgpPrefixNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<BgpPrefixNotFound>()("BgpPrefixNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1002 }],
 ) {}
-T.applyErrorMatchers(BgpPrefixNotFound, [{ code: 1002 }]);
 
-export class BindingNotFound extends Schema.TaggedErrorClass<BindingNotFound>()(
-  "BindingNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class BindingNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<BindingNotFound>()("BindingNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1002 }],
 ) {}
-T.applyErrorMatchers(BindingNotFound, [{ code: 1002 }]);
 
-export class DelegationNotFound extends Schema.TaggedErrorClass<DelegationNotFound>()(
-  "DelegationNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class DelegationNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DelegationNotFound>()("DelegationNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1000 }],
 ) {}
-T.applyErrorMatchers(DelegationNotFound, [{ code: 1000 }]);
 
-export class FeatureNotEnabled extends Schema.TaggedErrorClass<FeatureNotEnabled>()(
-  "FeatureNotEnabled",
-  { code: Schema.Number, message: Schema.String },
+export class FeatureNotEnabled extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<FeatureNotEnabled>()("FeatureNotEnabled", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1002, message: { includes: "address_maps_not_enabled" } }],
 ) {}
-T.applyErrorMatchers(FeatureNotEnabled, [
-  { code: 1002, message: { includes: "address_maps_not_enabled" } },
-]);
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class InvalidAccountId extends Schema.TaggedErrorClass<InvalidAccountId>()(
-  "InvalidAccountId",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidAccountId extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidAccountId>()("InvalidAccountId", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7003, message: { includes: "Could not route" } }],
 ) {}
-T.applyErrorMatchers(InvalidAccountId, [
-  { code: 7003, message: { includes: "Could not route" } },
-]);
 
-export class InvalidHostname extends Schema.TaggedErrorClass<InvalidHostname>()(
-  "InvalidHostname",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidHostname extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidHostname>()("InvalidHostname", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1002, message: { includes: "forbidden" } }],
 ) {}
-T.applyErrorMatchers(InvalidHostname, [
-  { code: 1002, message: { includes: "forbidden" } },
-]);
 
-export class InvalidLoaForm extends Schema.TaggedErrorClass<InvalidLoaForm>()(
-  "InvalidLoaForm",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidLoaForm extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidLoaForm>()("InvalidLoaForm", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1001, message: { includes: "invalid_loa_form" } }, { code: 1001 }],
 ) {}
-T.applyErrorMatchers(InvalidLoaForm, [
-  { code: 1001, message: { includes: "invalid_loa_form" } },
-  { code: 1001 },
-]);
 
-export class InvalidNetworkCidr extends Schema.TaggedErrorClass<InvalidNetworkCidr>()(
-  "InvalidNetworkCidr",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidNetworkCidr extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidNetworkCidr>()("InvalidNetworkCidr", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1001, message: { includes: "invalid_network_cidr" } }],
 ) {}
-T.applyErrorMatchers(InvalidNetworkCidr, [
-  { code: 1001, message: { includes: "invalid_network_cidr" } },
-]);
 
-export class InvalidZoneId extends Schema.TaggedErrorClass<InvalidZoneId>()(
-  "InvalidZoneId",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidZoneId extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidZoneId>()("InvalidZoneId", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7003, message: { includes: "Could not route" } }],
 ) {}
-T.applyErrorMatchers(InvalidZoneId, [
-  { code: 7003, message: { includes: "Could not route" } },
-]);
 
-export class IrrEntryNotFound extends Schema.TaggedErrorClass<IrrEntryNotFound>()(
-  "IrrEntryNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class IrrEntryNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<IrrEntryNotFound>()("IrrEntryNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1003, message: { includes: "irr_entry_not_found" } }],
 ) {}
-T.applyErrorMatchers(IrrEntryNotFound, [
-  { code: 1003, message: { includes: "irr_entry_not_found" } },
-]);
 
-export class LoaDocumentNotFound extends Schema.TaggedErrorClass<LoaDocumentNotFound>()(
-  "LoaDocumentNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class LoaDocumentNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<LoaDocumentNotFound>()("LoaDocumentNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1000 }],
 ) {}
-T.applyErrorMatchers(LoaDocumentNotFound, [{ code: 1000 }]);
 
-export class MethodNotAllowed extends Schema.TaggedErrorClass<MethodNotAllowed>()(
-  "MethodNotAllowed",
-  { code: Schema.Number, message: Schema.String },
+export class MethodNotAllowed extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<MethodNotAllowed>()("MethodNotAllowed", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [
+    { code: 10405, message: { includes: "not allowed" } },
+    { code: 10000, message: { includes: "not allowed" } },
+  ],
 ) {}
-T.applyErrorMatchers(MethodNotAllowed, [
-  { code: 10405, message: { includes: "not allowed" } },
-  { code: 10000, message: { includes: "not allowed" } },
-]);
 
-export class MissingAccountId extends Schema.TaggedErrorClass<MissingAccountId>()(
-  "MissingAccountId",
-  { code: Schema.Number, message: Schema.String },
+export class MissingAccountId extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<MissingAccountId>()("MissingAccountId", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1001 }],
 ) {}
-T.applyErrorMatchers(MissingAccountId, [{ code: 1001 }]);
 
-export class NonexistentAccountPrefix extends Schema.TaggedErrorClass<NonexistentAccountPrefix>()(
-  "NonexistentAccountPrefix",
-  { code: Schema.Number, message: Schema.String },
+export class NonexistentAccountPrefix extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<NonexistentAccountPrefix>()(
+    "NonexistentAccountPrefix",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1003 }],
 ) {}
-T.applyErrorMatchers(NonexistentAccountPrefix, [{ code: 1003 }]);
 
-export class PrefixNotFound extends Schema.TaggedErrorClass<PrefixNotFound>()(
-  "PrefixNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class PrefixNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<PrefixNotFound>()("PrefixNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [
+    { code: 1000 },
+    { code: 1000, message: { includes: "not_found" } },
+    { code: 1002, message: { includes: "forbidden" } },
+  ],
 ) {}
-T.applyErrorMatchers(PrefixNotFound, [
-  { code: 1000 },
-  { code: 1000, message: { includes: "not_found" } },
-  { code: 1002, message: { includes: "forbidden" } },
-]);
 
-export class RegionalHostnameEmpty extends Schema.TaggedErrorClass<RegionalHostnameEmpty>()(
-  "RegionalHostnameEmpty",
-  { code: Schema.Number, message: Schema.String },
+export class RegionalHostnameEmpty extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<RegionalHostnameEmpty>()("RegionalHostnameEmpty", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1000, message: { includes: "not_found" } }],
 ) {}
-T.applyErrorMatchers(RegionalHostnameEmpty, [
-  { code: 1000, message: { includes: "not_found" } },
-]);
 
-export class RegionalHostnameNotFound extends Schema.TaggedErrorClass<RegionalHostnameNotFound>()(
-  "RegionalHostnameNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class RegionalHostnameNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<RegionalHostnameNotFound>()(
+    "RegionalHostnameNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1002, message: { includes: "forbidden" } }],
 ) {}
-T.applyErrorMatchers(RegionalHostnameNotFound, [
-  { code: 1002, message: { includes: "forbidden" } },
-]);
 
-export class UnsupportedBindingConfiguration extends Schema.TaggedErrorClass<UnsupportedBindingConfiguration>()(
-  "UnsupportedBindingConfiguration",
-  { code: Schema.Number, message: Schema.String },
+export class UnsupportedBindingConfiguration extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<UnsupportedBindingConfiguration>()(
+    "UnsupportedBindingConfiguration",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1003 }],
 ) {}
-T.applyErrorMatchers(UnsupportedBindingConfiguration, [{ code: 1003 }]);
 
 // =============================================================================
 // AddressMap

--- a/packages/cloudflare/src/services/ai-gateway.ts
+++ b/packages/cloudflare/src/services/ai-gateway.ts
@@ -16,91 +16,101 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class DatasetNameAlreadyExists extends Schema.TaggedErrorClass<DatasetNameAlreadyExists>()(
-  "DatasetNameAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class DatasetNameAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DatasetNameAlreadyExists>()(
+    "DatasetNameAlreadyExists",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 400, message: { includes: "already exists" } }],
 ) {}
-T.applyErrorMatchers(DatasetNameAlreadyExists, [
-  { status: 400, message: { includes: "already exists" } },
-]);
 
-export class DatasetNotFound extends Schema.TaggedErrorClass<DatasetNotFound>()(
-  "DatasetNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class DatasetNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DatasetNotFound>()("DatasetNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7002 }],
 ) {}
-T.applyErrorMatchers(DatasetNotFound, [{ code: 7002 }]);
 
-export class EvaluationNameAlreadyExists extends Schema.TaggedErrorClass<EvaluationNameAlreadyExists>()(
-  "EvaluationNameAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class EvaluationNameAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<EvaluationNameAlreadyExists>()(
+    "EvaluationNameAlreadyExists",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 400, message: { includes: "already exists" } }],
 ) {}
-T.applyErrorMatchers(EvaluationNameAlreadyExists, [
-  { status: 400, message: { includes: "already exists" } },
-]);
 
-export class EvaluationNotFound extends Schema.TaggedErrorClass<EvaluationNotFound>()(
-  "EvaluationNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class EvaluationNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<EvaluationNotFound>()("EvaluationNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7002 }],
 ) {}
-T.applyErrorMatchers(EvaluationNotFound, [{ code: 7002 }]);
 
-export class GatewayAlreadyExists extends Schema.TaggedErrorClass<GatewayAlreadyExists>()(
-  "GatewayAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class GatewayAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<GatewayAlreadyExists>()("GatewayAlreadyExists", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7001 }, { status: 504 }],
 ) {}
-T.applyErrorMatchers(GatewayAlreadyExists, [{ code: 7001 }, { status: 504 }]);
 
-export class GatewayNotFound extends Schema.TaggedErrorClass<GatewayNotFound>()(
-  "GatewayNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class GatewayNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<GatewayNotFound>()("GatewayNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7002 }],
 ) {}
-T.applyErrorMatchers(GatewayNotFound, [{ code: 7002 }]);
 
-export class NoManualTopup extends Schema.TaggedErrorClass<NoManualTopup>()(
-  "NoManualTopup",
-  { code: Schema.Number, message: Schema.String },
+export class NoManualTopup extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<NoManualTopup>()("NoManualTopup", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1000, message: { includes: "NO_MANUAL_TOPUP" } }],
 ) {}
-T.applyErrorMatchers(NoManualTopup, [
-  { code: 1000, message: { includes: "NO_MANUAL_TOPUP" } },
-]);
 
-export class ProviderConfigAlreadyExists extends Schema.TaggedErrorClass<ProviderConfigAlreadyExists>()(
-  "ProviderConfigAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class ProviderConfigAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ProviderConfigAlreadyExists>()(
+    "ProviderConfigAlreadyExists",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 7001, message: { includes: "already exists" } }],
 ) {}
-T.applyErrorMatchers(ProviderConfigAlreadyExists, [
-  { code: 7001, message: { includes: "already exists" } },
-]);
 
-export class ProviderConfigNotFound extends Schema.TaggedErrorClass<ProviderConfigNotFound>()(
-  "ProviderConfigNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class ProviderConfigNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ProviderConfigNotFound>()("ProviderConfigNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7002 }],
 ) {}
-T.applyErrorMatchers(ProviderConfigNotFound, [{ code: 7002 }]);
 
-export class ProviderConfigSecretNotFound extends Schema.TaggedErrorClass<ProviderConfigSecretNotFound>()(
-  "ProviderConfigSecretNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class ProviderConfigSecretNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ProviderConfigSecretNotFound>()(
+    "ProviderConfigSecretNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 7001, message: { includes: "was not found" } }],
 ) {}
-T.applyErrorMatchers(ProviderConfigSecretNotFound, [
-  { code: 7001, message: { includes: "was not found" } },
-]);
 
-export class RouteAlreadyExists extends Schema.TaggedErrorClass<RouteAlreadyExists>()(
-  "RouteAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class RouteAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<RouteAlreadyExists>()("RouteAlreadyExists", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7005, message: { includes: "already exists" } }],
 ) {}
-T.applyErrorMatchers(RouteAlreadyExists, [
-  { code: 7005, message: { includes: "already exists" } },
-]);
 
-export class RouteNotFound extends Schema.TaggedErrorClass<RouteNotFound>()(
-  "RouteNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class RouteNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<RouteNotFound>()("RouteNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7005, message: { includes: "not found" } }],
 ) {}
-T.applyErrorMatchers(RouteNotFound, [
-  { code: 7005, message: { includes: "not found" } },
-]);
 
 // =============================================================================
 // AiGateway

--- a/packages/cloudflare/src/services/ai-security.ts
+++ b/packages/cloudflare/src/services/ai-security.ts
@@ -16,27 +16,29 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class AiSecurityNotEntitled extends Schema.TaggedErrorClass<AiSecurityNotEntitled>()(
-  "AiSecurityNotEntitled",
-  { code: Schema.Number, message: Schema.String },
+export class AiSecurityNotEntitled extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<AiSecurityNotEntitled>()("AiSecurityNotEntitled", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 13101, message: { includes: "not entitled" } }],
 ) {}
-T.applyErrorMatchers(AiSecurityNotEntitled, [
-  { code: 13101, message: { includes: "not entitled" } },
-]);
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class ZoneNotAuthorized extends Schema.TaggedErrorClass<ZoneNotAuthorized>()(
-  "ZoneNotAuthorized",
-  { code: Schema.Number, message: Schema.String },
+export class ZoneNotAuthorized extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ZoneNotAuthorized>()("ZoneNotAuthorized", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10000, message: { includes: "Authentication error" } }],
 ) {}
-T.applyErrorMatchers(ZoneNotAuthorized, [
-  { code: 10000, message: { includes: "Authentication error" } },
-]);
 
 // =============================================================================
 // AiSecurity

--- a/packages/cloudflare/src/services/ai.ts
+++ b/packages/cloudflare/src/services/ai.ts
@@ -17,29 +17,37 @@ import { UploadableSchema } from "../schemas.ts";
 // Errors
 // =============================================================================
 
-export class AccountNotFound extends Schema.TaggedErrorClass<AccountNotFound>()(
-  "AccountNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class AccountNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<AccountNotFound>()("AccountNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7003 }],
 ) {}
-T.applyErrorMatchers(AccountNotFound, [{ code: 7003 }]);
 
-export class ModelNotFound extends Schema.TaggedErrorClass<ModelNotFound>()(
-  "ModelNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class ModelNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ModelNotFound>()("ModelNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7003 }, { code: 7000 }],
 ) {}
-T.applyErrorMatchers(ModelNotFound, [{ code: 7003 }, { code: 7000 }]);
 
-export class ModelNotSupported extends Schema.TaggedErrorClass<ModelNotSupported>()(
-  "ModelNotSupported",
-  { code: Schema.Number, message: Schema.String },
+export class ModelNotSupported extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ModelNotSupported>()("ModelNotSupported", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1000 }],
 ) {}
-T.applyErrorMatchers(ModelNotSupported, [{ code: 1000 }]);
 
-export class ModelSchemaNotFound extends Schema.TaggedErrorClass<ModelSchemaNotFound>()(
-  "ModelSchemaNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class ModelSchemaNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ModelSchemaNotFound>()("ModelSchemaNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 6002 }],
 ) {}
-T.applyErrorMatchers(ModelSchemaNotFound, [{ code: 6002 }]);
 
 // =============================================================================
 // Ai

--- a/packages/cloudflare/src/services/aisearch.ts
+++ b/packages/cloudflare/src/services/aisearch.ts
@@ -17,84 +17,101 @@ import { UploadableSchema } from "../schemas.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class InstanceAlreadyExists extends Schema.TaggedErrorClass<InstanceAlreadyExists>()(
-  "InstanceAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class InstanceAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InstanceAlreadyExists>()("InstanceAlreadyExists", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 400, message: { includes: "already_exist" } }],
 ) {}
-T.applyErrorMatchers(InstanceAlreadyExists, [
-  { status: 400, message: { includes: "already_exist" } },
-]);
 
-export class InvalidRoute extends Schema.TaggedErrorClass<InvalidRoute>()(
-  "InvalidRoute",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidRoute extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidRoute>()("InvalidRoute", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7003 }],
 ) {}
-T.applyErrorMatchers(InvalidRoute, [{ code: 7003 }]);
 
-export class InvalidTokenCredentials extends Schema.TaggedErrorClass<InvalidTokenCredentials>()(
-  "InvalidTokenCredentials",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidTokenCredentials extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidTokenCredentials>()(
+    "InvalidTokenCredentials",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 7012 }, { status: 400, message: { includes: "invalid_token" } }],
 ) {}
-T.applyErrorMatchers(InvalidTokenCredentials, [
-  { code: 7012 },
-  { status: 400, message: { includes: "invalid_token" } },
-]);
 
-export class NamespaceAlreadyExists extends Schema.TaggedErrorClass<NamespaceAlreadyExists>()(
-  "NamespaceAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class NamespaceAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<NamespaceAlreadyExists>()("NamespaceAlreadyExists", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7064 }],
 ) {}
-T.applyErrorMatchers(NamespaceAlreadyExists, [{ code: 7064 }]);
 
-export class NamespaceNotFound extends Schema.TaggedErrorClass<NamespaceNotFound>()(
-  "NamespaceNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class NamespaceNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<NamespaceNotFound>()("NamespaceNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7063 }],
 ) {}
-T.applyErrorMatchers(NamespaceNotFound, [{ code: 7063 }]);
 
-export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
-  code: Schema.Number,
-  message: Schema.String,
-}) {}
-T.applyErrorMatchers(NotFound, [{ code: 7002 }]);
-
-export class SyncInCooldown extends Schema.TaggedErrorClass<SyncInCooldown>()(
-  "SyncInCooldown",
-  { code: Schema.Number, message: Schema.String },
+export class NotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<NotFound>()("NotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7002 }],
 ) {}
-T.applyErrorMatchers(SyncInCooldown, [{ code: 7020 }]);
 
-export class TokenInUseByInstances extends Schema.TaggedErrorClass<TokenInUseByInstances>()(
-  "TokenInUseByInstances",
-  { code: Schema.Number, message: Schema.String },
+export class SyncInCooldown extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SyncInCooldown>()("SyncInCooldown", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7020 }],
 ) {}
-T.applyErrorMatchers(TokenInUseByInstances, [
-  { status: 409, message: { includes: "token_in_use_by_instances" } },
-]);
 
-export class TokenNotFound extends Schema.TaggedErrorClass<TokenNotFound>()(
-  "TokenNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class TokenInUseByInstances extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<TokenInUseByInstances>()("TokenInUseByInstances", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 409, message: { includes: "token_in_use_by_instances" } }],
 ) {}
-T.applyErrorMatchers(TokenNotFound, [{ code: 7075 }]);
 
-export class UnableToConnect extends Schema.TaggedErrorClass<UnableToConnect>()(
-  "UnableToConnect",
-  { code: Schema.Number, message: Schema.String },
+export class TokenNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<TokenNotFound>()("TokenNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7075 }],
 ) {}
-T.applyErrorMatchers(UnableToConnect, [{ code: 7017 }]);
 
-export class ValidationError extends Schema.TaggedErrorClass<ValidationError>()(
-  "ValidationError",
-  { code: Schema.Number, message: Schema.String },
+export class UnableToConnect extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<UnableToConnect>()("UnableToConnect", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7017 }],
 ) {}
-T.applyErrorMatchers(ValidationError, [{ code: 7001 }]);
+
+export class ValidationError extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ValidationError>()("ValidationError", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7001 }],
+) {}
 
 // =============================================================================
 // CompletionsInstance

--- a/packages/cloudflare/src/services/alerting.ts
+++ b/packages/cloudflare/src/services/alerting.ts
@@ -16,85 +16,95 @@ import { type DefaultErrors, InternalServerError } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class FiltersRequired extends Schema.TaggedErrorClass<FiltersRequired>()(
-  "FiltersRequired",
-  { code: Schema.Number, message: Schema.String },
+export class FiltersRequired extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<FiltersRequired>()("FiltersRequired", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 17103 }],
 ) {}
-T.applyErrorMatchers(FiltersRequired, [{ code: 17103 }]);
 
 T.applyErrorMatchers(InternalServerError, [{ code: 15000 }]);
 
-export class InvalidAlertType extends Schema.TaggedErrorClass<InvalidAlertType>()(
-  "InvalidAlertType",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidAlertType extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidAlertType>()("InvalidAlertType", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 17004 }],
 ) {}
-T.applyErrorMatchers(InvalidAlertType, [{ code: 17004 }]);
 
-export class InvalidRoute extends Schema.TaggedErrorClass<InvalidRoute>()(
-  "InvalidRoute",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidRoute extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidRoute>()("InvalidRoute", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7003 }],
 ) {}
-T.applyErrorMatchers(InvalidRoute, [{ code: 7003 }]);
 
-export class InvalidSilence extends Schema.TaggedErrorClass<InvalidSilence>()(
-  "InvalidSilence",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidSilence extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidSilence>()("InvalidSilence", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 0, message: { includes: "invalid silence" } }],
 ) {}
-T.applyErrorMatchers(InvalidSilence, [
-  { code: 0, message: { includes: "invalid silence" } },
-]);
 
-export class InvalidWebhookId extends Schema.TaggedErrorClass<InvalidWebhookId>()(
-  "InvalidWebhookId",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidWebhookId extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidWebhookId>()("InvalidWebhookId", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 0, message: { includes: "invalid Webhook ID" } }],
 ) {}
-T.applyErrorMatchers(InvalidWebhookId, [
-  { code: 0, message: { includes: "invalid Webhook ID" } },
-]);
 
-export class MechanismRequired extends Schema.TaggedErrorClass<MechanismRequired>()(
-  "MechanismRequired",
-  { code: Schema.Number, message: Schema.String },
+export class MechanismRequired extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<MechanismRequired>()("MechanismRequired", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 17102 }],
 ) {}
-T.applyErrorMatchers(MechanismRequired, [{ code: 17102 }]);
 
-export class PolicyNotFound extends Schema.TaggedErrorClass<PolicyNotFound>()(
-  "PolicyNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class PolicyNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<PolicyNotFound>()("PolicyNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 0, message: { includes: "Policy not found" } }],
 ) {}
-T.applyErrorMatchers(PolicyNotFound, [
-  { code: 0, message: { includes: "Policy not found" } },
-]);
 
-export class SilenceAlreadyExists extends Schema.TaggedErrorClass<SilenceAlreadyExists>()(
-  "SilenceAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class SilenceAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SilenceAlreadyExists>()("SilenceAlreadyExists", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 15000 }],
 ) {}
-T.applyErrorMatchers(SilenceAlreadyExists, [{ code: 15000 }]);
 
-export class SilenceNotFound extends Schema.TaggedErrorClass<SilenceNotFound>()(
-  "SilenceNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class SilenceNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SilenceNotFound>()("SilenceNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 0, message: { includes: "silence not found" } }],
 ) {}
-T.applyErrorMatchers(SilenceNotFound, [
-  { code: 0, message: { includes: "silence not found" } },
-]);
 
-export class WebhookNotFound extends Schema.TaggedErrorClass<WebhookNotFound>()(
-  "WebhookNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class WebhookNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<WebhookNotFound>()("WebhookNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 0, message: { includes: "Webhook not found" } }],
 ) {}
-T.applyErrorMatchers(WebhookNotFound, [
-  { code: 0, message: { includes: "Webhook not found" } },
-]);
 
-export class WebhookTestFailed extends Schema.TaggedErrorClass<WebhookTestFailed>()(
-  "WebhookTestFailed",
-  { code: Schema.Number, message: Schema.String },
+export class WebhookTestFailed extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<WebhookTestFailed>()("WebhookTestFailed", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 0, message: { includes: "Webhook test failed" } }],
 ) {}
-T.applyErrorMatchers(WebhookTestFailed, [
-  { code: 0, message: { includes: "Webhook test failed" } },
-]);
 
 // =============================================================================
 // AvailableAlert

--- a/packages/cloudflare/src/services/api-gateway.ts
+++ b/packages/cloudflare/src/services/api-gateway.ts
@@ -17,59 +17,77 @@ import { UploadableSchema } from "../schemas.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class InvalidObjectIdentifier extends Schema.TaggedErrorClass<InvalidObjectIdentifier>()(
-  "InvalidObjectIdentifier",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidObjectIdentifier extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidObjectIdentifier>()(
+    "InvalidObjectIdentifier",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 7003 }],
 ) {}
-T.applyErrorMatchers(InvalidObjectIdentifier, [{ code: 7003 }]);
 
-export class LabelAlreadyExists extends Schema.TaggedErrorClass<LabelAlreadyExists>()(
-  "LabelAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class LabelAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<LabelAlreadyExists>()("LabelAlreadyExists", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 70009 }],
 ) {}
-T.applyErrorMatchers(LabelAlreadyExists, [{ code: 70009 }]);
 
-export class LabelNotFound extends Schema.TaggedErrorClass<LabelNotFound>()(
-  "LabelNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class LabelNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<LabelNotFound>()("LabelNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 70014 }],
 ) {}
-T.applyErrorMatchers(LabelNotFound, [{ code: 70014 }]);
 
-export class NotEntitled extends Schema.TaggedErrorClass<NotEntitled>()(
-  "NotEntitled",
-  { code: Schema.Number, message: Schema.String },
+export class NotEntitled extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<NotEntitled>()("NotEntitled", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10403 }, { code: 10404 }],
 ) {}
-T.applyErrorMatchers(NotEntitled, [{ code: 10403 }, { code: 10404 }]);
 
-export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
-  code: Schema.Number,
-  message: Schema.String,
-}) {}
-T.applyErrorMatchers(NotFound, [{ status: 404 }]);
-
-export class OperationNotFound extends Schema.TaggedErrorClass<OperationNotFound>()(
-  "OperationNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class NotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<NotFound>()("NotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(OperationNotFound, [{ code: 10404 }]);
 
-export class SchemaNotFound extends Schema.TaggedErrorClass<SchemaNotFound>()(
-  "SchemaNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class OperationNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<OperationNotFound>()("OperationNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10404 }],
 ) {}
-T.applyErrorMatchers(SchemaNotFound, [{ code: 19400 }]);
 
-export class ZonePurged extends Schema.TaggedErrorClass<ZonePurged>()(
-  "ZonePurged",
-  { code: Schema.Number, message: Schema.String },
+export class SchemaNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SchemaNotFound>()("SchemaNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 19400 }],
 ) {}
-T.applyErrorMatchers(ZonePurged, [{ code: 10410 }]);
+
+export class ZonePurged extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ZonePurged>()("ZonePurged", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10410 }],
+) {}
 
 // =============================================================================
 // Configuration

--- a/packages/cloudflare/src/services/argo.ts
+++ b/packages/cloudflare/src/services/argo.ts
@@ -16,31 +16,37 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class InvalidObjectIdentifier extends Schema.TaggedErrorClass<InvalidObjectIdentifier>()(
-  "InvalidObjectIdentifier",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidObjectIdentifier extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidObjectIdentifier>()(
+    "InvalidObjectIdentifier",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 7003 }],
 ) {}
-T.applyErrorMatchers(InvalidObjectIdentifier, [{ code: 7003 }]);
 
-export class NotAuthorized extends Schema.TaggedErrorClass<NotAuthorized>()(
-  "NotAuthorized",
-  { code: Schema.Number, message: Schema.String },
+export class NotAuthorized extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<NotAuthorized>()("NotAuthorized", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1015 }],
 ) {}
-T.applyErrorMatchers(NotAuthorized, [{ code: 1015 }]);
 
-export class ZoneNotFound extends Schema.TaggedErrorClass<ZoneNotFound>()(
-  "ZoneNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class ZoneNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ZoneNotFound>()("ZoneNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404, message: { includes: "Invalid or missing zone" } }],
 ) {}
-T.applyErrorMatchers(ZoneNotFound, [
-  { status: 404, message: { includes: "Invalid or missing zone" } },
-]);
 
 // =============================================================================
 // SmartRouting

--- a/packages/cloudflare/src/services/bot-management.ts
+++ b/packages/cloudflare/src/services/bot-management.ts
@@ -16,11 +16,13 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
 // =============================================================================
 // BotManagement

--- a/packages/cloudflare/src/services/cache.ts
+++ b/packages/cloudflare/src/services/cache.ts
@@ -16,34 +16,40 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class OriginCloudRegionNotFound extends Schema.TaggedErrorClass<OriginCloudRegionNotFound>()(
-  "OriginCloudRegionNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class OriginCloudRegionNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<OriginCloudRegionNotFound>()(
+    "OriginCloudRegionNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(OriginCloudRegionNotFound, [{ status: 404 }]);
 
-export class SettingUnavailableForPlan extends Schema.TaggedErrorClass<SettingUnavailableForPlan>()(
-  "SettingUnavailableForPlan",
-  { code: Schema.Number, message: Schema.String },
+export class SettingUnavailableForPlan extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SettingUnavailableForPlan>()(
+    "SettingUnavailableForPlan",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [
+    { status: 403, message: { includes: "not available for your plan" } },
+    { code: 1135, message: { includes: "not available for your plan" } },
+  ],
 ) {}
-T.applyErrorMatchers(SettingUnavailableForPlan, [
-  { status: 403, message: { includes: "not available for your plan" } },
-  { code: 1135, message: { includes: "not available for your plan" } },
-]);
 
-export class VariantsNotConfigured extends Schema.TaggedErrorClass<VariantsNotConfigured>()(
-  "VariantsNotConfigured",
-  { code: Schema.Number, message: Schema.String },
+export class VariantsNotConfigured extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<VariantsNotConfigured>()("VariantsNotConfigured", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404, message: { includes: "zone setting does not exist" } }],
 ) {}
-T.applyErrorMatchers(VariantsNotConfigured, [
-  { status: 404, message: { includes: "zone setting does not exist" } },
-]);
 
 // =============================================================================
 // Cache

--- a/packages/cloudflare/src/services/calls.ts
+++ b/packages/cloudflare/src/services/calls.ts
@@ -16,23 +16,29 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class CallsAppNotFound extends Schema.TaggedErrorClass<CallsAppNotFound>()(
-  "CallsAppNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class CallsAppNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<CallsAppNotFound>()("CallsAppNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 20007 }],
 ) {}
-T.applyErrorMatchers(CallsAppNotFound, [{ code: 20007 }]);
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class TurnKeyNotFound extends Schema.TaggedErrorClass<TurnKeyNotFound>()(
-  "TurnKeyNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class TurnKeyNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<TurnKeyNotFound>()("TurnKeyNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 20008 }],
 ) {}
-T.applyErrorMatchers(TurnKeyNotFound, [{ code: 20008 }]);
 
 // =============================================================================
 // Sfu

--- a/packages/cloudflare/src/services/certificate-authorities.ts
+++ b/packages/cloudflare/src/services/certificate-authorities.ts
@@ -16,11 +16,13 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
 // =============================================================================
 // HostnameAssociation

--- a/packages/cloudflare/src/services/client-certificates.ts
+++ b/packages/cloudflare/src/services/client-certificates.ts
@@ -16,28 +16,32 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class ClientCertificateAlreadyRevoked extends Schema.TaggedErrorClass<ClientCertificateAlreadyRevoked>()(
-  "ClientCertificateAlreadyRevoked",
-  { code: Schema.Number, message: Schema.String },
+export class ClientCertificateAlreadyRevoked extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ClientCertificateAlreadyRevoked>()(
+    "ClientCertificateAlreadyRevoked",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1407, message: { includes: "already deleted" } }],
 ) {}
-T.applyErrorMatchers(ClientCertificateAlreadyRevoked, [
-  { code: 1407, message: { includes: "already deleted" } },
-]);
 
-export class ClientCertificateNotFound extends Schema.TaggedErrorClass<ClientCertificateNotFound>()(
-  "ClientCertificateNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class ClientCertificateNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ClientCertificateNotFound>()(
+    "ClientCertificateNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [
+    { code: 1415, message: { includes: "Invalid Certificate ID" } },
+    { status: 404 },
+  ],
 ) {}
-T.applyErrorMatchers(ClientCertificateNotFound, [
-  { code: 1415, message: { includes: "Invalid Certificate ID" } },
-  { status: 404 },
-]);
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
 // =============================================================================
 // ClientCertificate

--- a/packages/cloudflare/src/services/cloud-connector.ts
+++ b/packages/cloudflare/src/services/cloud-connector.ts
@@ -16,19 +16,21 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class CloudConnectorRulesNotFound extends Schema.TaggedErrorClass<CloudConnectorRulesNotFound>()(
-  "CloudConnectorRulesNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class CloudConnectorRulesNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<CloudConnectorRulesNotFound>()(
+    "CloudConnectorRulesNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 10003, message: { includes: "could not find entrypoint ruleset" } }],
 ) {}
-T.applyErrorMatchers(CloudConnectorRulesNotFound, [
-  { code: 10003, message: { includes: "could not find entrypoint ruleset" } },
-]);
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
 // =============================================================================
 // Rule

--- a/packages/cloudflare/src/services/cloudforce-one.ts
+++ b/packages/cloudflare/src/services/cloudforce-one.ts
@@ -17,11 +17,13 @@ import { UploadableSchema } from "../schemas.ts";
 // Errors
 // =============================================================================
 
-export class ScanConfigNotFound extends Schema.TaggedErrorClass<ScanConfigNotFound>()(
-  "ScanConfigNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class ScanConfigNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ScanConfigNotFound>()("ScanConfigNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(ScanConfigNotFound, [{ status: 404 }]);
 
 // =============================================================================
 // BinaryStorage

--- a/packages/cloudflare/src/services/connectivity.ts
+++ b/packages/cloudflare/src/services/connectivity.ts
@@ -16,33 +16,37 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class VpcServiceNameAlreadyExists extends Schema.TaggedErrorClass<VpcServiceNameAlreadyExists>()(
-  "VpcServiceNameAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class VpcServiceNameAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<VpcServiceNameAlreadyExists>()(
+    "VpcServiceNameAlreadyExists",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 5101, message: { includes: "already exists" } }],
 ) {}
-T.applyErrorMatchers(VpcServiceNameAlreadyExists, [
-  { code: 5101, message: { includes: "already exists" } },
-]);
 
-export class VpcServiceNotFound extends Schema.TaggedErrorClass<VpcServiceNotFound>()(
-  "VpcServiceNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class VpcServiceNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<VpcServiceNotFound>()("VpcServiceNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 5104 }],
 ) {}
-T.applyErrorMatchers(VpcServiceNotFound, [{ code: 5104 }]);
 
-export class VpcTunnelNotFound extends Schema.TaggedErrorClass<VpcTunnelNotFound>()(
-  "VpcTunnelNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class VpcTunnelNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<VpcTunnelNotFound>()("VpcTunnelNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 5101, message: { includes: "Tunnel ID Not Found" } }],
 ) {}
-T.applyErrorMatchers(VpcTunnelNotFound, [
-  { code: 5101, message: { includes: "Tunnel ID Not Found" } },
-]);
 
 // =============================================================================
 // DirectoryService

--- a/packages/cloudflare/src/services/containers.ts
+++ b/packages/cloudflare/src/services/containers.ts
@@ -17,41 +17,50 @@ import { SensitiveString } from "../sensitive.ts";
 // Errors
 // =============================================================================
 
-export class ContainerApplicationNotFound extends Schema.TaggedErrorClass<ContainerApplicationNotFound>()(
-  "ContainerApplicationNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class ContainerApplicationNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ContainerApplicationNotFound>()(
+    "ContainerApplicationNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [
+    { code: 1609, message: { includes: "Container application not found" } },
+    { code: 1609, message: { includes: "APPLICATION_NOT_FOUND" } },
+  ],
 ) {}
-T.applyErrorMatchers(ContainerApplicationNotFound, [
-  { code: 1609, message: { includes: "Container application not found" } },
-  { code: 1609, message: { includes: "APPLICATION_NOT_FOUND" } },
-]);
 
-export class DurableObjectAlreadyHasApplication extends Schema.TaggedErrorClass<DurableObjectAlreadyHasApplication>()(
-  "DurableObjectAlreadyHasApplication",
-  { code: Schema.Number, message: Schema.String },
+export class DurableObjectAlreadyHasApplication extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DurableObjectAlreadyHasApplication>()(
+    "DurableObjectAlreadyHasApplication",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [
+    {
+      code: 1608,
+      message: { includes: "DURABLE_OBJECT_ALREADY_HAS_APPLICATION" },
+    },
+  ],
 ) {}
-T.applyErrorMatchers(DurableObjectAlreadyHasApplication, [
-  {
-    code: 1608,
-    message: { includes: "DURABLE_OBJECT_ALREADY_HAS_APPLICATION" },
-  },
-]);
 
-export class DurableObjectNotContainerEnabled extends Schema.TaggedErrorClass<DurableObjectNotContainerEnabled>()(
-  "DurableObjectNotContainerEnabled",
-  { code: Schema.Number, message: Schema.String },
+export class DurableObjectNotContainerEnabled extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DurableObjectNotContainerEnabled>()(
+    "DurableObjectNotContainerEnabled",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [
+    {
+      code: 1607,
+      message: { includes: "DURABLE_OBJECT_NOT_CONTAINER_ENABLED" },
+    },
+  ],
 ) {}
-T.applyErrorMatchers(DurableObjectNotContainerEnabled, [
-  { code: 1607, message: { includes: "DURABLE_OBJECT_NOT_CONTAINER_ENABLED" } },
-]);
 
-export class InvalidRoute extends Schema.TaggedErrorClass<InvalidRoute>()(
-  "InvalidRoute",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidRoute extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidRoute>()("InvalidRoute", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7003, message: { includes: "Could not route" } }],
 ) {}
-T.applyErrorMatchers(InvalidRoute, [
-  { code: 7003, message: { includes: "Could not route" } },
-]);
 
 // =============================================================================
 // ContainerApplication

--- a/packages/cloudflare/src/services/content-scanning.ts
+++ b/packages/cloudflare/src/services/content-scanning.ts
@@ -16,27 +16,29 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class ContentScanningNotEnabled extends Schema.TaggedErrorClass<ContentScanningNotEnabled>()(
-  "ContentScanningNotEnabled",
-  { code: Schema.Number, message: Schema.String },
+export class ContentScanningNotEnabled extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ContentScanningNotEnabled>()(
+    "ContentScanningNotEnabled",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 400, message: { includes: "File Upload Scan not enabled" } }],
 ) {}
-T.applyErrorMatchers(ContentScanningNotEnabled, [
-  { status: 400, message: { includes: "File Upload Scan not enabled" } },
-]);
 
-export class ContentScanningNotEntitled extends Schema.TaggedErrorClass<ContentScanningNotEntitled>()(
-  "ContentScanningNotEntitled",
-  { code: Schema.Number, message: Schema.String },
+export class ContentScanningNotEntitled extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ContentScanningNotEntitled>()(
+    "ContentScanningNotEntitled",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 400, message: { includes: "not entitled" } }],
 ) {}
-T.applyErrorMatchers(ContentScanningNotEntitled, [
-  { status: 400, message: { includes: "not entitled" } },
-]);
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
 // =============================================================================
 // ContentScanning

--- a/packages/cloudflare/src/services/custom-certificates.ts
+++ b/packages/cloudflare/src/services/custom-certificates.ts
@@ -16,34 +16,40 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class CustomCertificateNotFound extends Schema.TaggedErrorClass<CustomCertificateNotFound>()(
-  "CustomCertificateNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class CustomCertificateNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<CustomCertificateNotFound>()(
+    "CustomCertificateNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [
+    { status: 404 },
+    { code: 1002, message: { includes: "Invalid certificate" } },
+  ],
 ) {}
-T.applyErrorMatchers(CustomCertificateNotFound, [
-  { status: 404 },
-  { code: 1002, message: { includes: "Invalid certificate" } },
-]);
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class PlanLevelNotAllowed extends Schema.TaggedErrorClass<PlanLevelNotAllowed>()(
-  "PlanLevelNotAllowed",
-  { code: Schema.Number, message: Schema.String },
+export class PlanLevelNotAllowed extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<PlanLevelNotAllowed>()("PlanLevelNotAllowed", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1011 }],
 ) {}
-T.applyErrorMatchers(PlanLevelNotAllowed, [{ code: 1011 }]);
 
-export class ZoneNotFound extends Schema.TaggedErrorClass<ZoneNotFound>()(
-  "ZoneNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class ZoneNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ZoneNotFound>()("ZoneNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 400, message: { includes: "Cannot find a valid zone" } }],
 ) {}
-T.applyErrorMatchers(ZoneNotFound, [
-  { status: 400, message: { includes: "Cannot find a valid zone" } },
-]);
 
 // =============================================================================
 // CustomCertificate

--- a/packages/cloudflare/src/services/custom-hostnames.ts
+++ b/packages/cloudflare/src/services/custom-hostnames.ts
@@ -16,35 +16,45 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class CustomHostnameNotFound extends Schema.TaggedErrorClass<CustomHostnameNotFound>()(
-  "CustomHostnameNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class CustomHostnameNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<CustomHostnameNotFound>()("CustomHostnameNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1436 }, { status: 404 }],
 ) {}
-T.applyErrorMatchers(CustomHostnameNotFound, [{ code: 1436 }, { status: 404 }]);
 
-export class FallbackOriginNotFound extends Schema.TaggedErrorClass<FallbackOriginNotFound>()(
-  "FallbackOriginNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class FallbackOriginNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<FallbackOriginNotFound>()("FallbackOriginNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(FallbackOriginNotFound, [{ status: 404 }]);
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class SaasAccessNotGranted extends Schema.TaggedErrorClass<SaasAccessNotGranted>()(
-  "SaasAccessNotGranted",
-  { code: Schema.Number, message: Schema.String },
+export class SaasAccessNotGranted extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SaasAccessNotGranted>()("SaasAccessNotGranted", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1456 }],
 ) {}
-T.applyErrorMatchers(SaasAccessNotGranted, [{ code: 1456 }]);
 
-export class SaasQuotaNotAllocated extends Schema.TaggedErrorClass<SaasQuotaNotAllocated>()(
-  "SaasQuotaNotAllocated",
-  { code: Schema.Number, message: Schema.String },
+export class SaasQuotaNotAllocated extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SaasQuotaNotAllocated>()("SaasQuotaNotAllocated", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1404, status: 403 }],
 ) {}
-T.applyErrorMatchers(SaasQuotaNotAllocated, [{ code: 1404, status: 403 }]);
 
 // =============================================================================
 // CertificatePackCertificate

--- a/packages/cloudflare/src/services/custom-nameservers.ts
+++ b/packages/cloudflare/src/services/custom-nameservers.ts
@@ -16,33 +16,37 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class CustomNameserverAlreadyExists extends Schema.TaggedErrorClass<CustomNameserverAlreadyExists>()(
-  "CustomNameserverAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class CustomNameserverAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<CustomNameserverAlreadyExists>()(
+    "CustomNameserverAlreadyExists",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ message: { includes: "already exist" } }],
 ) {}
-T.applyErrorMatchers(CustomNameserverAlreadyExists, [
-  { message: { includes: "already exist" } },
-]);
 
-export class CustomNameserverNotFound extends Schema.TaggedErrorClass<CustomNameserverNotFound>()(
-  "CustomNameserverNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class CustomNameserverNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<CustomNameserverNotFound>()(
+    "CustomNameserverNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(CustomNameserverNotFound, [{ status: 404 }]);
 
-export class CustomNameserversNotEnabled extends Schema.TaggedErrorClass<CustomNameserversNotEnabled>()(
-  "CustomNameserversNotEnabled",
-  { code: Schema.Number, message: Schema.String },
+export class CustomNameserversNotEnabled extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<CustomNameserversNotEnabled>()(
+    "CustomNameserversNotEnabled",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1002, message: { includes: "not enabled" } }],
 ) {}
-T.applyErrorMatchers(CustomNameserversNotEnabled, [
-  { code: 1002, message: { includes: "not enabled" } },
-]);
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
 // =============================================================================
 // CustomNameserver

--- a/packages/cloudflare/src/services/d1.ts
+++ b/packages/cloudflare/src/services/d1.ts
@@ -16,59 +16,77 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class DatabaseAlreadyExists extends Schema.TaggedErrorClass<DatabaseAlreadyExists>()(
-  "DatabaseAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class DatabaseAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DatabaseAlreadyExists>()("DatabaseAlreadyExists", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7502 }],
 ) {}
-T.applyErrorMatchers(DatabaseAlreadyExists, [{ code: 7502 }]);
 
-export class DatabaseNotFound extends Schema.TaggedErrorClass<DatabaseNotFound>()(
-  "DatabaseNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class DatabaseNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DatabaseNotFound>()("DatabaseNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7404 }],
 ) {}
-T.applyErrorMatchers(DatabaseNotFound, [{ code: 7404 }]);
 
-export class InternalError extends Schema.TaggedErrorClass<InternalError>()(
-  "InternalError",
-  { code: Schema.Number, message: Schema.String },
+export class InternalError extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InternalError>()("InternalError", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7500 }],
 ) {}
-T.applyErrorMatchers(InternalError, [{ code: 7500 }]);
 
-export class InvalidObjectIdentifier extends Schema.TaggedErrorClass<InvalidObjectIdentifier>()(
-  "InvalidObjectIdentifier",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidObjectIdentifier extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidObjectIdentifier>()(
+    "InvalidObjectIdentifier",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 7003 }],
 ) {}
-T.applyErrorMatchers(InvalidObjectIdentifier, [{ code: 7003 }]);
 
-export class InvalidProperty extends Schema.TaggedErrorClass<InvalidProperty>()(
-  "InvalidProperty",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidProperty extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidProperty>()("InvalidProperty", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7400 }],
 ) {}
-T.applyErrorMatchers(InvalidProperty, [{ code: 7400 }]);
 
-export class InvalidRequest extends Schema.TaggedErrorClass<InvalidRequest>()(
-  "InvalidRequest",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidRequest extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidRequest>()("InvalidRequest", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7400 }],
 ) {}
-T.applyErrorMatchers(InvalidRequest, [{ code: 7400 }]);
 
-export class NoHistoryAvailable extends Schema.TaggedErrorClass<NoHistoryAvailable>()(
-  "NoHistoryAvailable",
-  { code: Schema.Number, message: Schema.String },
+export class NoHistoryAvailable extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<NoHistoryAvailable>()("NoHistoryAvailable", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7500 }],
 ) {}
-T.applyErrorMatchers(NoHistoryAvailable, [{ code: 7500 }]);
 
-export class TimestampTooOld extends Schema.TaggedErrorClass<TimestampTooOld>()(
-  "TimestampTooOld",
-  { code: Schema.Number, message: Schema.String },
+export class TimestampTooOld extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<TimestampTooOld>()("TimestampTooOld", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7400 }],
 ) {}
-T.applyErrorMatchers(TimestampTooOld, [{ code: 7400 }]);
 
-export class UnknownError extends Schema.TaggedErrorClass<UnknownError>()(
-  "UnknownError",
-  { code: Schema.Number, message: Schema.String },
+export class UnknownError extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<UnknownError>()("UnknownError", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 0 }],
 ) {}
-T.applyErrorMatchers(UnknownError, [{ code: 0 }]);
 
 // =============================================================================
 // BookmarkDatabaseTimeTravel

--- a/packages/cloudflare/src/services/ddos-protection.ts
+++ b/packages/cloudflare/src/services/ddos-protection.ts
@@ -16,47 +16,61 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class AdvancedTcpProtectionNotEntitled extends Schema.TaggedErrorClass<AdvancedTcpProtectionNotEntitled>()(
-  "AdvancedTcpProtectionNotEntitled",
-  { code: Schema.Number, message: Schema.String },
+export class AdvancedTcpProtectionNotEntitled extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<AdvancedTcpProtectionNotEntitled>()(
+    "AdvancedTcpProtectionNotEntitled",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 8888 }],
 ) {}
-T.applyErrorMatchers(AdvancedTcpProtectionNotEntitled, [{ code: 8888 }]);
 
-export class AllowlistEntryNotFound extends Schema.TaggedErrorClass<AllowlistEntryNotFound>()(
-  "AllowlistEntryNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class AllowlistEntryNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<AllowlistEntryNotFound>()("AllowlistEntryNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(AllowlistEntryNotFound, [{ status: 404 }]);
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class SynProtectionFilterNotFound extends Schema.TaggedErrorClass<SynProtectionFilterNotFound>()(
-  "SynProtectionFilterNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class SynProtectionFilterNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SynProtectionFilterNotFound>()(
+    "SynProtectionFilterNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(SynProtectionFilterNotFound, [{ status: 404 }]);
 
-export class SynProtectionRuleNotFound extends Schema.TaggedErrorClass<SynProtectionRuleNotFound>()(
-  "SynProtectionRuleNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class SynProtectionRuleNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SynProtectionRuleNotFound>()(
+    "SynProtectionRuleNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(SynProtectionRuleNotFound, [{ status: 404 }]);
 
-export class TcpFlowProtectionFilterNotFound extends Schema.TaggedErrorClass<TcpFlowProtectionFilterNotFound>()(
-  "TcpFlowProtectionFilterNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class TcpFlowProtectionFilterNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<TcpFlowProtectionFilterNotFound>()(
+    "TcpFlowProtectionFilterNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(TcpFlowProtectionFilterNotFound, [{ status: 404 }]);
 
-export class TcpFlowProtectionRuleNotFound extends Schema.TaggedErrorClass<TcpFlowProtectionRuleNotFound>()(
-  "TcpFlowProtectionRuleNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class TcpFlowProtectionRuleNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<TcpFlowProtectionRuleNotFound>()(
+    "TcpFlowProtectionRuleNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(TcpFlowProtectionRuleNotFound, [{ status: 404 }]);
 
 // =============================================================================
 // AdvancedTcpProtectionAllowlist

--- a/packages/cloudflare/src/services/diagnostics.ts
+++ b/packages/cloudflare/src/services/diagnostics.ts
@@ -16,23 +16,29 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class EndpointHealthcheckNotFound extends Schema.TaggedErrorClass<EndpointHealthcheckNotFound>()(
-  "EndpointHealthcheckNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class EndpointHealthcheckNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<EndpointHealthcheckNotFound>()(
+    "EndpointHealthcheckNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1022 }],
 ) {}
-T.applyErrorMatchers(EndpointHealthcheckNotFound, [{ code: 1022 }]);
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class InvalidHealthcheckEndpoint extends Schema.TaggedErrorClass<InvalidHealthcheckEndpoint>()(
-  "InvalidHealthcheckEndpoint",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidHealthcheckEndpoint extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidHealthcheckEndpoint>()(
+    "InvalidHealthcheckEndpoint",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1002 }],
 ) {}
-T.applyErrorMatchers(InvalidHealthcheckEndpoint, [{ code: 1002 }]);
 
 // =============================================================================
 // EndpointHealthcheck

--- a/packages/cloudflare/src/services/dns-firewall.ts
+++ b/packages/cloudflare/src/services/dns-firewall.ts
@@ -16,23 +16,29 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class DnsFirewallNotEntitled extends Schema.TaggedErrorClass<DnsFirewallNotEntitled>()(
-  "DnsFirewallNotEntitled",
-  { code: Schema.Number, message: Schema.String },
+export class DnsFirewallNotEntitled extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DnsFirewallNotEntitled>()("DnsFirewallNotEntitled", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10101 }],
 ) {}
-T.applyErrorMatchers(DnsFirewallNotEntitled, [{ code: 10101 }]);
 
-export class DnsFirewallNotFound extends Schema.TaggedErrorClass<DnsFirewallNotFound>()(
-  "DnsFirewallNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class DnsFirewallNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DnsFirewallNotFound>()("DnsFirewallNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 11001 }],
 ) {}
-T.applyErrorMatchers(DnsFirewallNotFound, [{ code: 11001 }]);
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
 // =============================================================================
 // AnalyticReport

--- a/packages/cloudflare/src/services/dns.ts
+++ b/packages/cloudflare/src/services/dns.ts
@@ -17,75 +17,97 @@ import { SensitiveString } from "../sensitive.ts";
 // Errors
 // =============================================================================
 
-export class AclNotFound extends Schema.TaggedErrorClass<AclNotFound>()(
-  "AclNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class AclNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<AclNotFound>()("AclNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(AclNotFound, [{ status: 404 }]);
 
-export class DnsRecordAlreadyExists extends Schema.TaggedErrorClass<DnsRecordAlreadyExists>()(
-  "DnsRecordAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class DnsRecordAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DnsRecordAlreadyExists>()("DnsRecordAlreadyExists", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [
+    { code: 81057 },
+    { code: 81058 },
+    { status: 400, message: { includes: "identical record already exists" } },
+  ],
 ) {}
-T.applyErrorMatchers(DnsRecordAlreadyExists, [
-  { code: 81057 },
-  { code: 81058 },
-  { status: 400, message: { includes: "identical record already exists" } },
-]);
 
-export class DnsSettingNotAvailable extends Schema.TaggedErrorClass<DnsSettingNotAvailable>()(
-  "DnsSettingNotAvailable",
-  { code: Schema.Number, message: Schema.String },
+export class DnsSettingNotAvailable extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DnsSettingNotAvailable>()("DnsSettingNotAvailable", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1003 }],
 ) {}
-T.applyErrorMatchers(DnsSettingNotAvailable, [{ code: 1003 }]);
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class IncomingZoneTransferNotFound extends Schema.TaggedErrorClass<IncomingZoneTransferNotFound>()(
-  "IncomingZoneTransferNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class IncomingZoneTransferNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<IncomingZoneTransferNotFound>()(
+    "IncomingZoneTransferNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(IncomingZoneTransferNotFound, [{ status: 404 }]);
 
-export class InternalDnsNotAvailable extends Schema.TaggedErrorClass<InternalDnsNotAvailable>()(
-  "InternalDnsNotAvailable",
-  { code: Schema.Number, message: Schema.String },
+export class InternalDnsNotAvailable extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InternalDnsNotAvailable>()(
+    "InternalDnsNotAvailable",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1029 }],
 ) {}
-T.applyErrorMatchers(InternalDnsNotAvailable, [{ code: 1029 }]);
 
-export class OutgoingZoneTransferNotFound extends Schema.TaggedErrorClass<OutgoingZoneTransferNotFound>()(
-  "OutgoingZoneTransferNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class OutgoingZoneTransferNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<OutgoingZoneTransferNotFound>()(
+    "OutgoingZoneTransferNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(OutgoingZoneTransferNotFound, [{ status: 404 }]);
 
-export class OutgoingZoneTransfersNotAllowed extends Schema.TaggedErrorClass<OutgoingZoneTransfersNotAllowed>()(
-  "OutgoingZoneTransfersNotAllowed",
-  { code: Schema.Number, message: Schema.String },
+export class OutgoingZoneTransfersNotAllowed extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<OutgoingZoneTransfersNotAllowed>()(
+    "OutgoingZoneTransfersNotAllowed",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 401 }],
 ) {}
-T.applyErrorMatchers(OutgoingZoneTransfersNotAllowed, [{ status: 401 }]);
 
-export class PeerNotFound extends Schema.TaggedErrorClass<PeerNotFound>()(
-  "PeerNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class PeerNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<PeerNotFound>()("PeerNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(PeerNotFound, [{ status: 404 }]);
 
-export class TsigNotFound extends Schema.TaggedErrorClass<TsigNotFound>()(
-  "TsigNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class TsigNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<TsigNotFound>()("TsigNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(TsigNotFound, [{ status: 404 }]);
 
-export class ViewNotFound extends Schema.TaggedErrorClass<ViewNotFound>()(
-  "ViewNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class ViewNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ViewNotFound>()("ViewNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1015 }, { status: 404 }],
 ) {}
-T.applyErrorMatchers(ViewNotFound, [{ code: 1015 }, { status: 404 }]);
 
 // =============================================================================
 // AnalyticReport

--- a/packages/cloudflare/src/services/durable-objects.ts
+++ b/packages/cloudflare/src/services/durable-objects.ts
@@ -16,23 +16,29 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class InvalidIdentifier extends Schema.TaggedErrorClass<InvalidIdentifier>()(
-  "InvalidIdentifier",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidIdentifier extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidIdentifier>()("InvalidIdentifier", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7003 }],
 ) {}
-T.applyErrorMatchers(InvalidIdentifier, [{ code: 7003 }]);
 
-export class MalformedParameter extends Schema.TaggedErrorClass<MalformedParameter>()(
-  "MalformedParameter",
-  { code: Schema.Number, message: Schema.String },
+export class MalformedParameter extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<MalformedParameter>()("MalformedParameter", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10077 }],
 ) {}
-T.applyErrorMatchers(MalformedParameter, [{ code: 10077 }]);
 
-export class NamespaceNotFound extends Schema.TaggedErrorClass<NamespaceNotFound>()(
-  "NamespaceNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class NamespaceNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<NamespaceNotFound>()("NamespaceNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10066 }],
 ) {}
-T.applyErrorMatchers(NamespaceNotFound, [{ code: 10066 }]);
 
 // =============================================================================
 // Namespace

--- a/packages/cloudflare/src/services/email-routing.ts
+++ b/packages/cloudflare/src/services/email-routing.ts
@@ -16,23 +16,29 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class DestinationNotVerified extends Schema.TaggedErrorClass<DestinationNotVerified>()(
-  "DestinationNotVerified",
-  { code: Schema.Number, message: Schema.String },
+export class DestinationNotVerified extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DestinationNotVerified>()("DestinationNotVerified", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 2054 }],
 ) {}
-T.applyErrorMatchers(DestinationNotVerified, [{ code: 2054 }]);
 
-export class EmailRoutingRuleNotFound extends Schema.TaggedErrorClass<EmailRoutingRuleNotFound>()(
-  "EmailRoutingRuleNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class EmailRoutingRuleNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<EmailRoutingRuleNotFound>()(
+    "EmailRoutingRuleNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(EmailRoutingRuleNotFound, [{ status: 404 }]);
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
 // =============================================================================
 // Address

--- a/packages/cloudflare/src/services/email-security.ts
+++ b/packages/cloudflare/src/services/email-security.ts
@@ -16,52 +16,66 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class AllowPolicyNotFound extends Schema.TaggedErrorClass<AllowPolicyNotFound>()(
-  "AllowPolicyNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class AllowPolicyNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<AllowPolicyNotFound>()("AllowPolicyNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(AllowPolicyNotFound, [{ status: 404 }]);
 
-export class BlockSenderNotFound extends Schema.TaggedErrorClass<BlockSenderNotFound>()(
-  "BlockSenderNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class BlockSenderNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<BlockSenderNotFound>()("BlockSenderNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(BlockSenderNotFound, [{ status: 404 }]);
 
-export class EmailSecurityDomainNotFound extends Schema.TaggedErrorClass<EmailSecurityDomainNotFound>()(
-  "EmailSecurityDomainNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class EmailSecurityDomainNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<EmailSecurityDomainNotFound>()(
+    "EmailSecurityDomainNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(EmailSecurityDomainNotFound, [{ status: 404 }]);
 
-export class EmailSecurityNotEntitled extends Schema.TaggedErrorClass<EmailSecurityNotEntitled>()(
-  "EmailSecurityNotEntitled",
-  { code: Schema.Number, message: Schema.String },
+export class EmailSecurityNotEntitled extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<EmailSecurityNotEntitled>()(
+    "EmailSecurityNotEntitled",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [
+    {
+      status: 403,
+      message: { includes: "not available in the current subscription" },
+    },
+  ],
 ) {}
-T.applyErrorMatchers(EmailSecurityNotEntitled, [
-  {
-    status: 403,
-    message: { includes: "not available in the current subscription" },
-  },
-]);
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class ImpersonationRegistryEntryNotFound extends Schema.TaggedErrorClass<ImpersonationRegistryEntryNotFound>()(
-  "ImpersonationRegistryEntryNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class ImpersonationRegistryEntryNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ImpersonationRegistryEntryNotFound>()(
+    "ImpersonationRegistryEntryNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(ImpersonationRegistryEntryNotFound, [{ status: 404 }]);
 
-export class TrustedDomainNotFound extends Schema.TaggedErrorClass<TrustedDomainNotFound>()(
-  "TrustedDomainNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class TrustedDomainNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<TrustedDomainNotFound>()("TrustedDomainNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(TrustedDomainNotFound, [{ status: 404 }]);
 
 // =============================================================================
 // Investigate

--- a/packages/cloudflare/src/services/email-sending.ts
+++ b/packages/cloudflare/src/services/email-sending.ts
@@ -16,23 +16,29 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class SendingSubdomainAlreadyExists extends Schema.TaggedErrorClass<SendingSubdomainAlreadyExists>()(
-  "SendingSubdomainAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class SendingSubdomainAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SendingSubdomainAlreadyExists>()(
+    "SendingSubdomainAlreadyExists",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 2040 }],
 ) {}
-T.applyErrorMatchers(SendingSubdomainAlreadyExists, [{ code: 2040 }]);
 
-export class SendingSubdomainNotFound extends Schema.TaggedErrorClass<SendingSubdomainNotFound>()(
-  "SendingSubdomainNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class SendingSubdomainNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SendingSubdomainNotFound>()(
+    "SendingSubdomainNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 2033 }],
 ) {}
-T.applyErrorMatchers(SendingSubdomainNotFound, [{ code: 2033 }]);
 
 // =============================================================================
 // EmailSending

--- a/packages/cloudflare/src/services/firewall.ts
+++ b/packages/cloudflare/src/services/firewall.ts
@@ -16,68 +16,77 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class AccessRuleNotFound extends Schema.TaggedErrorClass<AccessRuleNotFound>()(
-  "AccessRuleNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class AccessRuleNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<AccessRuleNotFound>()("AccessRuleNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10001, message: { includes: "not_found" } }, { status: 404 }],
 ) {}
-T.applyErrorMatchers(AccessRuleNotFound, [
-  { code: 10001, message: { includes: "not_found" } },
-  { status: 404 },
-]);
 
-export class DuplicateAccessRule extends Schema.TaggedErrorClass<DuplicateAccessRule>()(
-  "DuplicateAccessRule",
-  { code: Schema.Number, message: Schema.String },
+export class DuplicateAccessRule extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DuplicateAccessRule>()("DuplicateAccessRule", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10009, message: { includes: "duplicate_of_existing" } }],
 ) {}
-T.applyErrorMatchers(DuplicateAccessRule, [
-  { code: 10009, message: { includes: "duplicate_of_existing" } },
-]);
 
-export class DuplicateLockdown extends Schema.TaggedErrorClass<DuplicateLockdown>()(
-  "DuplicateLockdown",
-  { code: Schema.Number, message: Schema.String },
+export class DuplicateLockdown extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DuplicateLockdown>()("DuplicateLockdown", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [
+    {
+      code: 10009,
+      message: { includes: "zonelockdown.api.duplicate_of_existing" },
+    },
+  ],
 ) {}
-T.applyErrorMatchers(DuplicateLockdown, [
-  {
-    code: 10009,
-    message: { includes: "zonelockdown.api.duplicate_of_existing" },
-  },
-]);
 
-export class DuplicateUaRule extends Schema.TaggedErrorClass<DuplicateUaRule>()(
-  "DuplicateUaRule",
-  { code: Schema.Number, message: Schema.String },
+export class DuplicateUaRule extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DuplicateUaRule>()("DuplicateUaRule", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [
+    {
+      code: 10009,
+      message: { includes: "firewalluablock.api.duplicate_of_existing" },
+    },
+  ],
 ) {}
-T.applyErrorMatchers(DuplicateUaRule, [
-  {
-    code: 10009,
-    message: { includes: "firewalluablock.api.duplicate_of_existing" },
-  },
-]);
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class LockdownNotFound extends Schema.TaggedErrorClass<LockdownNotFound>()(
-  "LockdownNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class LockdownNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<LockdownNotFound>()("LockdownNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [
+    { code: 10001, message: { includes: "zonelockdown.api.not_found" } },
+    { status: 404 },
+  ],
 ) {}
-T.applyErrorMatchers(LockdownNotFound, [
-  { code: 10001, message: { includes: "zonelockdown.api.not_found" } },
-  { status: 404 },
-]);
 
-export class UaRuleNotFound extends Schema.TaggedErrorClass<UaRuleNotFound>()(
-  "UaRuleNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class UaRuleNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<UaRuleNotFound>()("UaRuleNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [
+    { code: 10001, message: { includes: "firewalluablock.api.not_found" } },
+    { status: 404 },
+  ],
 ) {}
-T.applyErrorMatchers(UaRuleNotFound, [
-  { code: 10001, message: { includes: "firewalluablock.api.not_found" } },
-  { status: 404 },
-]);
 
 // =============================================================================
 // AccessRule

--- a/packages/cloudflare/src/services/flagship.ts
+++ b/packages/cloudflare/src/services/flagship.ts
@@ -16,29 +16,29 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class FlagshipAppNotFound extends Schema.TaggedErrorClass<FlagshipAppNotFound>()(
-  "FlagshipAppNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class FlagshipAppNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<FlagshipAppNotFound>()("FlagshipAppNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404, message: { includes: "App not found" } }],
 ) {}
-T.applyErrorMatchers(FlagshipAppNotFound, [
-  { status: 404, message: { includes: "App not found" } },
-]);
 
-export class FlagshipFlagAlreadyExists extends Schema.TaggedErrorClass<FlagshipFlagAlreadyExists>()(
-  "FlagshipFlagAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class FlagshipFlagAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<FlagshipFlagAlreadyExists>()(
+    "FlagshipFlagAlreadyExists",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 409, message: { includes: "Flag already exists" } }],
 ) {}
-T.applyErrorMatchers(FlagshipFlagAlreadyExists, [
-  { status: 409, message: { includes: "Flag already exists" } },
-]);
 
-export class FlagshipFlagNotFound extends Schema.TaggedErrorClass<FlagshipFlagNotFound>()(
-  "FlagshipFlagNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class FlagshipFlagNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<FlagshipFlagNotFound>()("FlagshipFlagNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404, message: { includes: "Flag not found" } }],
 ) {}
-T.applyErrorMatchers(FlagshipFlagNotFound, [
-  { status: 404, message: { includes: "Flag not found" } },
-]);
 
 // =============================================================================
 // App

--- a/packages/cloudflare/src/services/fraud.ts
+++ b/packages/cloudflare/src/services/fraud.ts
@@ -16,17 +16,21 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class FraudDetectionNotEntitled extends Schema.TaggedErrorClass<FraudDetectionNotEntitled>()(
-  "FraudDetectionNotEntitled",
-  { code: Schema.Number, message: Schema.String },
+export class FraudDetectionNotEntitled extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<FraudDetectionNotEntitled>()(
+    "FraudDetectionNotEntitled",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 10400 }],
 ) {}
-T.applyErrorMatchers(FraudDetectionNotEntitled, [{ code: 10400 }]);
 
 // =============================================================================
 // Fraud

--- a/packages/cloudflare/src/services/google-tag-gateway.ts
+++ b/packages/cloudflare/src/services/google-tag-gateway.ts
@@ -16,11 +16,13 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
 // =============================================================================
 // Config

--- a/packages/cloudflare/src/services/healthchecks.ts
+++ b/packages/cloudflare/src/services/healthchecks.ts
@@ -16,25 +16,29 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class HealthcheckAlreadyExists extends Schema.TaggedErrorClass<HealthcheckAlreadyExists>()(
-  "HealthcheckAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class HealthcheckAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<HealthcheckAlreadyExists>()(
+    "HealthcheckAlreadyExists",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ message: { includes: "already exists" } }],
 ) {}
-T.applyErrorMatchers(HealthcheckAlreadyExists, [
-  { message: { includes: "already exists" } },
-]);
 
-export class HealthcheckNotFound extends Schema.TaggedErrorClass<HealthcheckNotFound>()(
-  "HealthcheckNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class HealthcheckNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<HealthcheckNotFound>()("HealthcheckNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(HealthcheckNotFound, [{ status: 404 }]);
 
 // =============================================================================
 // Healthcheck

--- a/packages/cloudflare/src/services/hostnames.ts
+++ b/packages/cloudflare/src/services/hostnames.ts
@@ -16,23 +16,29 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class AdvancedCertificateManagerRequired extends Schema.TaggedErrorClass<AdvancedCertificateManagerRequired>()(
-  "AdvancedCertificateManagerRequired",
-  { code: Schema.Number, message: Schema.String },
+export class AdvancedCertificateManagerRequired extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<AdvancedCertificateManagerRequired>()(
+    "AdvancedCertificateManagerRequired",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1450 }],
 ) {}
-T.applyErrorMatchers(AdvancedCertificateManagerRequired, [{ code: 1450 }]);
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class HostnameTlsSettingNotFound extends Schema.TaggedErrorClass<HostnameTlsSettingNotFound>()(
-  "HostnameTlsSettingNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class HostnameTlsSettingNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<HostnameTlsSettingNotFound>()(
+    "HostnameTlsSettingNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(HostnameTlsSettingNotFound, [{ status: 404 }]);
 
 // =============================================================================
 // SettingTl

--- a/packages/cloudflare/src/services/hyperdrive.ts
+++ b/packages/cloudflare/src/services/hyperdrive.ts
@@ -17,41 +17,48 @@ import { SensitiveString } from "../sensitive.ts";
 // Errors
 // =============================================================================
 
-export class HyperdriveConfigNotFound extends Schema.TaggedErrorClass<HyperdriveConfigNotFound>()(
-  "HyperdriveConfigNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class HyperdriveConfigNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<HyperdriveConfigNotFound>()(
+    "HyperdriveConfigNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 2006 }, { status: 404 }],
 ) {}
-T.applyErrorMatchers(HyperdriveConfigNotFound, [
-  { code: 2006 },
-  { status: 404 },
-]);
 
-export class InvalidHyperdriveConfig extends Schema.TaggedErrorClass<InvalidHyperdriveConfig>()(
-  "InvalidHyperdriveConfig",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidHyperdriveConfig extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidHyperdriveConfig>()(
+    "InvalidHyperdriveConfig",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 2007 }],
 ) {}
-T.applyErrorMatchers(InvalidHyperdriveConfig, [{ code: 2007 }]);
 
-export class InvalidObjectIdentifier extends Schema.TaggedErrorClass<InvalidObjectIdentifier>()(
-  "InvalidObjectIdentifier",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidObjectIdentifier extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidObjectIdentifier>()(
+    "InvalidObjectIdentifier",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 7003 }],
 ) {}
-T.applyErrorMatchers(InvalidObjectIdentifier, [{ code: 7003 }]);
 
-export class MethodNotAllowed extends Schema.TaggedErrorClass<MethodNotAllowed>()(
-  "MethodNotAllowed",
-  { code: Schema.Number, message: Schema.String },
+export class MethodNotAllowed extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<MethodNotAllowed>()("MethodNotAllowed", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [
+    { code: 10000, message: { includes: "method not allowed" } },
+    { code: 10405, message: { includes: "Method not allowed" } },
+  ],
 ) {}
-T.applyErrorMatchers(MethodNotAllowed, [
-  { code: 10000, message: { includes: "method not allowed" } },
-  { code: 10405, message: { includes: "Method not allowed" } },
-]);
 
-export class PrivateHostNotAllowed extends Schema.TaggedErrorClass<PrivateHostNotAllowed>()(
-  "PrivateHostNotAllowed",
-  { code: Schema.Number, message: Schema.String },
+export class PrivateHostNotAllowed extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<PrivateHostNotAllowed>()("PrivateHostNotAllowed", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 2009 }],
 ) {}
-T.applyErrorMatchers(PrivateHostNotAllowed, [{ code: 2009 }]);
 
 // =============================================================================
 // Config

--- a/packages/cloudflare/src/services/iam.ts
+++ b/packages/cloudflare/src/services/iam.ts
@@ -16,49 +16,53 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class InvalidMember extends Schema.TaggedErrorClass<InvalidMember>()(
-  "InvalidMember",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidMember extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidMember>()("InvalidMember", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 400 }],
 ) {}
-T.applyErrorMatchers(InvalidMember, [{ code: 400 }]);
 
-export class ResourceGroupNotFound extends Schema.TaggedErrorClass<ResourceGroupNotFound>()(
-  "ResourceGroupNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class ResourceGroupNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ResourceGroupNotFound>()("ResourceGroupNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 404, message: { includes: "Resource group" } }],
 ) {}
-T.applyErrorMatchers(ResourceGroupNotFound, [
-  { code: 404, message: { includes: "Resource group" } },
-]);
 
-export class UserGroupMemberNotFound extends Schema.TaggedErrorClass<UserGroupMemberNotFound>()(
-  "UserGroupMemberNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class UserGroupMemberNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<UserGroupMemberNotFound>()(
+    "UserGroupMemberNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 404, message: { includes: "not found in user group" } }],
 ) {}
-T.applyErrorMatchers(UserGroupMemberNotFound, [
-  { code: 404, message: { includes: "not found in user group" } },
-]);
 
-export class UserGroupNameInUse extends Schema.TaggedErrorClass<UserGroupNameInUse>()(
-  "UserGroupNameInUse",
-  { code: Schema.Number, message: Schema.String },
+export class UserGroupNameInUse extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<UserGroupNameInUse>()("UserGroupNameInUse", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 400, message: { includes: "already in use" } }],
 ) {}
-T.applyErrorMatchers(UserGroupNameInUse, [
-  { code: 400, message: { includes: "already in use" } },
-]);
 
-export class UserGroupNotFound extends Schema.TaggedErrorClass<UserGroupNotFound>()(
-  "UserGroupNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class UserGroupNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<UserGroupNotFound>()("UserGroupNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 404, message: { includes: "User group" } }],
 ) {}
-T.applyErrorMatchers(UserGroupNotFound, [
-  { code: 404, message: { includes: "User group" } },
-]);
 
 // =============================================================================
 // OauthClient

--- a/packages/cloudflare/src/services/images.ts
+++ b/packages/cloudflare/src/services/images.ts
@@ -17,56 +17,69 @@ import { UploadableSchema } from "../schemas.ts";
 // Errors
 // =============================================================================
 
-export class ImageAlreadyExists extends Schema.TaggedErrorClass<ImageAlreadyExists>()(
-  "ImageAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class ImageAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ImageAlreadyExists>()("ImageAlreadyExists", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 5409 }],
 ) {}
-T.applyErrorMatchers(ImageAlreadyExists, [{ code: 5409 }]);
 
-export class ImageNotFound extends Schema.TaggedErrorClass<ImageNotFound>()(
-  "ImageNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class ImageNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ImageNotFound>()("ImageNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 5404 }],
 ) {}
-T.applyErrorMatchers(ImageNotFound, [{ code: 5404 }]);
 
-export class ImagesAccessNotEnabled extends Schema.TaggedErrorClass<ImagesAccessNotEnabled>()(
-  "ImagesAccessNotEnabled",
-  { code: Schema.Number, message: Schema.String },
+export class ImagesAccessNotEnabled extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ImagesAccessNotEnabled>()("ImagesAccessNotEnabled", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 5403 }],
 ) {}
-T.applyErrorMatchers(ImagesAccessNotEnabled, [{ code: 5403 }]);
 
-export class InvalidUploadFormat extends Schema.TaggedErrorClass<InvalidUploadFormat>()(
-  "InvalidUploadFormat",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidUploadFormat extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidUploadFormat>()("InvalidUploadFormat", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 5415 }],
 ) {}
-T.applyErrorMatchers(InvalidUploadFormat, [{ code: 5415 }]);
 
-export class KeyNotFound extends Schema.TaggedErrorClass<KeyNotFound>()(
-  "KeyNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class KeyNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<KeyNotFound>()("KeyNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 5404 }],
 ) {}
-T.applyErrorMatchers(KeyNotFound, [{ code: 5404 }]);
 
-export class VariantAlreadyExists extends Schema.TaggedErrorClass<VariantAlreadyExists>()(
-  "VariantAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class VariantAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<VariantAlreadyExists>()("VariantAlreadyExists", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 5409 }],
 ) {}
-T.applyErrorMatchers(VariantAlreadyExists, [{ code: 5409 }]);
 
-export class VariantNameNotAllowed extends Schema.TaggedErrorClass<VariantNameNotAllowed>()(
-  "VariantNameNotAllowed",
-  { code: Schema.Number, message: Schema.String },
+export class VariantNameNotAllowed extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<VariantNameNotAllowed>()("VariantNameNotAllowed", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 5400 }],
 ) {}
-T.applyErrorMatchers(VariantNameNotAllowed, [{ code: 5400 }]);
 
-export class VariantNotFound extends Schema.TaggedErrorClass<VariantNotFound>()(
-  "VariantNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class VariantNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<VariantNotFound>()("VariantNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 5401 }, { status: 404, message: { includes: "not found" } }],
 ) {}
-T.applyErrorMatchers(VariantNotFound, [
-  { code: 5401 },
-  { status: 404, message: { includes: "not found" } },
-]);
 
 // =============================================================================
 // V1

--- a/packages/cloudflare/src/services/intel.ts
+++ b/packages/cloudflare/src/services/intel.ts
@@ -16,30 +16,34 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class IndicatorFeedNotFound extends Schema.TaggedErrorClass<IndicatorFeedNotFound>()(
-  "IndicatorFeedNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class IndicatorFeedNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<IndicatorFeedNotFound>()("IndicatorFeedNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403, message: { includes: "does not exist" } }],
 ) {}
-T.applyErrorMatchers(IndicatorFeedNotFound, [
-  { status: 403, message: { includes: "does not exist" } },
-]);
 
-export class IndicatorFeedsNotEntitled extends Schema.TaggedErrorClass<IndicatorFeedsNotEntitled>()(
-  "IndicatorFeedsNotEntitled",
-  { code: Schema.Number, message: Schema.String },
+export class IndicatorFeedsNotEntitled extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<IndicatorFeedsNotEntitled>()(
+    "IndicatorFeedsNotEntitled",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [
+    {
+      status: 403,
+      message: { includes: "does not have permission to create a feed" },
+    },
+  ],
 ) {}
-T.applyErrorMatchers(IndicatorFeedsNotEntitled, [
-  {
-    status: 403,
-    message: { includes: "does not have permission to create a feed" },
-  },
-]);
 
 // =============================================================================
 // Asn

--- a/packages/cloudflare/src/services/keyless-certificates.ts
+++ b/packages/cloudflare/src/services/keyless-certificates.ts
@@ -16,27 +16,29 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class KeylessCertificateNotFound extends Schema.TaggedErrorClass<KeylessCertificateNotFound>()(
-  "KeylessCertificateNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class KeylessCertificateNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<KeylessCertificateNotFound>()(
+    "KeylessCertificateNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1005, message: { includes: "Invalid or missing Keyless SSL" } }],
 ) {}
-T.applyErrorMatchers(KeylessCertificateNotFound, [
-  { code: 1005, message: { includes: "Invalid or missing Keyless SSL" } },
-]);
 
-export class KeylessSslNotAvailable extends Schema.TaggedErrorClass<KeylessSslNotAvailable>()(
-  "KeylessSslNotAvailable",
-  { code: Schema.Number, message: Schema.String },
+export class KeylessSslNotAvailable extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<KeylessSslNotAvailable>()("KeylessSslNotAvailable", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1067, message: { includes: "Keyless SSL is not available" } }],
 ) {}
-T.applyErrorMatchers(KeylessSslNotAvailable, [
-  { code: 1067, message: { includes: "Keyless SSL is not available" } },
-]);
 
 // =============================================================================
 // KeylessCertificate

--- a/packages/cloudflare/src/services/kv.ts
+++ b/packages/cloudflare/src/services/kv.ts
@@ -17,62 +17,80 @@ import { UploadableSchema } from "../schemas.ts";
 // Errors
 // =============================================================================
 
-export class InvalidExpirationTtl extends Schema.TaggedErrorClass<InvalidExpirationTtl>()(
-  "InvalidExpirationTtl",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidExpirationTtl extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidExpirationTtl>()("InvalidExpirationTtl", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10034 }],
 ) {}
-T.applyErrorMatchers(InvalidExpirationTtl, [{ code: 10034 }]);
 
-export class InvalidObjectIdentifier extends Schema.TaggedErrorClass<InvalidObjectIdentifier>()(
-  "InvalidObjectIdentifier",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidObjectIdentifier extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidObjectIdentifier>()(
+    "InvalidObjectIdentifier",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 7003 }],
 ) {}
-T.applyErrorMatchers(InvalidObjectIdentifier, [{ code: 7003 }]);
 
-export class InvalidRequestBody extends Schema.TaggedErrorClass<InvalidRequestBody>()(
-  "InvalidRequestBody",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidRequestBody extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidRequestBody>()("InvalidRequestBody", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10012 }],
 ) {}
-T.applyErrorMatchers(InvalidRequestBody, [{ code: 10012 }]);
 
-export class KeyNotFound extends Schema.TaggedErrorClass<KeyNotFound>()(
-  "KeyNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class KeyNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<KeyNotFound>()("KeyNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10009 }],
 ) {}
-T.applyErrorMatchers(KeyNotFound, [{ code: 10009 }]);
 
-export class MethodNotAllowed extends Schema.TaggedErrorClass<MethodNotAllowed>()(
-  "MethodNotAllowed",
-  { code: Schema.Number, message: Schema.String },
+export class MethodNotAllowed extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<MethodNotAllowed>()("MethodNotAllowed", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [
+    { code: 10405, message: { includes: "not allowed" } },
+    { code: 10000, message: { includes: "not allowed" } },
+  ],
 ) {}
-T.applyErrorMatchers(MethodNotAllowed, [
-  { code: 10405, message: { includes: "not allowed" } },
-  { code: 10000, message: { includes: "not allowed" } },
-]);
 
-export class MinimumKeysRequired extends Schema.TaggedErrorClass<MinimumKeysRequired>()(
-  "MinimumKeysRequired",
-  { code: Schema.Number, message: Schema.String },
+export class MinimumKeysRequired extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<MinimumKeysRequired>()("MinimumKeysRequired", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10029 }],
 ) {}
-T.applyErrorMatchers(MinimumKeysRequired, [{ code: 10029 }]);
 
-export class NamespaceNotFound extends Schema.TaggedErrorClass<NamespaceNotFound>()(
-  "NamespaceNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class NamespaceNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<NamespaceNotFound>()("NamespaceNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10013 }],
 ) {}
-T.applyErrorMatchers(NamespaceNotFound, [{ code: 10013 }]);
 
-export class NamespaceTitleAlreadyExists extends Schema.TaggedErrorClass<NamespaceTitleAlreadyExists>()(
-  "NamespaceTitleAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class NamespaceTitleAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<NamespaceTitleAlreadyExists>()(
+    "NamespaceTitleAlreadyExists",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 10014 }],
 ) {}
-T.applyErrorMatchers(NamespaceTitleAlreadyExists, [{ code: 10014 }]);
 
-export class TitleRequired extends Schema.TaggedErrorClass<TitleRequired>()(
-  "TitleRequired",
-  { code: Schema.Number, message: Schema.String },
+export class TitleRequired extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<TitleRequired>()("TitleRequired", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10019 }],
 ) {}
-T.applyErrorMatchers(TitleRequired, [{ code: 10019 }]);
 
 // =============================================================================
 // Namespace

--- a/packages/cloudflare/src/services/leaked-credential-checks.ts
+++ b/packages/cloudflare/src/services/leaked-credential-checks.ts
@@ -17,29 +17,37 @@ import { SensitiveString } from "../sensitive.ts";
 // Errors
 // =============================================================================
 
-export class DetectionNotFound extends Schema.TaggedErrorClass<DetectionNotFound>()(
-  "DetectionNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class DetectionNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DetectionNotFound>()("DetectionNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 11002 }],
 ) {}
-T.applyErrorMatchers(DetectionNotFound, [{ code: 11002 }]);
 
-export class DetectionQuotaExceeded extends Schema.TaggedErrorClass<DetectionQuotaExceeded>()(
-  "DetectionQuotaExceeded",
-  { code: Schema.Number, message: Schema.String },
+export class DetectionQuotaExceeded extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DetectionQuotaExceeded>()("DetectionQuotaExceeded", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 50001 }],
 ) {}
-T.applyErrorMatchers(DetectionQuotaExceeded, [{ code: 50001 }]);
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class LeakedCredentialChecksDisabled extends Schema.TaggedErrorClass<LeakedCredentialChecksDisabled>()(
-  "LeakedCredentialChecksDisabled",
-  { code: Schema.Number, message: Schema.String },
+export class LeakedCredentialChecksDisabled extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<LeakedCredentialChecksDisabled>()(
+    "LeakedCredentialChecksDisabled",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 11001 }],
 ) {}
-T.applyErrorMatchers(LeakedCredentialChecksDisabled, [{ code: 11001 }]);
 
 // =============================================================================
 // Detection

--- a/packages/cloudflare/src/services/load-balancers.ts
+++ b/packages/cloudflare/src/services/load-balancers.ts
@@ -16,91 +16,101 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class LoadBalancerNotFound extends Schema.TaggedErrorClass<LoadBalancerNotFound>()(
-  "LoadBalancerNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class LoadBalancerNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<LoadBalancerNotFound>()("LoadBalancerNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1001 }],
 ) {}
-T.applyErrorMatchers(LoadBalancerNotFound, [{ code: 1001 }]);
 
-export class LoadBalancingNotEnabledForZone extends Schema.TaggedErrorClass<LoadBalancingNotEnabledForZone>()(
-  "LoadBalancingNotEnabledForZone",
-  { code: Schema.Number, message: Schema.String },
+export class LoadBalancingNotEnabledForZone extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<LoadBalancingNotEnabledForZone>()(
+    "LoadBalancingNotEnabledForZone",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1002, message: { includes: "load balancing not enabled" } }],
 ) {}
-T.applyErrorMatchers(LoadBalancingNotEnabledForZone, [
-  { code: 1002, message: { includes: "load balancing not enabled" } },
-]);
 
-export class MonitorGroupInUse extends Schema.TaggedErrorClass<MonitorGroupInUse>()(
-  "MonitorGroupInUse",
-  { code: Schema.Number, message: Schema.String },
+export class MonitorGroupInUse extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<MonitorGroupInUse>()("MonitorGroupInUse", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1002, message: { includes: "still referenced" } }],
 ) {}
-T.applyErrorMatchers(MonitorGroupInUse, [
-  { code: 1002, message: { includes: "still referenced" } },
-]);
 
-export class MonitorGroupNotFound extends Schema.TaggedErrorClass<MonitorGroupNotFound>()(
-  "MonitorGroupNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class MonitorGroupNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<MonitorGroupNotFound>()("MonitorGroupNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1001 }],
 ) {}
-T.applyErrorMatchers(MonitorGroupNotFound, [{ code: 1001 }]);
 
-export class MonitorGroupsNotEnabled extends Schema.TaggedErrorClass<MonitorGroupsNotEnabled>()(
-  "MonitorGroupsNotEnabled",
-  { code: Schema.Number, message: Schema.String },
+export class MonitorGroupsNotEnabled extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<MonitorGroupsNotEnabled>()(
+    "MonitorGroupsNotEnabled",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1002, message: { includes: "monitor groups not enabled" } }],
 ) {}
-T.applyErrorMatchers(MonitorGroupsNotEnabled, [
-  { code: 1002, message: { includes: "monitor groups not enabled" } },
-]);
 
-export class MonitorIntervalOutOfRange extends Schema.TaggedErrorClass<MonitorIntervalOutOfRange>()(
-  "MonitorIntervalOutOfRange",
-  { code: Schema.Number, message: Schema.String },
+export class MonitorIntervalOutOfRange extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<MonitorIntervalOutOfRange>()(
+    "MonitorIntervalOutOfRange",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1002, message: { includes: "interval is not in range" } }],
 ) {}
-T.applyErrorMatchers(MonitorIntervalOutOfRange, [
-  { code: 1002, message: { includes: "interval is not in range" } },
-]);
 
-export class MonitorInUse extends Schema.TaggedErrorClass<MonitorInUse>()(
-  "MonitorInUse",
-  { code: Schema.Number, message: Schema.String },
+export class MonitorInUse extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<MonitorInUse>()("MonitorInUse", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1002, message: { includes: "still referenced" } }],
 ) {}
-T.applyErrorMatchers(MonitorInUse, [
-  { code: 1002, message: { includes: "still referenced" } },
-]);
 
-export class MonitorNotFound extends Schema.TaggedErrorClass<MonitorNotFound>()(
-  "MonitorNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class MonitorNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<MonitorNotFound>()("MonitorNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1001 }],
 ) {}
-T.applyErrorMatchers(MonitorNotFound, [{ code: 1001 }]);
 
-export class PoolAccessFailed extends Schema.TaggedErrorClass<PoolAccessFailed>()(
-  "PoolAccessFailed",
-  { code: Schema.Number, message: Schema.String },
+export class PoolAccessFailed extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<PoolAccessFailed>()("PoolAccessFailed", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1002, message: { includes: "Access Failed" } }],
 ) {}
-T.applyErrorMatchers(PoolAccessFailed, [
-  { code: 1002, message: { includes: "Access Failed" } },
-]);
 
-export class PoolInUse extends Schema.TaggedErrorClass<PoolInUse>()(
-  "PoolInUse",
-  { code: Schema.Number, message: Schema.String },
+export class PoolInUse extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<PoolInUse>()("PoolInUse", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1002, message: { includes: "still referenced" } }],
 ) {}
-T.applyErrorMatchers(PoolInUse, [
-  { code: 1002, message: { includes: "still referenced" } },
-]);
 
-export class PoolNotFound extends Schema.TaggedErrorClass<PoolNotFound>()(
-  "PoolNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class PoolNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<PoolNotFound>()("PoolNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1001 }],
 ) {}
-T.applyErrorMatchers(PoolNotFound, [{ code: 1001 }]);
 
 // =============================================================================
 // LoadBalancer

--- a/packages/cloudflare/src/services/logpush.ts
+++ b/packages/cloudflare/src/services/logpush.ts
@@ -16,26 +16,29 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class JobNotFound extends Schema.TaggedErrorClass<JobNotFound>()(
-  "JobNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class JobNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<JobNotFound>()("JobNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1000, message: { includes: "job not found" } }, { status: 404 }],
 ) {}
-T.applyErrorMatchers(JobNotFound, [
-  { code: 1000, message: { includes: "job not found" } },
-  { status: 404 },
-]);
 
-export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
-  code: Schema.Number,
-  message: Schema.String,
-}) {}
-T.applyErrorMatchers(NotFound, [{ status: 404 }]);
+export class NotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<NotFound>()("NotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404 }],
+) {}
 
 // =============================================================================
 // DatasetField

--- a/packages/cloudflare/src/services/logs.ts
+++ b/packages/cloudflare/src/services/logs.ts
@@ -16,25 +16,29 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class CmbConfigNotFound extends Schema.TaggedErrorClass<CmbConfigNotFound>()(
-  "CmbConfigNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class CmbConfigNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<CmbConfigNotFound>()("CmbConfigNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(CmbConfigNotFound, [{ status: 404 }]);
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class LogsControlNotAuthorized extends Schema.TaggedErrorClass<LogsControlNotAuthorized>()(
-  "LogsControlNotAuthorized",
-  { code: Schema.Number, message: Schema.String },
+export class LogsControlNotAuthorized extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<LogsControlNotAuthorized>()(
+    "LogsControlNotAuthorized",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 10000, message: { includes: "Unauthorized" } }],
 ) {}
-T.applyErrorMatchers(LogsControlNotAuthorized, [
-  { code: 10000, message: { includes: "Unauthorized" } },
-]);
 
 // =============================================================================
 // ControlCmbConfig

--- a/packages/cloudflare/src/services/magic-cloud-networking.ts
+++ b/packages/cloudflare/src/services/magic-cloud-networking.ts
@@ -16,35 +16,45 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class CatalogSyncNotFound extends Schema.TaggedErrorClass<CatalogSyncNotFound>()(
-  "CatalogSyncNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class CatalogSyncNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<CatalogSyncNotFound>()("CatalogSyncNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(CatalogSyncNotFound, [{ status: 404 }]);
 
-export class CloudIntegrationNotFound extends Schema.TaggedErrorClass<CloudIntegrationNotFound>()(
-  "CloudIntegrationNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class CloudIntegrationNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<CloudIntegrationNotFound>()(
+    "CloudIntegrationNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(CloudIntegrationNotFound, [{ status: 404 }]);
 
-export class FeatureNotEnabled extends Schema.TaggedErrorClass<FeatureNotEnabled>()(
-  "FeatureNotEnabled",
-  { code: Schema.Number, message: Schema.String },
+export class FeatureNotEnabled extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<FeatureNotEnabled>()("FeatureNotEnabled", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1012, status: 403 }],
 ) {}
-T.applyErrorMatchers(FeatureNotEnabled, [{ code: 1012, status: 403 }]);
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class OnRampNotFound extends Schema.TaggedErrorClass<OnRampNotFound>()(
-  "OnRampNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class OnRampNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<OnRampNotFound>()("OnRampNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(OnRampNotFound, [{ status: 404 }]);
 
 // =============================================================================
 // AllCloudIntegration

--- a/packages/cloudflare/src/services/magic-network-monitoring.ts
+++ b/packages/cloudflare/src/services/magic-network-monitoring.ts
@@ -16,58 +16,66 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class DuplicateMnmRuleName extends Schema.TaggedErrorClass<DuplicateMnmRuleName>()(
-  "DuplicateMnmRuleName",
-  { code: Schema.Number, message: Schema.String },
+export class DuplicateMnmRuleName extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DuplicateMnmRuleName>()("DuplicateMnmRuleName", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1008, message: { includes: "rule name must be unique" } }],
 ) {}
-T.applyErrorMatchers(DuplicateMnmRuleName, [
-  { code: 1008, message: { includes: "rule name must be unique" } },
-]);
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class InvalidMnmConfig extends Schema.TaggedErrorClass<InvalidMnmConfig>()(
-  "InvalidMnmConfig",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidMnmConfig extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidMnmConfig>()("InvalidMnmConfig", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1003 }],
 ) {}
-T.applyErrorMatchers(InvalidMnmConfig, [{ code: 1003 }]);
 
-export class MnmConfigAlreadyExists extends Schema.TaggedErrorClass<MnmConfigAlreadyExists>()(
-  "MnmConfigAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class MnmConfigAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<MnmConfigAlreadyExists>()("MnmConfigAlreadyExists", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1005, message: { includes: "already exists" } }],
 ) {}
-T.applyErrorMatchers(MnmConfigAlreadyExists, [
-  { code: 1005, message: { includes: "already exists" } },
-]);
 
-export class MnmConfigMissing extends Schema.TaggedErrorClass<MnmConfigMissing>()(
-  "MnmConfigMissing",
-  { code: Schema.Number, message: Schema.String },
+export class MnmConfigMissing extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<MnmConfigMissing>()("MnmConfigMissing", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [
+    {
+      code: 1008,
+      message: { includes: "without initial account configuration" },
+    },
+  ],
 ) {}
-T.applyErrorMatchers(MnmConfigMissing, [
-  {
-    code: 1008,
-    message: { includes: "without initial account configuration" },
-  },
-]);
 
-export class MnmConfigNotFound extends Schema.TaggedErrorClass<MnmConfigNotFound>()(
-  "MnmConfigNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class MnmConfigNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<MnmConfigNotFound>()("MnmConfigNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1004, message: { includes: "not found" } }],
 ) {}
-T.applyErrorMatchers(MnmConfigNotFound, [
-  { code: 1004, message: { includes: "not found" } },
-]);
 
-export class MnmRuleNotFound extends Schema.TaggedErrorClass<MnmRuleNotFound>()(
-  "MnmRuleNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class MnmRuleNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<MnmRuleNotFound>()("MnmRuleNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1009 }],
 ) {}
-T.applyErrorMatchers(MnmRuleNotFound, [{ code: 1009 }]);
 
 // =============================================================================
 // Config

--- a/packages/cloudflare/src/services/magic-transit.ts
+++ b/packages/cloudflare/src/services/magic-transit.ts
@@ -16,71 +16,93 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class AppNotFound extends Schema.TaggedErrorClass<AppNotFound>()(
-  "AppNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class AppNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<AppNotFound>()("AppNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(AppNotFound, [{ status: 404 }]);
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class GreTunnelNotFound extends Schema.TaggedErrorClass<GreTunnelNotFound>()(
-  "GreTunnelNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class GreTunnelNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<GreTunnelNotFound>()("GreTunnelNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1029 }],
 ) {}
-T.applyErrorMatchers(GreTunnelNotFound, [{ code: 1029 }]);
 
-export class IpsecTunnelNotFound extends Schema.TaggedErrorClass<IpsecTunnelNotFound>()(
-  "IpsecTunnelNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class IpsecTunnelNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<IpsecTunnelNotFound>()("IpsecTunnelNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1032 }],
 ) {}
-T.applyErrorMatchers(IpsecTunnelNotFound, [{ code: 1032 }]);
 
-export class MagicTransitNotOnboarded extends Schema.TaggedErrorClass<MagicTransitNotOnboarded>()(
-  "MagicTransitNotOnboarded",
-  { code: Schema.Number, message: Schema.String },
+export class MagicTransitNotOnboarded extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<MagicTransitNotOnboarded>()(
+    "MagicTransitNotOnboarded",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1012 }],
 ) {}
-T.applyErrorMatchers(MagicTransitNotOnboarded, [{ code: 1012 }]);
 
-export class MagicWanUnauthorized extends Schema.TaggedErrorClass<MagicWanUnauthorized>()(
-  "MagicWanUnauthorized",
-  { code: Schema.Number, message: Schema.String },
+export class MagicWanUnauthorized extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<MagicWanUnauthorized>()("MagicWanUnauthorized", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1025 }],
 ) {}
-T.applyErrorMatchers(MagicWanUnauthorized, [{ code: 1025 }]);
 
-export class RouteNotFound extends Schema.TaggedErrorClass<RouteNotFound>()(
-  "RouteNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class RouteNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<RouteNotFound>()("RouteNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1020 }],
 ) {}
-T.applyErrorMatchers(RouteNotFound, [{ code: 1020 }]);
 
-export class SiteAclNotFound extends Schema.TaggedErrorClass<SiteAclNotFound>()(
-  "SiteAclNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class SiteAclNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SiteAclNotFound>()("SiteAclNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(SiteAclNotFound, [{ status: 404 }]);
 
-export class SiteLanNotFound extends Schema.TaggedErrorClass<SiteLanNotFound>()(
-  "SiteLanNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class SiteLanNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SiteLanNotFound>()("SiteLanNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(SiteLanNotFound, [{ status: 404 }]);
 
-export class SiteNotFound extends Schema.TaggedErrorClass<SiteNotFound>()(
-  "SiteNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class SiteNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SiteNotFound>()("SiteNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(SiteNotFound, [{ status: 404 }]);
 
-export class SiteWanNotFound extends Schema.TaggedErrorClass<SiteWanNotFound>()(
-  "SiteWanNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class SiteWanNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SiteWanNotFound>()("SiteWanNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(SiteWanNotFound, [{ status: 404 }]);
 
 // =============================================================================
 // App

--- a/packages/cloudflare/src/services/managed-transforms.ts
+++ b/packages/cloudflare/src/services/managed-transforms.ts
@@ -16,11 +16,13 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
 // =============================================================================
 // ManagedTransform

--- a/packages/cloudflare/src/services/mtls-certificates.ts
+++ b/packages/cloudflare/src/services/mtls-certificates.ts
@@ -16,30 +16,32 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class CertificateAlreadyDeleted extends Schema.TaggedErrorClass<CertificateAlreadyDeleted>()(
-  "CertificateAlreadyDeleted",
-  { code: Schema.Number, message: Schema.String },
+export class CertificateAlreadyDeleted extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<CertificateAlreadyDeleted>()(
+    "CertificateAlreadyDeleted",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 400, message: { includes: "already deleted" } }],
 ) {}
-T.applyErrorMatchers(CertificateAlreadyDeleted, [
-  { status: 400, message: { includes: "already deleted" } },
-]);
 
-export class CertificateAlreadyExists extends Schema.TaggedErrorClass<CertificateAlreadyExists>()(
-  "CertificateAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class CertificateAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<CertificateAlreadyExists>()(
+    "CertificateAlreadyExists",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1471, message: { includes: "already exists" } }],
 ) {}
-T.applyErrorMatchers(CertificateAlreadyExists, [
-  { code: 1471, message: { includes: "already exists" } },
-]);
 
-export class CertificateNotFound extends Schema.TaggedErrorClass<CertificateNotFound>()(
-  "CertificateNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class CertificateNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<CertificateNotFound>()("CertificateNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [
+    { code: 1472, message: { includes: "Certificate not found" } },
+    { status: 404 },
+  ],
 ) {}
-T.applyErrorMatchers(CertificateNotFound, [
-  { code: 1472, message: { includes: "Certificate not found" } },
-  { status: 404 },
-]);
 
 // =============================================================================
 // Association

--- a/packages/cloudflare/src/services/network-interconnects.ts
+++ b/packages/cloudflare/src/services/network-interconnects.ts
@@ -16,11 +16,13 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
 // =============================================================================
 // Cni

--- a/packages/cloudflare/src/services/organizations.ts
+++ b/packages/cloudflare/src/services/organizations.ts
@@ -16,17 +16,21 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class OrganizationNotFound extends Schema.TaggedErrorClass<OrganizationNotFound>()(
-  "OrganizationNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class OrganizationNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<OrganizationNotFound>()("OrganizationNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(OrganizationNotFound, [{ status: 404 }]);
 
 // =============================================================================
 // BillingUsage

--- a/packages/cloudflare/src/services/origin-ca-certificates.ts
+++ b/packages/cloudflare/src/services/origin-ca-certificates.ts
@@ -16,35 +16,45 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class CertificateAlreadyRevoked extends Schema.TaggedErrorClass<CertificateAlreadyRevoked>()(
-  "CertificateAlreadyRevoked",
-  { code: Schema.Number, message: Schema.String },
+export class CertificateAlreadyRevoked extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<CertificateAlreadyRevoked>()(
+    "CertificateAlreadyRevoked",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1014 }],
 ) {}
-T.applyErrorMatchers(CertificateAlreadyRevoked, [{ code: 1014 }]);
 
-export class CertificateNotFound extends Schema.TaggedErrorClass<CertificateNotFound>()(
-  "CertificateNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class CertificateNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<CertificateNotFound>()("CertificateNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1101 }],
 ) {}
-T.applyErrorMatchers(CertificateNotFound, [{ code: 1101 }]);
 
-export class CertificateRevocationFailed extends Schema.TaggedErrorClass<CertificateRevocationFailed>()(
-  "CertificateRevocationFailed",
-  { code: Schema.Number, message: Schema.String },
+export class CertificateRevocationFailed extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<CertificateRevocationFailed>()(
+    "CertificateRevocationFailed",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1000 }],
 ) {}
-T.applyErrorMatchers(CertificateRevocationFailed, [{ code: 1000 }]);
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class HostnameNotAuthorized extends Schema.TaggedErrorClass<HostnameNotAuthorized>()(
-  "HostnameNotAuthorized",
-  { code: Schema.Number, message: Schema.String },
+export class HostnameNotAuthorized extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<HostnameNotAuthorized>()("HostnameNotAuthorized", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1010 }],
 ) {}
-T.applyErrorMatchers(HostnameNotAuthorized, [{ code: 1010 }]);
 
 // =============================================================================
 // OriginCaCertificate

--- a/packages/cloudflare/src/services/origin-post-quantum-encryption.ts
+++ b/packages/cloudflare/src/services/origin-post-quantum-encryption.ts
@@ -16,25 +16,29 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class InvalidSettingValue extends Schema.TaggedErrorClass<InvalidSettingValue>()(
-  "InvalidSettingValue",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidSettingValue extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidSettingValue>()("InvalidSettingValue", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1146, message: { includes: "origin_post_quantum_encryption" } }],
 ) {}
-T.applyErrorMatchers(InvalidSettingValue, [
-  { code: 1146, message: { includes: "origin_post_quantum_encryption" } },
-]);
 
-export class InvalidZoneIdentifier extends Schema.TaggedErrorClass<InvalidZoneIdentifier>()(
-  "InvalidZoneIdentifier",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidZoneIdentifier extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidZoneIdentifier>()("InvalidZoneIdentifier", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7003 }],
 ) {}
-T.applyErrorMatchers(InvalidZoneIdentifier, [{ code: 7003 }]);
 
 // =============================================================================
 // OriginPostQuantumEncryption

--- a/packages/cloudflare/src/services/origin-tls-client-auth.ts
+++ b/packages/cloudflare/src/services/origin-tls-client-auth.ts
@@ -17,115 +17,126 @@ import { SensitiveString } from "../sensitive.ts";
 // Errors
 // =============================================================================
 
-export class CertificateAlreadyDeleted extends Schema.TaggedErrorClass<CertificateAlreadyDeleted>()(
-  "CertificateAlreadyDeleted",
-  { code: Schema.Number, message: Schema.String },
+export class CertificateAlreadyDeleted extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<CertificateAlreadyDeleted>()(
+    "CertificateAlreadyDeleted",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 400, message: { includes: "already deleted" } }],
 ) {}
-T.applyErrorMatchers(CertificateAlreadyDeleted, [
-  { status: 400, message: { includes: "already deleted" } },
-]);
 
-export class CertificateAlreadyExists extends Schema.TaggedErrorClass<CertificateAlreadyExists>()(
-  "CertificateAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class CertificateAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<CertificateAlreadyExists>()(
+    "CertificateAlreadyExists",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1406, message: { includes: "already exists" } }],
 ) {}
-T.applyErrorMatchers(CertificateAlreadyExists, [
-  { code: 1406, message: { includes: "already exists" } },
-]);
 
-export class CertificateNotFound extends Schema.TaggedErrorClass<CertificateNotFound>()(
-  "CertificateNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class CertificateNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<CertificateNotFound>()("CertificateNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [
+    { code: 1552, message: { includes: "certificate not found" } },
+    { status: 404 },
+  ],
 ) {}
-T.applyErrorMatchers(CertificateNotFound, [
-  { code: 1552, message: { includes: "certificate not found" } },
-  { status: 404 },
-]);
 
-export class CertificatePendingDeletion extends Schema.TaggedErrorClass<CertificatePendingDeletion>()(
-  "CertificatePendingDeletion",
-  { code: Schema.Number, message: Schema.String },
+export class CertificatePendingDeletion extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<CertificatePendingDeletion>()(
+    "CertificatePendingDeletion",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1414, message: { includes: "pending deletion" } }],
 ) {}
-T.applyErrorMatchers(CertificatePendingDeletion, [
-  { code: 1414, message: { includes: "pending deletion" } },
-]);
 
-export class CertificatePendingDeployment extends Schema.TaggedErrorClass<CertificatePendingDeployment>()(
-  "CertificatePendingDeployment",
-  { code: Schema.Number, message: Schema.String },
+export class CertificatePendingDeployment extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<CertificatePendingDeployment>()(
+    "CertificatePendingDeployment",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1434, message: { includes: "pending deployment" } }],
 ) {}
-T.applyErrorMatchers(CertificatePendingDeployment, [
-  { code: 1434, message: { includes: "pending deployment" } },
-]);
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class HostnameAssociationNotFound extends Schema.TaggedErrorClass<HostnameAssociationNotFound>()(
-  "HostnameAssociationNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class HostnameAssociationNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<HostnameAssociationNotFound>()(
+    "HostnameAssociationNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [
+    {
+      code: 1553,
+      message: { includes: "setting for this hostname not found" },
+    },
+    { status: 404 },
+  ],
 ) {}
-T.applyErrorMatchers(HostnameAssociationNotFound, [
-  { code: 1553, message: { includes: "setting for this hostname not found" } },
-  { status: 404 },
-]);
 
-export class HostnameCertificateIdRequired extends Schema.TaggedErrorClass<HostnameCertificateIdRequired>()(
-  "HostnameCertificateIdRequired",
-  { code: Schema.Number, message: Schema.String },
+export class HostnameCertificateIdRequired extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<HostnameCertificateIdRequired>()(
+    "HostnameCertificateIdRequired",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1404, message: { includes: "Certificate ID required" } }],
 ) {}
-T.applyErrorMatchers(HostnameCertificateIdRequired, [
-  { code: 1404, message: { includes: "Certificate ID required" } },
-]);
 
-export class HostnameCertificateInUse extends Schema.TaggedErrorClass<HostnameCertificateInUse>()(
-  "HostnameCertificateInUse",
-  { code: Schema.Number, message: Schema.String },
+export class HostnameCertificateInUse extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<HostnameCertificateInUse>()(
+    "HostnameCertificateInUse",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1433, message: { includes: "in use" } }],
 ) {}
-T.applyErrorMatchers(HostnameCertificateInUse, [
-  { code: 1433, message: { includes: "in use" } },
-]);
 
-export class HostnameCertificateNotFound extends Schema.TaggedErrorClass<HostnameCertificateNotFound>()(
-  "HostnameCertificateNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class HostnameCertificateNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<HostnameCertificateNotFound>()(
+    "HostnameCertificateNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1552 }, { code: 1551 }, { status: 404 }],
 ) {}
-T.applyErrorMatchers(HostnameCertificateNotFound, [
-  { code: 1552 },
-  { code: 1551 },
-  { status: 404 },
-]);
 
-export class InvalidCertificate extends Schema.TaggedErrorClass<InvalidCertificate>()(
-  "InvalidCertificate",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidCertificate extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidCertificate>()("InvalidCertificate", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1408, message: { includes: "Unable to parse certificate" } }],
 ) {}
-T.applyErrorMatchers(InvalidCertificate, [
-  { code: 1408, message: { includes: "Unable to parse certificate" } },
-]);
 
-export class InvalidCertificateId extends Schema.TaggedErrorClass<InvalidCertificateId>()(
-  "InvalidCertificateId",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidCertificateId extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidCertificateId>()("InvalidCertificateId", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1415, message: { includes: "Invalid Certificate ID" } }],
 ) {}
-T.applyErrorMatchers(InvalidCertificateId, [
-  { code: 1415, message: { includes: "Invalid Certificate ID" } },
-]);
 
-export class InvalidHostnameConfig extends Schema.TaggedErrorClass<InvalidHostnameConfig>()(
-  "InvalidHostnameConfig",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidHostnameConfig extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidHostnameConfig>()("InvalidHostnameConfig", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1415 }],
 ) {}
-T.applyErrorMatchers(InvalidHostnameConfig, [{ code: 1415 }]);
 
-export class ZoneClientCertConflict extends Schema.TaggedErrorClass<ZoneClientCertConflict>()(
-  "ZoneClientCertConflict",
-  { code: Schema.Number, message: Schema.String },
+export class ZoneClientCertConflict extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ZoneClientCertConflict>()("ZoneClientCertConflict", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 409 }],
 ) {}
-T.applyErrorMatchers(ZoneClientCertConflict, [{ status: 409 }]);
 
 // =============================================================================
 // Hostname

--- a/packages/cloudflare/src/services/page-rules.ts
+++ b/packages/cloudflare/src/services/page-rules.ts
@@ -16,17 +16,21 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class PageRuleNotFound extends Schema.TaggedErrorClass<PageRuleNotFound>()(
-  "PageRuleNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class PageRuleNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<PageRuleNotFound>()("PageRuleNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(PageRuleNotFound, [{ status: 404 }]);
 
 // =============================================================================
 // PageRule

--- a/packages/cloudflare/src/services/page-shield.ts
+++ b/packages/cloudflare/src/services/page-shield.ts
@@ -16,41 +16,45 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class NotEntitled extends Schema.TaggedErrorClass<NotEntitled>()(
-  "NotEntitled",
-  { code: Schema.Number, message: Schema.String },
+export class NotEntitled extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<NotEntitled>()("NotEntitled", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403, message: { includes: "not entitled" } }],
 ) {}
-T.applyErrorMatchers(NotEntitled, [
-  { status: 403, message: { includes: "not entitled" } },
-]);
 
-export class PolicyNotFound extends Schema.TaggedErrorClass<PolicyNotFound>()(
-  "PolicyNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class PolicyNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<PolicyNotFound>()("PolicyNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404, message: { includes: "Could not find Policy" } }],
 ) {}
-T.applyErrorMatchers(PolicyNotFound, [
-  { status: 404, message: { includes: "Could not find Policy" } },
-]);
 
-export class PolicyQuotaExceeded extends Schema.TaggedErrorClass<PolicyQuotaExceeded>()(
-  "PolicyQuotaExceeded",
-  { code: Schema.Number, message: Schema.String },
-) {}
-T.applyErrorMatchers(PolicyQuotaExceeded, [
-  {
-    status: 400,
-    message: {
-      includes:
-        "exceeded the maximum number of rules in the phase http_response_page_shield",
+export class PolicyQuotaExceeded extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<PolicyQuotaExceeded>()("PolicyQuotaExceeded", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [
+    {
+      status: 400,
+      message: {
+        includes:
+          "exceeded the maximum number of rules in the phase http_response_page_shield",
+      },
     },
-  },
-]);
+  ],
+) {}
 
 // =============================================================================
 // Connection

--- a/packages/cloudflare/src/services/pages.ts
+++ b/packages/cloudflare/src/services/pages.ts
@@ -17,47 +17,61 @@ import { UploadableSchema } from "../schemas.ts";
 // Errors
 // =============================================================================
 
-export class ActiveProductionDeployment extends Schema.TaggedErrorClass<ActiveProductionDeployment>()(
-  "ActiveProductionDeployment",
-  { code: Schema.Number, message: Schema.String },
+export class ActiveProductionDeployment extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ActiveProductionDeployment>()(
+    "ActiveProductionDeployment",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 8000034 }],
 ) {}
-T.applyErrorMatchers(ActiveProductionDeployment, [{ code: 8000034 }]);
 
-export class DeploymentNotFound extends Schema.TaggedErrorClass<DeploymentNotFound>()(
-  "DeploymentNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class DeploymentNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DeploymentNotFound>()("DeploymentNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 8000009 }],
 ) {}
-T.applyErrorMatchers(DeploymentNotFound, [{ code: 8000009 }]);
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class PagesDomainAlreadyExists extends Schema.TaggedErrorClass<PagesDomainAlreadyExists>()(
-  "PagesDomainAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class PagesDomainAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<PagesDomainAlreadyExists>()(
+    "PagesDomainAlreadyExists",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 8000018 }],
 ) {}
-T.applyErrorMatchers(PagesDomainAlreadyExists, [{ code: 8000018 }]);
 
-export class PagesDomainNotFound extends Schema.TaggedErrorClass<PagesDomainNotFound>()(
-  "PagesDomainNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class PagesDomainNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<PagesDomainNotFound>()("PagesDomainNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 8000021 }],
 ) {}
-T.applyErrorMatchers(PagesDomainNotFound, [{ code: 8000021 }]);
 
-export class ProjectAlreadyExists extends Schema.TaggedErrorClass<ProjectAlreadyExists>()(
-  "ProjectAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class ProjectAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ProjectAlreadyExists>()("ProjectAlreadyExists", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 8000002 }],
 ) {}
-T.applyErrorMatchers(ProjectAlreadyExists, [{ code: 8000002 }]);
 
-export class ProjectNotFound extends Schema.TaggedErrorClass<ProjectNotFound>()(
-  "ProjectNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class ProjectNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ProjectNotFound>()("ProjectNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 8000007 }],
 ) {}
-T.applyErrorMatchers(ProjectNotFound, [{ code: 8000007 }]);
 
 // =============================================================================
 // BuildCacheProject

--- a/packages/cloudflare/src/services/pipelines.ts
+++ b/packages/cloudflare/src/services/pipelines.ts
@@ -17,103 +17,125 @@ import { SensitiveString } from "../sensitive.ts";
 // Errors
 // =============================================================================
 
-export class InvalidSinkConfig extends Schema.TaggedErrorClass<InvalidSinkConfig>()(
-  "InvalidSinkConfig",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidSinkConfig extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidSinkConfig>()("InvalidSinkConfig", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1012 }],
 ) {}
-T.applyErrorMatchers(InvalidSinkConfig, [{ code: 1012 }]);
 
-export class InvalidSinkId extends Schema.TaggedErrorClass<InvalidSinkId>()(
-  "InvalidSinkId",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidSinkId extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidSinkId>()("InvalidSinkId", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 2 }],
 ) {}
-T.applyErrorMatchers(InvalidSinkId, [{ code: 2 }]);
 
-export class InvalidSql extends Schema.TaggedErrorClass<InvalidSql>()(
-  "InvalidSql",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidSql extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidSql>()("InvalidSql", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1014 }],
 ) {}
-T.applyErrorMatchers(InvalidSql, [{ code: 1014 }]);
 
-export class InvalidStreamId extends Schema.TaggedErrorClass<InvalidStreamId>()(
-  "InvalidStreamId",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidStreamId extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidStreamId>()("InvalidStreamId", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 2 }],
 ) {}
-T.applyErrorMatchers(InvalidStreamId, [{ code: 2 }]);
 
-export class InvalidStreamName extends Schema.TaggedErrorClass<InvalidStreamName>()(
-  "InvalidStreamName",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidStreamName extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidStreamName>()("InvalidStreamName", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 2 }],
 ) {}
-T.applyErrorMatchers(InvalidStreamName, [{ code: 2 }]);
 
-export class PipelineAlreadyExists extends Schema.TaggedErrorClass<PipelineAlreadyExists>()(
-  "PipelineAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class PipelineAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<PipelineAlreadyExists>()("PipelineAlreadyExists", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1003 }],
 ) {}
-T.applyErrorMatchers(PipelineAlreadyExists, [{ code: 1003 }]);
 
-export class PipelineNotExists extends Schema.TaggedErrorClass<PipelineNotExists>()(
-  "PipelineNotExists",
-  { code: Schema.Number, message: Schema.String },
+export class PipelineNotExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<PipelineNotExists>()("PipelineNotExists", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1000 }],
 ) {}
-T.applyErrorMatchers(PipelineNotExists, [{ code: 1000 }]);
 
-export class SinkAlreadyExists extends Schema.TaggedErrorClass<SinkAlreadyExists>()(
-  "SinkAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class SinkAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SinkAlreadyExists>()("SinkAlreadyExists", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1003 }],
 ) {}
-T.applyErrorMatchers(SinkAlreadyExists, [{ code: 1003 }]);
 
-export class SinkAuthFailed extends Schema.TaggedErrorClass<SinkAuthFailed>()(
-  "SinkAuthFailed",
-  { code: Schema.Number, message: Schema.String },
+export class SinkAuthFailed extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SinkAuthFailed>()("SinkAuthFailed", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1012, message: { includes: "could not authenticate" } }],
 ) {}
-T.applyErrorMatchers(SinkAuthFailed, [
-  { code: 1012, message: { includes: "could not authenticate" } },
-]);
 
-export class SinkInUse extends Schema.TaggedErrorClass<SinkInUse>()(
-  "SinkInUse",
-  { code: Schema.Number, message: Schema.String },
+export class SinkInUse extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SinkInUse>()("SinkInUse", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 422, message: { includes: "in use" } }],
 ) {}
-T.applyErrorMatchers(SinkInUse, [
-  { status: 422, message: { includes: "in use" } },
-]);
 
-export class SinkNotFound extends Schema.TaggedErrorClass<SinkNotFound>()(
-  "SinkNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class SinkNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SinkNotFound>()("SinkNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1015 }],
 ) {}
-T.applyErrorMatchers(SinkNotFound, [{ code: 1015 }]);
 
-export class StreamAlreadyExists extends Schema.TaggedErrorClass<StreamAlreadyExists>()(
-  "StreamAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class StreamAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<StreamAlreadyExists>()("StreamAlreadyExists", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1003 }],
 ) {}
-T.applyErrorMatchers(StreamAlreadyExists, [{ code: 1003 }]);
 
-export class StreamInUse extends Schema.TaggedErrorClass<StreamInUse>()(
-  "StreamInUse",
-  { code: Schema.Number, message: Schema.String },
+export class StreamInUse extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<StreamInUse>()("StreamInUse", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 422, message: { includes: "in use" } }],
 ) {}
-T.applyErrorMatchers(StreamInUse, [
-  { status: 422, message: { includes: "in use" } },
-]);
 
-export class StreamNotFound extends Schema.TaggedErrorClass<StreamNotFound>()(
-  "StreamNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class StreamNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<StreamNotFound>()("StreamNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1016 }],
 ) {}
-T.applyErrorMatchers(StreamNotFound, [{ code: 1016 }]);
 
-export class TableNotFound extends Schema.TaggedErrorClass<TableNotFound>()(
-  "TableNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class TableNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<TableNotFound>()("TableNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1014, message: { includes: "not found" } }],
 ) {}
-T.applyErrorMatchers(TableNotFound, [
-  { code: 1014, message: { includes: "not found" } },
-]);
 
 // =============================================================================
 // Pipeline

--- a/packages/cloudflare/src/services/queues.ts
+++ b/packages/cloudflare/src/services/queues.ts
@@ -16,121 +16,145 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class ConsumerAlreadyExists extends Schema.TaggedErrorClass<ConsumerAlreadyExists>()(
-  "ConsumerAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class ConsumerAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ConsumerAlreadyExists>()("ConsumerAlreadyExists", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 11004 }],
 ) {}
-T.applyErrorMatchers(ConsumerAlreadyExists, [{ code: 11004 }]);
 
-export class ConsumerNotFound extends Schema.TaggedErrorClass<ConsumerNotFound>()(
-  "ConsumerNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class ConsumerNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ConsumerNotFound>()("ConsumerNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10013 }, { code: 10105 }, { code: 11006 }],
 ) {}
-T.applyErrorMatchers(ConsumerNotFound, [
-  { code: 10013 },
-  { code: 10105 },
-  { code: 11006 },
-]);
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class InvalidMessageBody extends Schema.TaggedErrorClass<InvalidMessageBody>()(
-  "InvalidMessageBody",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidMessageBody extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidMessageBody>()("InvalidMessageBody", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10207 }, { code: 10013 }],
 ) {}
-T.applyErrorMatchers(InvalidMessageBody, [{ code: 10207 }, { code: 10013 }]);
 
-export class InvalidQueueId extends Schema.TaggedErrorClass<InvalidQueueId>()(
-  "InvalidQueueId",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidQueueId extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidQueueId>()("InvalidQueueId", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10107 }],
 ) {}
-T.applyErrorMatchers(InvalidQueueId, [{ code: 10107 }]);
 
-export class InvalidQueueName extends Schema.TaggedErrorClass<InvalidQueueName>()(
-  "InvalidQueueName",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidQueueName extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidQueueName>()("InvalidQueueName", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 11003 }],
 ) {}
-T.applyErrorMatchers(InvalidQueueName, [{ code: 11003 }]);
 
-export class InvalidRequestBody extends Schema.TaggedErrorClass<InvalidRequestBody>()(
-  "InvalidRequestBody",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidRequestBody extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidRequestBody>()("InvalidRequestBody", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10026 }],
 ) {}
-T.applyErrorMatchers(InvalidRequestBody, [{ code: 10026 }]);
 
-export class InvalidRoute extends Schema.TaggedErrorClass<InvalidRoute>()(
-  "InvalidRoute",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidRoute extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidRoute>()("InvalidRoute", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7003 }],
 ) {}
-T.applyErrorMatchers(InvalidRoute, [{ code: 7003 }]);
 
-export class QueueAlreadyExists extends Schema.TaggedErrorClass<QueueAlreadyExists>()(
-  "QueueAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class QueueAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<QueueAlreadyExists>()("QueueAlreadyExists", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 11009 }],
 ) {}
-T.applyErrorMatchers(QueueAlreadyExists, [{ code: 11009 }]);
 
-export class QueueHandlerMissing extends Schema.TaggedErrorClass<QueueHandlerMissing>()(
-  "QueueHandlerMissing",
-  { code: Schema.Number, message: Schema.String },
+export class QueueHandlerMissing extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<QueueHandlerMissing>()("QueueHandlerMissing", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [
+    { code: 11001 },
+    { status: 400, message: { includes: "queue handler is missing" } },
+  ],
 ) {}
-T.applyErrorMatchers(QueueHandlerMissing, [
-  { code: 11001 },
-  { status: 400, message: { includes: "queue handler is missing" } },
-]);
 
-export class QueueInUseByEventNotification extends Schema.TaggedErrorClass<QueueInUseByEventNotification>()(
-  "QueueInUseByEventNotification",
-  { code: Schema.Number, message: Schema.String },
+export class QueueInUseByEventNotification extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<QueueInUseByEventNotification>()(
+    "QueueInUseByEventNotification",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 11017 }],
 ) {}
-T.applyErrorMatchers(QueueInUseByEventNotification, [{ code: 11017 }]);
 
-export class QueueNotFound extends Schema.TaggedErrorClass<QueueNotFound>()(
-  "QueueNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class QueueNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<QueueNotFound>()("QueueNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [
+    { code: 11000 },
+    { code: 0, message: { includes: "Queue does not exist" } },
+    { status: 404, message: { includes: "Queue does not exist" } },
+  ],
 ) {}
-T.applyErrorMatchers(QueueNotFound, [
-  { code: 11000 },
-  { code: 0, message: { includes: "Queue does not exist" } },
-  { status: 404, message: { includes: "Queue does not exist" } },
-]);
 
-export class SubscriptionAlreadyExists extends Schema.TaggedErrorClass<SubscriptionAlreadyExists>()(
-  "SubscriptionAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class SubscriptionAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SubscriptionAlreadyExists>()(
+    "SubscriptionAlreadyExists",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [
+    {
+      status: 405,
+      message: { includes: "do not support multiple subscriptions" },
+    },
+  ],
 ) {}
-T.applyErrorMatchers(SubscriptionAlreadyExists, [
-  {
-    status: 405,
-    message: { includes: "do not support multiple subscriptions" },
-  },
-]);
 
-export class SubscriptionNotFound extends Schema.TaggedErrorClass<SubscriptionNotFound>()(
-  "SubscriptionNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class SubscriptionNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SubscriptionNotFound>()("SubscriptionNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404, message: { includes: "No subscription with this ID" } }],
 ) {}
-T.applyErrorMatchers(SubscriptionNotFound, [
-  { status: 404, message: { includes: "No subscription with this ID" } },
-]);
 
-export class UnrecognizedEventType extends Schema.TaggedErrorClass<UnrecognizedEventType>()(
-  "UnrecognizedEventType",
-  { code: Schema.Number, message: Schema.String },
+export class UnrecognizedEventType extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<UnrecognizedEventType>()("UnrecognizedEventType", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 0, message: { includes: "Unrecognized event types" } }],
 ) {}
-T.applyErrorMatchers(UnrecognizedEventType, [
-  { code: 0, message: { includes: "Unrecognized event types" } },
-]);
 
-export class WorkerNotFound extends Schema.TaggedErrorClass<WorkerNotFound>()(
-  "WorkerNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class WorkerNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<WorkerNotFound>()("WorkerNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10007 }],
 ) {}
-T.applyErrorMatchers(WorkerNotFound, [{ code: 10007 }]);
 
 // =============================================================================
 // Consumer

--- a/packages/cloudflare/src/services/r2-data-catalog.ts
+++ b/packages/cloudflare/src/services/r2-data-catalog.ts
@@ -16,47 +16,61 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class InvalidCredential extends Schema.TaggedErrorClass<InvalidCredential>()(
-  "InvalidCredential",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidCredential extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidCredential>()("InvalidCredential", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 30004 }, { code: 30005 }],
 ) {}
-T.applyErrorMatchers(InvalidCredential, [{ code: 30004 }, { code: 30005 }]);
 
-export class InvalidRoute extends Schema.TaggedErrorClass<InvalidRoute>()(
-  "InvalidRoute",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidRoute extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidRoute>()("InvalidRoute", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7003 }],
 ) {}
-T.applyErrorMatchers(InvalidRoute, [{ code: 7003 }]);
 
-export class NoSuchBucket extends Schema.TaggedErrorClass<NoSuchBucket>()(
-  "NoSuchBucket",
-  { code: Schema.Number, message: Schema.String },
+export class NoSuchBucket extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<NoSuchBucket>()("NoSuchBucket", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10006 }, { code: 40406 }],
 ) {}
-T.applyErrorMatchers(NoSuchBucket, [{ code: 10006 }, { code: 40406 }]);
 
-export class TableNotFound extends Schema.TaggedErrorClass<TableNotFound>()(
-  "TableNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class TableNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<TableNotFound>()("TableNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10001 }, { code: 40403 }],
 ) {}
-T.applyErrorMatchers(TableNotFound, [{ code: 10001 }, { code: 40403 }]);
 
-export class WarehouseInactive extends Schema.TaggedErrorClass<WarehouseInactive>()(
-  "WarehouseInactive",
-  { code: Schema.Number, message: Schema.String },
+export class WarehouseInactive extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<WarehouseInactive>()("WarehouseInactive", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 40402 }],
 ) {}
-T.applyErrorMatchers(WarehouseInactive, [{ code: 40402 }]);
 
-export class WarehouseNotFound extends Schema.TaggedErrorClass<WarehouseNotFound>()(
-  "WarehouseNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class WarehouseNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<WarehouseNotFound>()("WarehouseNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 40401 }],
 ) {}
-T.applyErrorMatchers(WarehouseNotFound, [{ code: 40401 }]);
 
 // =============================================================================
 // Credential

--- a/packages/cloudflare/src/services/r2.ts
+++ b/packages/cloudflare/src/services/r2.ts
@@ -21,106 +21,133 @@ import { SensitiveString } from "../sensitive.ts";
 // Errors
 // =============================================================================
 
-export class BucketAlreadyExists extends Schema.TaggedErrorClass<BucketAlreadyExists>()(
-  "BucketAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class BucketAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<BucketAlreadyExists>()("BucketAlreadyExists", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10004 }],
 ) {}
-T.applyErrorMatchers(BucketAlreadyExists, [{ code: 10004 }]);
 
-export class BucketNotFound extends Schema.TaggedErrorClass<BucketNotFound>()(
-  "BucketNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class BucketNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<BucketNotFound>()("BucketNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10085 }],
 ) {}
-T.applyErrorMatchers(BucketNotFound, [{ code: 10085 }]);
 
-export class CustomDomainInUse extends Schema.TaggedErrorClass<CustomDomainInUse>()(
-  "CustomDomainInUse",
-  { code: Schema.Number, message: Schema.String },
+export class CustomDomainInUse extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<CustomDomainInUse>()("CustomDomainInUse", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 409, message: { includes: "in use" } }],
 ) {}
-T.applyErrorMatchers(CustomDomainInUse, [
-  { status: 409, message: { includes: "in use" } },
-]);
 
-export class DomainNotFound extends Schema.TaggedErrorClass<DomainNotFound>()(
-  "DomainNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class DomainNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DomainNotFound>()("DomainNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10053 }],
 ) {}
-T.applyErrorMatchers(DomainNotFound, [{ code: 10053 }]);
 
-export class EventNotificationConfigNotFound extends Schema.TaggedErrorClass<EventNotificationConfigNotFound>()(
-  "EventNotificationConfigNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class EventNotificationConfigNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<EventNotificationConfigNotFound>()(
+    "EventNotificationConfigNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 11011 }],
 ) {}
-T.applyErrorMatchers(EventNotificationConfigNotFound, [{ code: 11011 }]);
 
-export class EventNotificationRuleConflict extends Schema.TaggedErrorClass<EventNotificationRuleConflict>()(
-  "EventNotificationRuleConflict",
-  { code: Schema.Number, message: Schema.String },
+export class EventNotificationRuleConflict extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<EventNotificationRuleConflict>()(
+    "EventNotificationRuleConflict",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 11020 }],
 ) {}
-T.applyErrorMatchers(EventNotificationRuleConflict, [{ code: 11020 }]);
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class InvalidBucketName extends Schema.TaggedErrorClass<InvalidBucketName>()(
-  "InvalidBucketName",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidBucketName extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidBucketName>()("InvalidBucketName", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10005 }],
 ) {}
-T.applyErrorMatchers(InvalidBucketName, [{ code: 10005 }]);
 
-export class InvalidEventNotificationConfig extends Schema.TaggedErrorClass<InvalidEventNotificationConfig>()(
-  "InvalidEventNotificationConfig",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidEventNotificationConfig extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidEventNotificationConfig>()(
+    "InvalidEventNotificationConfig",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 11014 }, { code: 11019 }],
 ) {}
-T.applyErrorMatchers(InvalidEventNotificationConfig, [
-  { code: 11014 },
-  { code: 11019 },
-]);
 
-export class InvalidRoute extends Schema.TaggedErrorClass<InvalidRoute>()(
-  "InvalidRoute",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidRoute extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidRoute>()("InvalidRoute", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7003 }],
 ) {}
-T.applyErrorMatchers(InvalidRoute, [{ code: 7003 }]);
 
-export class InvalidUpstreamCredentials extends Schema.TaggedErrorClass<InvalidUpstreamCredentials>()(
-  "InvalidUpstreamCredentials",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidUpstreamCredentials extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidUpstreamCredentials>()(
+    "InvalidUpstreamCredentials",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 10063 }],
 ) {}
-T.applyErrorMatchers(InvalidUpstreamCredentials, [{ code: 10063 }]);
 
-export class NoCorsConfiguration extends Schema.TaggedErrorClass<NoCorsConfiguration>()(
-  "NoCorsConfiguration",
-  { code: Schema.Number, message: Schema.String },
+export class NoCorsConfiguration extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<NoCorsConfiguration>()("NoCorsConfiguration", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10059 }],
 ) {}
-T.applyErrorMatchers(NoCorsConfiguration, [{ code: 10059 }]);
 
-export class NoEventNotificationConfig extends Schema.TaggedErrorClass<NoEventNotificationConfig>()(
-  "NoEventNotificationConfig",
-  { code: Schema.Number, message: Schema.String },
+export class NoEventNotificationConfig extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<NoEventNotificationConfig>()(
+    "NoEventNotificationConfig",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 11015 }],
 ) {}
-T.applyErrorMatchers(NoEventNotificationConfig, [{ code: 11015 }]);
 
-export class NoRoute extends Schema.TaggedErrorClass<NoRoute>()("NoRoute", {
-  code: Schema.Number,
-  message: Schema.String,
-}) {}
-T.applyErrorMatchers(NoRoute, [{ code: 10015 }]);
-
-export class NoSuchBucket extends Schema.TaggedErrorClass<NoSuchBucket>()(
-  "NoSuchBucket",
-  { code: Schema.Number, message: Schema.String },
+export class NoRoute extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<NoRoute>()("NoRoute", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10015 }],
 ) {}
-T.applyErrorMatchers(NoSuchBucket, [{ code: 10006 }]);
 
-export class QueueNotFound extends Schema.TaggedErrorClass<QueueNotFound>()(
-  "QueueNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class NoSuchBucket extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<NoSuchBucket>()("NoSuchBucket", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10006 }],
 ) {}
-T.applyErrorMatchers(QueueNotFound, [{ code: 11000 }]);
+
+export class QueueNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<QueueNotFound>()("QueueNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 11000 }],
+) {}
 
 // =============================================================================
 // AllSuperSlurperJob

--- a/packages/cloudflare/src/services/realtime-kit.ts
+++ b/packages/cloudflare/src/services/realtime-kit.ts
@@ -17,35 +17,45 @@ import { SensitiveString } from "../sensitive.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class RealtimeKitPresetExists extends Schema.TaggedErrorClass<RealtimeKitPresetExists>()(
-  "RealtimeKitPresetExists",
-  { code: Schema.Number, message: Schema.String },
+export class RealtimeKitPresetExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<RealtimeKitPresetExists>()(
+    "RealtimeKitPresetExists",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 409 }],
 ) {}
-T.applyErrorMatchers(RealtimeKitPresetExists, [{ status: 409 }]);
 
-export class RealtimeKitPresetNotFound extends Schema.TaggedErrorClass<RealtimeKitPresetNotFound>()(
-  "RealtimeKitPresetNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class RealtimeKitPresetNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<RealtimeKitPresetNotFound>()(
+    "RealtimeKitPresetNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(RealtimeKitPresetNotFound, [{ status: 404 }]);
 
-export class RealtimeKitWebhookExists extends Schema.TaggedErrorClass<RealtimeKitWebhookExists>()(
-  "RealtimeKitWebhookExists",
-  { code: Schema.Number, message: Schema.String },
+export class RealtimeKitWebhookExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<RealtimeKitWebhookExists>()(
+    "RealtimeKitWebhookExists",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 409 }],
 ) {}
-T.applyErrorMatchers(RealtimeKitWebhookExists, [{ status: 409 }]);
 
-export class RealtimeKitWebhookNotFound extends Schema.TaggedErrorClass<RealtimeKitWebhookNotFound>()(
-  "RealtimeKitWebhookNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class RealtimeKitWebhookNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<RealtimeKitWebhookNotFound>()(
+    "RealtimeKitWebhookNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(RealtimeKitWebhookNotFound, [{ status: 404 }]);
 
 // =============================================================================
 // ActiveLivestreamsForLivestreamIdLivestream

--- a/packages/cloudflare/src/services/registrar.ts
+++ b/packages/cloudflare/src/services/registrar.ts
@@ -16,29 +16,35 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class RegistrarDomainNotOwned extends Schema.TaggedErrorClass<RegistrarDomainNotOwned>()(
-  "RegistrarDomainNotOwned",
-  { code: Schema.Number, message: Schema.String },
+export class RegistrarDomainNotOwned extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<RegistrarDomainNotOwned>()(
+    "RegistrarDomainNotOwned",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [
+    {
+      code: 10000,
+      status: 403,
+      message: { includes: "Domain doesn't belong to the user" },
+    },
+  ],
 ) {}
-T.applyErrorMatchers(RegistrarDomainNotOwned, [
-  {
-    code: 10000,
-    status: 403,
-    message: { includes: "Domain doesn't belong to the user" },
-  },
-]);
 
-export class RegistrarUpdateNotAllowed extends Schema.TaggedErrorClass<RegistrarUpdateNotAllowed>()(
-  "RegistrarUpdateNotAllowed",
-  { code: Schema.Number, message: Schema.String },
+export class RegistrarUpdateNotAllowed extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<RegistrarUpdateNotAllowed>()(
+    "RegistrarUpdateNotAllowed",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 422 }],
 ) {}
-T.applyErrorMatchers(RegistrarUpdateNotAllowed, [{ status: 422 }]);
 
 // =============================================================================
 // Domain

--- a/packages/cloudflare/src/services/resource-sharing.ts
+++ b/packages/cloudflare/src/services/resource-sharing.ts
@@ -16,29 +16,37 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class ShareNotFound extends Schema.TaggedErrorClass<ShareNotFound>()(
-  "ShareNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class ShareNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ShareNotFound>()("ShareNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1004 }, { status: 404 }],
 ) {}
-T.applyErrorMatchers(ShareNotFound, [{ code: 1004 }, { status: 404 }]);
 
-export class ShareRecipientNotFound extends Schema.TaggedErrorClass<ShareRecipientNotFound>()(
-  "ShareRecipientNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class ShareRecipientNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ShareRecipientNotFound>()("ShareRecipientNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1004 }, { status: 404 }],
 ) {}
-T.applyErrorMatchers(ShareRecipientNotFound, [{ code: 1004 }, { status: 404 }]);
 
-export class ShareResourceNotFound extends Schema.TaggedErrorClass<ShareResourceNotFound>()(
-  "ShareResourceNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class ShareResourceNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ShareResourceNotFound>()("ShareResourceNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1004 }, { status: 404 }],
 ) {}
-T.applyErrorMatchers(ShareResourceNotFound, [{ code: 1004 }, { status: 404 }]);
 
 // =============================================================================
 // Recipient

--- a/packages/cloudflare/src/services/resource-tagging.ts
+++ b/packages/cloudflare/src/services/resource-tagging.ts
@@ -16,23 +16,29 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class TagPreconditionFailed extends Schema.TaggedErrorClass<TagPreconditionFailed>()(
-  "TagPreconditionFailed",
-  { code: Schema.Number, message: Schema.String },
+export class TagPreconditionFailed extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<TagPreconditionFailed>()("TagPreconditionFailed", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 412 }],
 ) {}
-T.applyErrorMatchers(TagPreconditionFailed, [{ status: 412 }]);
 
-export class ZoneTagResourceNotFound extends Schema.TaggedErrorClass<ZoneTagResourceNotFound>()(
-  "ZoneTagResourceNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class ZoneTagResourceNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ZoneTagResourceNotFound>()(
+    "ZoneTagResourceNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(ZoneTagResourceNotFound, [{ status: 404 }]);
 
 // =============================================================================
 // AccountTag

--- a/packages/cloudflare/src/services/rules.ts
+++ b/packages/cloudflare/src/services/rules.ts
@@ -16,23 +16,29 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class ListAlreadyExists extends Schema.TaggedErrorClass<ListAlreadyExists>()(
-  "ListAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class ListAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ListAlreadyExists>()("ListAlreadyExists", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10021 }],
 ) {}
-T.applyErrorMatchers(ListAlreadyExists, [{ code: 10021 }]);
 
-export class ListNotFound extends Schema.TaggedErrorClass<ListNotFound>()(
-  "ListNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class ListNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ListNotFound>()("ListNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10001 }],
 ) {}
-T.applyErrorMatchers(ListNotFound, [{ code: 10001 }]);
 
 // =============================================================================
 // List

--- a/packages/cloudflare/src/services/rulesets.ts
+++ b/packages/cloudflare/src/services/rulesets.ts
@@ -17,26 +17,29 @@ import { SensitiveString } from "../sensitive.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class PhaseNotEntitled extends Schema.TaggedErrorClass<PhaseNotEntitled>()(
-  "PhaseNotEntitled",
-  { code: Schema.Number, message: Schema.String },
+export class PhaseNotEntitled extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<PhaseNotEntitled>()("PhaseNotEntitled", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 50002 }, { status: 400, message: { includes: "not entitled" } }],
 ) {}
-T.applyErrorMatchers(PhaseNotEntitled, [
-  { code: 50002 },
-  { status: 400, message: { includes: "not entitled" } },
-]);
 
-export class RulesetNotFound extends Schema.TaggedErrorClass<RulesetNotFound>()(
-  "RulesetNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class RulesetNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<RulesetNotFound>()("RulesetNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10003 }, { code: 10001 }],
 ) {}
-T.applyErrorMatchers(RulesetNotFound, [{ code: 10003 }, { code: 10001 }]);
 
 // =============================================================================
 // Pha

--- a/packages/cloudflare/src/services/rum.ts
+++ b/packages/cloudflare/src/services/rum.ts
@@ -16,37 +16,45 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class MaxRulesExceeded extends Schema.TaggedErrorClass<MaxRulesExceeded>()(
-  "MaxRulesExceeded",
-  { code: Schema.Number, message: Schema.String },
+export class MaxRulesExceeded extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<MaxRulesExceeded>()("MaxRulesExceeded", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 409, message: { includes: "maxRulesError" } }],
 ) {}
-T.applyErrorMatchers(MaxRulesExceeded, [
-  { status: 409, message: { includes: "maxRulesError" } },
-]);
 
-export class RuleNotFound extends Schema.TaggedErrorClass<RuleNotFound>()(
-  "RuleNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class RuleNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<RuleNotFound>()("RuleNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10003 }],
 ) {}
-T.applyErrorMatchers(RuleNotFound, [{ code: 10003 }]);
 
-export class RulesetNotFound extends Schema.TaggedErrorClass<RulesetNotFound>()(
-  "RulesetNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class RulesetNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<RulesetNotFound>()("RulesetNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(RulesetNotFound, [{ status: 404 }]);
 
-export class SiteNotFound extends Schema.TaggedErrorClass<SiteNotFound>()(
-  "SiteNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class SiteNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SiteNotFound>()("SiteNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10015 }],
 ) {}
-T.applyErrorMatchers(SiteNotFound, [{ code: 10015 }]);
 
 // =============================================================================
 // Rule

--- a/packages/cloudflare/src/services/schema-validation.ts
+++ b/packages/cloudflare/src/services/schema-validation.ts
@@ -16,35 +16,45 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class InvalidSchema extends Schema.TaggedErrorClass<InvalidSchema>()(
-  "InvalidSchema",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidSchema extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidSchema>()("InvalidSchema", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 50010 }],
 ) {}
-T.applyErrorMatchers(InvalidSchema, [{ code: 50010 }]);
 
-export class OperationNotFound extends Schema.TaggedErrorClass<OperationNotFound>()(
-  "OperationNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class OperationNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<OperationNotFound>()("OperationNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10404 }],
 ) {}
-T.applyErrorMatchers(OperationNotFound, [{ code: 10404 }]);
 
-export class SchemaNotFound extends Schema.TaggedErrorClass<SchemaNotFound>()(
-  "SchemaNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class SchemaNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SchemaNotFound>()("SchemaNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 19400 }],
 ) {}
-T.applyErrorMatchers(SchemaNotFound, [{ code: 19400 }]);
 
-export class UnentitledMitigationAction extends Schema.TaggedErrorClass<UnentitledMitigationAction>()(
-  "UnentitledMitigationAction",
-  { code: Schema.Number, message: Schema.String },
+export class UnentitledMitigationAction extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<UnentitledMitigationAction>()(
+    "UnentitledMitigationAction",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 11400 }],
 ) {}
-T.applyErrorMatchers(UnentitledMitigationAction, [{ code: 11400 }]);
 
 // =============================================================================
 // Schema

--- a/packages/cloudflare/src/services/secrets-store.ts
+++ b/packages/cloudflare/src/services/secrets-store.ts
@@ -16,81 +16,85 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class InvalidAccountId extends Schema.TaggedErrorClass<InvalidAccountId>()(
-  "InvalidAccountId",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidAccountId extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidAccountId>()("InvalidAccountId", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7003 }],
 ) {}
-T.applyErrorMatchers(InvalidAccountId, [{ code: 7003 }]);
 
-export class InvalidJsonBody extends Schema.TaggedErrorClass<InvalidJsonBody>()(
-  "InvalidJsonBody",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidJsonBody extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidJsonBody>()("InvalidJsonBody", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1001, message: { includes: "invalid_json_body" } }],
 ) {}
-T.applyErrorMatchers(InvalidJsonBody, [
-  { code: 1001, message: { includes: "invalid_json_body" } },
-]);
 
-export class MaximumStoresExceeded extends Schema.TaggedErrorClass<MaximumStoresExceeded>()(
-  "MaximumStoresExceeded",
-  { code: Schema.Number, message: Schema.String },
+export class MaximumStoresExceeded extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<MaximumStoresExceeded>()("MaximumStoresExceeded", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1003, message: { includes: "maximum_stores_exceeded" } }],
 ) {}
-T.applyErrorMatchers(MaximumStoresExceeded, [
-  { code: 1003, message: { includes: "maximum_stores_exceeded" } },
-]);
 
-export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
-  code: Schema.Number,
-  message: Schema.String,
-}) {}
-T.applyErrorMatchers(NotFound, [{ code: 1000 }]);
-
-export class SecretNameAlreadyExists extends Schema.TaggedErrorClass<SecretNameAlreadyExists>()(
-  "SecretNameAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class NotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<NotFound>()("NotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1000 }],
 ) {}
-T.applyErrorMatchers(SecretNameAlreadyExists, [
-  { code: 1003, message: { includes: "secret_name_already_exists" } },
-]);
 
-export class SecretNameEmpty extends Schema.TaggedErrorClass<SecretNameEmpty>()(
-  "SecretNameEmpty",
-  { code: Schema.Number, message: Schema.String },
+export class SecretNameAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SecretNameAlreadyExists>()(
+    "SecretNameAlreadyExists",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1003, message: { includes: "secret_name_already_exists" } }],
 ) {}
-T.applyErrorMatchers(SecretNameEmpty, [
-  { code: 1001, message: { includes: "secret_name_empty" } },
-]);
 
-export class SecretNotFound extends Schema.TaggedErrorClass<SecretNotFound>()(
-  "SecretNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class SecretNameEmpty extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SecretNameEmpty>()("SecretNameEmpty", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1001, message: { includes: "secret_name_empty" } }],
 ) {}
-T.applyErrorMatchers(SecretNotFound, [
-  { code: 1001, message: { includes: "secret_not_found" } },
-]);
 
-export class SecretScopeInvalid extends Schema.TaggedErrorClass<SecretScopeInvalid>()(
-  "SecretScopeInvalid",
-  { code: Schema.Number, message: Schema.String },
+export class SecretNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SecretNotFound>()("SecretNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1001, message: { includes: "secret_not_found" } }],
 ) {}
-T.applyErrorMatchers(SecretScopeInvalid, [
-  { code: 1001, message: { includes: "secret_scope_invalid" } },
-]);
 
-export class SecretScopesEmpty extends Schema.TaggedErrorClass<SecretScopesEmpty>()(
-  "SecretScopesEmpty",
-  { code: Schema.Number, message: Schema.String },
+export class SecretScopeInvalid extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SecretScopeInvalid>()("SecretScopeInvalid", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1001, message: { includes: "secret_scope_invalid" } }],
 ) {}
-T.applyErrorMatchers(SecretScopesEmpty, [
-  { code: 1001, message: { includes: "secret_scopes_empty" } },
-]);
 
-export class StoreNotFound extends Schema.TaggedErrorClass<StoreNotFound>()(
-  "StoreNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class SecretScopesEmpty extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SecretScopesEmpty>()("SecretScopesEmpty", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1001, message: { includes: "secret_scopes_empty" } }],
 ) {}
-T.applyErrorMatchers(StoreNotFound, [
-  { code: 1001, message: { includes: "store_not_found" } },
-]);
+
+export class StoreNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<StoreNotFound>()("StoreNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1001, message: { includes: "store_not_found" } }],
+) {}
 
 // =============================================================================
 // Quota

--- a/packages/cloudflare/src/services/security-txt.ts
+++ b/packages/cloudflare/src/services/security-txt.ts
@@ -16,19 +16,21 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class SecurityTxtInvalid extends Schema.TaggedErrorClass<SecurityTxtInvalid>()(
-  "SecurityTxtInvalid",
-  { code: Schema.Number, message: Schema.String },
+export class SecurityTxtInvalid extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SecurityTxtInvalid>()("SecurityTxtInvalid", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10400, message: { includes: "invalid or missing values" } }],
 ) {}
-T.applyErrorMatchers(SecurityTxtInvalid, [
-  { code: 10400, message: { includes: "invalid or missing values" } },
-]);
 
 // =============================================================================
 // SecurityTxt

--- a/packages/cloudflare/src/services/snippets.ts
+++ b/packages/cloudflare/src/services/snippets.ts
@@ -17,35 +17,43 @@ import { UploadableSchema } from "../schemas.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class SnippetInUse extends Schema.TaggedErrorClass<SnippetInUse>()(
-  "SnippetInUse",
-  { code: Schema.Number, message: Schema.String },
+export class SnippetInUse extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SnippetInUse>()("SnippetInUse", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [
+    { status: 400, message: { includes: "still used" } },
+    { status: 409, message: { includes: "still used" } },
+  ],
 ) {}
-T.applyErrorMatchers(SnippetInUse, [
-  { status: 400, message: { includes: "still used" } },
-  { status: 409, message: { includes: "still used" } },
-]);
 
-export class SnippetNotFound extends Schema.TaggedErrorClass<SnippetNotFound>()(
-  "SnippetNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class SnippetNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SnippetNotFound>()("SnippetNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [
+    { status: 400, message: { includes: "snippet not found" } },
+    { status: 404 },
+  ],
 ) {}
-T.applyErrorMatchers(SnippetNotFound, [
-  { status: 400, message: { includes: "snippet not found" } },
-  { status: 404 },
-]);
 
-export class SnippetRulesNotFound extends Schema.TaggedErrorClass<SnippetRulesNotFound>()(
-  "SnippetRulesNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class SnippetRulesNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SnippetRulesNotFound>()("SnippetRulesNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(SnippetRulesNotFound, [{ status: 404 }]);
 
 // =============================================================================
 // Content

--- a/packages/cloudflare/src/services/spectrum.ts
+++ b/packages/cloudflare/src/services/spectrum.ts
@@ -16,23 +16,29 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class SpectrumAppNotFound extends Schema.TaggedErrorClass<SpectrumAppNotFound>()(
-  "SpectrumAppNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class SpectrumAppNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SpectrumAppNotFound>()("SpectrumAppNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10006 }],
 ) {}
-T.applyErrorMatchers(SpectrumAppNotFound, [{ code: 10006 }]);
 
-export class SpectrumProtocolNotAvailable extends Schema.TaggedErrorClass<SpectrumProtocolNotAvailable>()(
-  "SpectrumProtocolNotAvailable",
-  { code: Schema.Number, message: Schema.String },
+export class SpectrumProtocolNotAvailable extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SpectrumProtocolNotAvailable>()(
+    "SpectrumProtocolNotAvailable",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 13002 }],
 ) {}
-T.applyErrorMatchers(SpectrumProtocolNotAvailable, [{ code: 13002 }]);
 
 // =============================================================================
 // AnalyticAggregateCurrent

--- a/packages/cloudflare/src/services/speed.ts
+++ b/packages/cloudflare/src/services/speed.ts
@@ -16,36 +16,37 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class TestScheduleAlreadyExists extends Schema.TaggedErrorClass<TestScheduleAlreadyExists>()(
-  "TestScheduleAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class TestScheduleAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<TestScheduleAlreadyExists>()(
+    "TestScheduleAlreadyExists",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 400, message: { includes: "scheduled_test_already_exists" } }],
 ) {}
-T.applyErrorMatchers(TestScheduleAlreadyExists, [
-  { code: 400, message: { includes: "scheduled_test_already_exists" } },
-]);
 
-export class TestScheduleNotFound extends Schema.TaggedErrorClass<TestScheduleNotFound>()(
-  "TestScheduleNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class TestScheduleNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<TestScheduleNotFound>()("TestScheduleNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 404, message: { includes: "schedule_not_found" } }, { status: 404 }],
 ) {}
-T.applyErrorMatchers(TestScheduleNotFound, [
-  { code: 404, message: { includes: "schedule_not_found" } },
-  { status: 404 },
-]);
 
-export class TestScheduleQuotaReached extends Schema.TaggedErrorClass<TestScheduleQuotaReached>()(
-  "TestScheduleQuotaReached",
-  { code: Schema.Number, message: Schema.String },
+export class TestScheduleQuotaReached extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<TestScheduleQuotaReached>()(
+    "TestScheduleQuotaReached",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 429, message: { includes: "quota reached" } }],
 ) {}
-T.applyErrorMatchers(TestScheduleQuotaReached, [
-  { code: 429, message: { includes: "quota reached" } },
-]);
 
 // =============================================================================
 // Availability

--- a/packages/cloudflare/src/services/ssl.ts
+++ b/packages/cloudflare/src/services/ssl.ts
@@ -16,26 +16,29 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class AdvancedCertificateManagerRequired extends Schema.TaggedErrorClass<AdvancedCertificateManagerRequired>()(
-  "AdvancedCertificateManagerRequired",
-  { code: Schema.Number, message: Schema.String },
+export class AdvancedCertificateManagerRequired extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<AdvancedCertificateManagerRequired>()(
+    "AdvancedCertificateManagerRequired",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1450 }],
 ) {}
-T.applyErrorMatchers(AdvancedCertificateManagerRequired, [{ code: 1450 }]);
 
-export class CertificatePackNotFound extends Schema.TaggedErrorClass<CertificatePackNotFound>()(
-  "CertificatePackNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class CertificatePackNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<CertificatePackNotFound>()(
+    "CertificatePackNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1408 }, { status: 404 }],
 ) {}
-T.applyErrorMatchers(CertificatePackNotFound, [
-  { code: 1408 },
-  { status: 404 },
-]);
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
 // =============================================================================
 // Analyze

--- a/packages/cloudflare/src/services/stream.ts
+++ b/packages/cloudflare/src/services/stream.ts
@@ -16,47 +16,61 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class LiveInputNotFound extends Schema.TaggedErrorClass<LiveInputNotFound>()(
-  "LiveInputNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class LiveInputNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<LiveInputNotFound>()("LiveInputNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10003 }],
 ) {}
-T.applyErrorMatchers(LiveInputNotFound, [{ code: 10003 }]);
 
-export class OutputNotFound extends Schema.TaggedErrorClass<OutputNotFound>()(
-  "OutputNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class OutputNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<OutputNotFound>()("OutputNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10003 }],
 ) {}
-T.applyErrorMatchers(OutputNotFound, [{ code: 10003 }]);
 
-export class SigningKeyNotFound extends Schema.TaggedErrorClass<SigningKeyNotFound>()(
-  "SigningKeyNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class SigningKeyNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SigningKeyNotFound>()("SigningKeyNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10003 }],
 ) {}
-T.applyErrorMatchers(SigningKeyNotFound, [{ code: 10003 }]);
 
-export class WatermarkImageInvalid extends Schema.TaggedErrorClass<WatermarkImageInvalid>()(
-  "WatermarkImageInvalid",
-  { code: Schema.Number, message: Schema.String },
+export class WatermarkImageInvalid extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<WatermarkImageInvalid>()("WatermarkImageInvalid", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10004 }],
 ) {}
-T.applyErrorMatchers(WatermarkImageInvalid, [{ code: 10004 }]);
 
-export class WatermarkNotFound extends Schema.TaggedErrorClass<WatermarkNotFound>()(
-  "WatermarkNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class WatermarkNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<WatermarkNotFound>()("WatermarkNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10003 }],
 ) {}
-T.applyErrorMatchers(WatermarkNotFound, [{ code: 10003 }]);
 
-export class WebhookNotFound extends Schema.TaggedErrorClass<WebhookNotFound>()(
-  "WebhookNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class WebhookNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<WebhookNotFound>()("WebhookNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10003 }],
 ) {}
-T.applyErrorMatchers(WebhookNotFound, [{ code: 10003 }]);
 
 // =============================================================================
 // AudioTrack

--- a/packages/cloudflare/src/services/token-validation.ts
+++ b/packages/cloudflare/src/services/token-validation.ts
@@ -16,29 +16,37 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class TokenConfigurationNotFound extends Schema.TaggedErrorClass<TokenConfigurationNotFound>()(
-  "TokenConfigurationNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class TokenConfigurationNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<TokenConfigurationNotFound>()(
+    "TokenConfigurationNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(TokenConfigurationNotFound, [{ status: 404 }]);
 
-export class TokenValidationNotEntitled extends Schema.TaggedErrorClass<TokenValidationNotEntitled>()(
-  "TokenValidationNotEntitled",
-  { code: Schema.Number, message: Schema.String },
+export class TokenValidationNotEntitled extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<TokenValidationNotEntitled>()(
+    "TokenValidationNotEntitled",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 10403 }],
 ) {}
-T.applyErrorMatchers(TokenValidationNotEntitled, [{ code: 10403 }]);
 
-export class TokenValidationRuleNotFound extends Schema.TaggedErrorClass<TokenValidationRuleNotFound>()(
-  "TokenValidationRuleNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class TokenValidationRuleNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<TokenValidationRuleNotFound>()(
+    "TokenValidationRuleNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(TokenValidationRuleNotFound, [{ status: 404 }]);
 
 // =============================================================================
 // Configuration

--- a/packages/cloudflare/src/services/turnstile.ts
+++ b/packages/cloudflare/src/services/turnstile.ts
@@ -16,17 +16,21 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class WidgetNotFound extends Schema.TaggedErrorClass<WidgetNotFound>()(
-  "WidgetNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class WidgetNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<WidgetNotFound>()("WidgetNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10404 }, { code: 10407 }],
 ) {}
-T.applyErrorMatchers(WidgetNotFound, [{ code: 10404 }, { code: 10407 }]);
 
 // =============================================================================
 // SecretWidget

--- a/packages/cloudflare/src/services/url-normalization.ts
+++ b/packages/cloudflare/src/services/url-normalization.ts
@@ -16,11 +16,13 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
 // =============================================================================
 // UrlNormalization

--- a/packages/cloudflare/src/services/user.ts
+++ b/packages/cloudflare/src/services/user.ts
@@ -16,45 +16,53 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class InvalidRoute extends Schema.TaggedErrorClass<InvalidRoute>()(
-  "InvalidRoute",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidRoute extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidRoute>()("InvalidRoute", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7003 }],
 ) {}
-T.applyErrorMatchers(InvalidRoute, [{ code: 7003 }]);
 
-export class InvalidTokenName extends Schema.TaggedErrorClass<InvalidTokenName>()(
-  "InvalidTokenName",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidTokenName extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidTokenName>()("InvalidTokenName", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 400, message: { includes: "name must have a length" } }],
 ) {}
-T.applyErrorMatchers(InvalidTokenName, [
-  { code: 400, message: { includes: "name must have a length" } },
-]);
 
-export class MethodNotAllowed extends Schema.TaggedErrorClass<MethodNotAllowed>()(
-  "MethodNotAllowed",
-  { code: Schema.Number, message: Schema.String },
+export class MethodNotAllowed extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<MethodNotAllowed>()("MethodNotAllowed", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7001 }],
 ) {}
-T.applyErrorMatchers(MethodNotAllowed, [{ code: 7001 }]);
 
-export class PermissionGroupNotFound extends Schema.TaggedErrorClass<PermissionGroupNotFound>()(
-  "PermissionGroupNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class PermissionGroupNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<PermissionGroupNotFound>()(
+    "PermissionGroupNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1001, message: { includes: "Permission group" } }],
 ) {}
-T.applyErrorMatchers(PermissionGroupNotFound, [
-  { code: 1001, message: { includes: "Permission group" } },
-]);
 
-export class TokenNotFound extends Schema.TaggedErrorClass<TokenNotFound>()(
-  "TokenNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class TokenNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<TokenNotFound>()("TokenNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1003 }],
 ) {}
-T.applyErrorMatchers(TokenNotFound, [{ code: 1003 }]);
 
 // =============================================================================
 // AuditLog

--- a/packages/cloudflare/src/services/vectorize.ts
+++ b/packages/cloudflare/src/services/vectorize.ts
@@ -17,56 +17,69 @@ import { UploadableSchema } from "../schemas.ts";
 // Errors
 // =============================================================================
 
-export class Gone extends Schema.TaggedErrorClass<Gone>()("Gone", {
-  code: Schema.Number,
-  message: Schema.String,
-}) {}
-T.applyErrorMatchers(Gone, [
-  { code: 3005 },
-  { message: { includes: "index deleted" } },
-]);
-
-export class IndexAlreadyExists extends Schema.TaggedErrorClass<IndexAlreadyExists>()(
-  "IndexAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class Gone extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Gone>()("Gone", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 3005 }, { message: { includes: "index deleted" } }],
 ) {}
-T.applyErrorMatchers(IndexAlreadyExists, [{ code: 3002 }]);
 
-export class IndexInvalidConfig extends Schema.TaggedErrorClass<IndexInvalidConfig>()(
-  "IndexInvalidConfig",
-  { code: Schema.Number, message: Schema.String },
+export class IndexAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<IndexAlreadyExists>()("IndexAlreadyExists", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 3002 }],
 ) {}
-T.applyErrorMatchers(IndexInvalidConfig, [{ code: 3003 }]);
 
-export class IndexInvalidName extends Schema.TaggedErrorClass<IndexInvalidName>()(
-  "IndexInvalidName",
-  { code: Schema.Number, message: Schema.String },
+export class IndexInvalidConfig extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<IndexInvalidConfig>()("IndexInvalidConfig", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 3003 }],
 ) {}
-T.applyErrorMatchers(IndexInvalidName, [{ code: 3001 }]);
 
-export class MetadataIndexAlreadyExists extends Schema.TaggedErrorClass<MetadataIndexAlreadyExists>()(
-  "MetadataIndexAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class IndexInvalidName extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<IndexInvalidName>()("IndexInvalidName", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 3001 }],
 ) {}
-T.applyErrorMatchers(MetadataIndexAlreadyExists, [{ code: 40004 }]);
 
-export class MetadataIndexInvalidType extends Schema.TaggedErrorClass<MetadataIndexInvalidType>()(
-  "MetadataIndexInvalidType",
-  { code: Schema.Number, message: Schema.String },
+export class MetadataIndexAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<MetadataIndexAlreadyExists>()(
+    "MetadataIndexAlreadyExists",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 40004 }],
 ) {}
-T.applyErrorMatchers(MetadataIndexInvalidType, [{ code: 40026 }]);
 
-export class MetadataIndexNotFound extends Schema.TaggedErrorClass<MetadataIndexNotFound>()(
-  "MetadataIndexNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class MetadataIndexInvalidType extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<MetadataIndexInvalidType>()(
+    "MetadataIndexInvalidType",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 40026 }],
 ) {}
-T.applyErrorMatchers(MetadataIndexNotFound, [{ code: 40005 }]);
 
-export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
-  code: Schema.Number,
-  message: Schema.String,
-}) {}
-T.applyErrorMatchers(NotFound, [{ code: 3000 }]);
+export class MetadataIndexNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<MetadataIndexNotFound>()("MetadataIndexNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 40005 }],
+) {}
+
+export class NotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<NotFound>()("NotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 3000 }],
+) {}
 
 // =============================================================================
 // ByIdsIndex

--- a/packages/cloudflare/src/services/vulnerability-scanner.ts
+++ b/packages/cloudflare/src/services/vulnerability-scanner.ts
@@ -16,35 +16,45 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class CredentialNotFound extends Schema.TaggedErrorClass<CredentialNotFound>()(
-  "CredentialNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class CredentialNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<CredentialNotFound>()("CredentialNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 14002 }],
 ) {}
-T.applyErrorMatchers(CredentialNotFound, [{ code: 14002 }]);
 
-export class CredentialSetNotFound extends Schema.TaggedErrorClass<CredentialSetNotFound>()(
-  "CredentialSetNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class CredentialSetNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<CredentialSetNotFound>()("CredentialSetNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 14001 }],
 ) {}
-T.applyErrorMatchers(CredentialSetNotFound, [{ code: 14001 }]);
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class TargetEnvironmentNotFound extends Schema.TaggedErrorClass<TargetEnvironmentNotFound>()(
-  "TargetEnvironmentNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class TargetEnvironmentNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<TargetEnvironmentNotFound>()(
+    "TargetEnvironmentNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 11001 }],
 ) {}
-T.applyErrorMatchers(TargetEnvironmentNotFound, [{ code: 11001 }]);
 
-export class ZoneTagNotFound extends Schema.TaggedErrorClass<ZoneTagNotFound>()(
-  "ZoneTagNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class ZoneTagNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ZoneTagNotFound>()("ZoneTagNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 14150 }],
 ) {}
-T.applyErrorMatchers(ZoneTagNotFound, [{ code: 14150 }]);
 
 // =============================================================================
 // CredentialSet

--- a/packages/cloudflare/src/services/waiting-rooms.ts
+++ b/packages/cloudflare/src/services/waiting-rooms.ts
@@ -16,23 +16,29 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class WaitingRoomNotFound extends Schema.TaggedErrorClass<WaitingRoomNotFound>()(
-  "WaitingRoomNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class WaitingRoomNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<WaitingRoomNotFound>()("WaitingRoomNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1001 }],
 ) {}
-T.applyErrorMatchers(WaitingRoomNotFound, [{ code: 1001 }]);
 
-export class ZoneNotEntitled extends Schema.TaggedErrorClass<ZoneNotEntitled>()(
-  "ZoneNotEntitled",
-  { code: Schema.Number, message: Schema.String },
+export class ZoneNotEntitled extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ZoneNotEntitled>()("ZoneNotEntitled", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1034 }],
 ) {}
-T.applyErrorMatchers(ZoneNotEntitled, [{ code: 1034 }]);
 
 // =============================================================================
 // Event

--- a/packages/cloudflare/src/services/web3.ts
+++ b/packages/cloudflare/src/services/web3.ts
@@ -16,31 +16,37 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class InvalidWeb3HostnameTarget extends Schema.TaggedErrorClass<InvalidWeb3HostnameTarget>()(
-  "InvalidWeb3HostnameTarget",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidWeb3HostnameTarget extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidWeb3HostnameTarget>()(
+    "InvalidWeb3HostnameTarget",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1006 }],
 ) {}
-T.applyErrorMatchers(InvalidWeb3HostnameTarget, [{ code: 1006 }]);
 
-export class Web3HostnameNotEntitled extends Schema.TaggedErrorClass<Web3HostnameNotEntitled>()(
-  "Web3HostnameNotEntitled",
-  { code: Schema.Number, message: Schema.String },
+export class Web3HostnameNotEntitled extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Web3HostnameNotEntitled>()(
+    "Web3HostnameNotEntitled",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1010, message: { includes: "not entitled" } }],
 ) {}
-T.applyErrorMatchers(Web3HostnameNotEntitled, [
-  { code: 1010, message: { includes: "not entitled" } },
-]);
 
-export class Web3HostnameNotFound extends Schema.TaggedErrorClass<Web3HostnameNotFound>()(
-  "Web3HostnameNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class Web3HostnameNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Web3HostnameNotFound>()("Web3HostnameNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1002 }],
 ) {}
-T.applyErrorMatchers(Web3HostnameNotFound, [{ code: 1002 }]);
 
 // =============================================================================
 // Hostname

--- a/packages/cloudflare/src/services/workers-for-platforms.ts
+++ b/packages/cloudflare/src/services/workers-for-platforms.ts
@@ -17,29 +17,37 @@ import { UploadableSchema } from "../schemas.ts";
 // Errors
 // =============================================================================
 
-export class DispatchNamespaceAlreadyExists extends Schema.TaggedErrorClass<DispatchNamespaceAlreadyExists>()(
-  "DispatchNamespaceAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class DispatchNamespaceAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DispatchNamespaceAlreadyExists>()(
+    "DispatchNamespaceAlreadyExists",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 100120 }],
 ) {}
-T.applyErrorMatchers(DispatchNamespaceAlreadyExists, [{ code: 100120 }]);
 
-export class DispatchNamespaceNotFound extends Schema.TaggedErrorClass<DispatchNamespaceNotFound>()(
-  "DispatchNamespaceNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class DispatchNamespaceNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DispatchNamespaceNotFound>()(
+    "DispatchNamespaceNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 100119 }],
 ) {}
-T.applyErrorMatchers(DispatchNamespaceNotFound, [{ code: 100119 }]);
 
-export class DispatchNamespaceScriptNotFound extends Schema.TaggedErrorClass<DispatchNamespaceScriptNotFound>()(
-  "DispatchNamespaceScriptNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class DispatchNamespaceScriptNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DispatchNamespaceScriptNotFound>()(
+    "DispatchNamespaceScriptNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 10007 }],
 ) {}
-T.applyErrorMatchers(DispatchNamespaceScriptNotFound, [{ code: 10007 }]);
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
 // =============================================================================
 // DispatchNamespace

--- a/packages/cloudflare/src/services/workers.ts
+++ b/packages/cloudflare/src/services/workers.ts
@@ -17,169 +17,206 @@ import { UploadableSchema } from "../schemas.ts";
 // Errors
 // =============================================================================
 
-export class ContentTypeRequired extends Schema.TaggedErrorClass<ContentTypeRequired>()(
-  "ContentTypeRequired",
-  { code: Schema.Number, message: Schema.String },
+export class ContentTypeRequired extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ContentTypeRequired>()("ContentTypeRequired", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10001 }],
 ) {}
-T.applyErrorMatchers(ContentTypeRequired, [{ code: 10001 }]);
 
-export class DeploymentNotFound extends Schema.TaggedErrorClass<DeploymentNotFound>()(
-  "DeploymentNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class DeploymentNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DeploymentNotFound>()("DeploymentNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10336 }],
 ) {}
-T.applyErrorMatchers(DeploymentNotFound, [{ code: 10336 }]);
 
-export class DomainNotFound extends Schema.TaggedErrorClass<DomainNotFound>()(
-  "DomainNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class DomainNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DomainNotFound>()("DomainNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 100114 }],
 ) {}
-T.applyErrorMatchers(DomainNotFound, [{ code: 100114 }]);
 
-export class DuplicateMigrationTarget extends Schema.TaggedErrorClass<DuplicateMigrationTarget>()(
-  "DuplicateMigrationTarget",
-  { code: Schema.Number, message: Schema.String },
+export class DuplicateMigrationTarget extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DuplicateMigrationTarget>()(
+    "DuplicateMigrationTarget",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [
+    {
+      code: 10074,
+      message: { includes: "cannot be the target of more than one migration" },
+    },
+  ],
 ) {}
-T.applyErrorMatchers(DuplicateMigrationTarget, [
-  {
-    code: 10074,
-    message: { includes: "cannot be the target of more than one migration" },
-  },
-]);
 
-export class DurableObjectMustBeSqlite extends Schema.TaggedErrorClass<DurableObjectMustBeSqlite>()(
-  "DurableObjectMustBeSqlite",
-  { code: Schema.Number, message: Schema.String },
+export class DurableObjectMustBeSqlite extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DurableObjectMustBeSqlite>()(
+    "DurableObjectMustBeSqlite",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 10074, message: { includes: "not a SQLite Durable Object" } }],
 ) {}
-T.applyErrorMatchers(DurableObjectMustBeSqlite, [
-  { code: 10074, message: { includes: "not a SQLite Durable Object" } },
-]);
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class HostnameAlreadyInUse extends Schema.TaggedErrorClass<HostnameAlreadyInUse>()(
-  "HostnameAlreadyInUse",
-  { code: Schema.Number, message: Schema.String },
+export class HostnameAlreadyInUse extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<HostnameAlreadyInUse>()("HostnameAlreadyInUse", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 100116 }],
 ) {}
-T.applyErrorMatchers(HostnameAlreadyInUse, [{ code: 100116 }]);
 
 T.applyErrorMatchers(InternalServerError, [
   { code: 10002, message: { includes: "An unknown error has occurred" } },
 ]);
 
-export class InvalidRoute extends Schema.TaggedErrorClass<InvalidRoute>()(
-  "InvalidRoute",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidRoute extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidRoute>()("InvalidRoute", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7003 }, { code: 7003, message: { includes: "Could not route" } }],
 ) {}
-T.applyErrorMatchers(InvalidRoute, [
-  { code: 7003 },
-  { code: 7003, message: { includes: "Could not route" } },
-]);
 
-export class InvalidRoutePattern extends Schema.TaggedErrorClass<InvalidRoutePattern>()(
-  "InvalidRoutePattern",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidRoutePattern extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidRoutePattern>()("InvalidRoutePattern", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10022 }],
 ) {}
-T.applyErrorMatchers(InvalidRoutePattern, [{ code: 10022 }]);
 
-export class InvalidWorkerScript extends Schema.TaggedErrorClass<InvalidWorkerScript>()(
-  "InvalidWorkerScript",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidWorkerScript extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidWorkerScript>()("InvalidWorkerScript", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10068 }],
 ) {}
-T.applyErrorMatchers(InvalidWorkerScript, [{ code: 10068 }]);
 
-export class ObservabilityDestinationCreateFailed extends Schema.TaggedErrorClass<ObservabilityDestinationCreateFailed>()(
-  "ObservabilityDestinationCreateFailed",
-  { code: Schema.Number, message: Schema.String },
+export class ObservabilityDestinationCreateFailed extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ObservabilityDestinationCreateFailed>()(
+    "ObservabilityDestinationCreateFailed",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 400, message: "Bad Request" }],
 ) {}
-T.applyErrorMatchers(ObservabilityDestinationCreateFailed, [
-  { status: 400, message: "Bad Request" },
-]);
 
-export class ObservabilityDestinationNotFound extends Schema.TaggedErrorClass<ObservabilityDestinationNotFound>()(
-  "ObservabilityDestinationNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class ObservabilityDestinationNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ObservabilityDestinationNotFound>()(
+    "ObservabilityDestinationNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(ObservabilityDestinationNotFound, [{ status: 404 }]);
 
-export class ObservabilityDestinationPreflightFailed extends Schema.TaggedErrorClass<ObservabilityDestinationPreflightFailed>()(
-  "ObservabilityDestinationPreflightFailed",
-  { code: Schema.Number, message: Schema.String },
+export class ObservabilityDestinationPreflightFailed extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ObservabilityDestinationPreflightFailed>()(
+    "ObservabilityDestinationPreflightFailed",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 400, message: "Bad Request" }],
 ) {}
-T.applyErrorMatchers(ObservabilityDestinationPreflightFailed, [
-  { status: 400, message: "Bad Request" },
-]);
 
-export class QueueConsumerConflict extends Schema.TaggedErrorClass<QueueConsumerConflict>()(
-  "QueueConsumerConflict",
-  { code: Schema.Number, message: Schema.String },
+export class QueueConsumerConflict extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<QueueConsumerConflict>()("QueueConsumerConflict", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10064 }],
 ) {}
-T.applyErrorMatchers(QueueConsumerConflict, [{ code: 10064 }]);
 
-export class RouteNotFound extends Schema.TaggedErrorClass<RouteNotFound>()(
-  "RouteNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class RouteNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<RouteNotFound>()("RouteNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10009 }, { status: 404 }],
 ) {}
-T.applyErrorMatchers(RouteNotFound, [{ code: 10009 }, { status: 404 }]);
 
-export class ScriptModuleNotFound extends Schema.TaggedErrorClass<ScriptModuleNotFound>()(
-  "ScriptModuleNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class ScriptModuleNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ScriptModuleNotFound>()("ScriptModuleNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10021, message: { includes: "No such module" } }],
 ) {}
-T.applyErrorMatchers(ScriptModuleNotFound, [
-  { code: 10021, message: { includes: "No such module" } },
-]);
 
-export class ScriptStartupError extends Schema.TaggedErrorClass<ScriptStartupError>()(
-  "ScriptStartupError",
-  { code: Schema.Number, message: Schema.String },
+export class ScriptStartupError extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ScriptStartupError>()("ScriptStartupError", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10021 }],
 ) {}
-T.applyErrorMatchers(ScriptStartupError, [{ code: 10021 }]);
 
-export class SecretNotFound extends Schema.TaggedErrorClass<SecretNotFound>()(
-  "SecretNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class SecretNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SecretNotFound>()("SecretNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10056 }],
 ) {}
-T.applyErrorMatchers(SecretNotFound, [{ code: 10056 }]);
 
-export class ServiceBindingConflict extends Schema.TaggedErrorClass<ServiceBindingConflict>()(
-  "ServiceBindingConflict",
-  { code: Schema.Number, message: Schema.String },
+export class ServiceBindingConflict extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ServiceBindingConflict>()("ServiceBindingConflict", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10142 }],
 ) {}
-T.applyErrorMatchers(ServiceBindingConflict, [{ code: 10142 }]);
 
-export class SubdomainAlreadyExists extends Schema.TaggedErrorClass<SubdomainAlreadyExists>()(
-  "SubdomainAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class SubdomainAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SubdomainAlreadyExists>()("SubdomainAlreadyExists", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10036 }],
 ) {}
-T.applyErrorMatchers(SubdomainAlreadyExists, [{ code: 10036 }]);
 
-export class SubdomainNotFound extends Schema.TaggedErrorClass<SubdomainNotFound>()(
-  "SubdomainNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class SubdomainNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SubdomainNotFound>()("SubdomainNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(SubdomainNotFound, [{ status: 404 }]);
 
-export class VersionNotFound extends Schema.TaggedErrorClass<VersionNotFound>()(
-  "VersionNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class VersionNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<VersionNotFound>()("VersionNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 100146 }],
 ) {}
-T.applyErrorMatchers(VersionNotFound, [{ code: 100146 }]);
 
-export class WorkerNotFound extends Schema.TaggedErrorClass<WorkerNotFound>()(
-  "WorkerNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class WorkerNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<WorkerNotFound>()("WorkerNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10007 }],
 ) {}
-T.applyErrorMatchers(WorkerNotFound, [{ code: 10007 }]);
 
-export class WorkerVersionNotFound extends Schema.TaggedErrorClass<WorkerVersionNotFound>()(
-  "WorkerVersionNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class WorkerVersionNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<WorkerVersionNotFound>()("WorkerVersionNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10071 }],
 ) {}
-T.applyErrorMatchers(WorkerVersionNotFound, [{ code: 10071 }]);
 
 // =============================================================================
 // AccountSetting

--- a/packages/cloudflare/src/services/workflows.ts
+++ b/packages/cloudflare/src/services/workflows.ts
@@ -16,53 +16,69 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class InstanceAlreadyExists extends Schema.TaggedErrorClass<InstanceAlreadyExists>()(
-  "InstanceAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class InstanceAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InstanceAlreadyExists>()("InstanceAlreadyExists", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10405 }],
 ) {}
-T.applyErrorMatchers(InstanceAlreadyExists, [{ code: 10405 }]);
 
-export class InstanceCannotTerminate extends Schema.TaggedErrorClass<InstanceCannotTerminate>()(
-  "InstanceCannotTerminate",
-  { code: Schema.Number, message: Schema.String },
+export class InstanceCannotTerminate extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InstanceCannotTerminate>()(
+    "InstanceCannotTerminate",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 10401 }],
 ) {}
-T.applyErrorMatchers(InstanceCannotTerminate, [{ code: 10401 }]);
 
-export class InstanceNotFound extends Schema.TaggedErrorClass<InstanceNotFound>()(
-  "InstanceNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class InstanceNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InstanceNotFound>()("InstanceNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10201 }, { code: 10400 }],
 ) {}
-T.applyErrorMatchers(InstanceNotFound, [{ code: 10201 }, { code: 10400 }]);
 
-export class InvalidBody extends Schema.TaggedErrorClass<InvalidBody>()(
-  "InvalidBody",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidBody extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidBody>()("InvalidBody", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10002 }],
 ) {}
-T.applyErrorMatchers(InvalidBody, [{ code: 10002 }]);
 
-export class InvalidRoute extends Schema.TaggedErrorClass<InvalidRoute>()(
-  "InvalidRoute",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidRoute extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidRoute>()("InvalidRoute", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 7003 }],
 ) {}
-T.applyErrorMatchers(InvalidRoute, [{ code: 7003 }]);
 
-export class VersionNotFound extends Schema.TaggedErrorClass<VersionNotFound>()(
-  "VersionNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class VersionNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<VersionNotFound>()("VersionNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10300 }],
 ) {}
-T.applyErrorMatchers(VersionNotFound, [{ code: 10300 }]);
 
-export class WorkflowInternalError extends Schema.TaggedErrorClass<WorkflowInternalError>()(
-  "WorkflowInternalError",
-  { code: Schema.Number, message: Schema.String },
+export class WorkflowInternalError extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<WorkflowInternalError>()("WorkflowInternalError", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10001 }],
 ) {}
-T.applyErrorMatchers(WorkflowInternalError, [{ code: 10001 }]);
 
-export class WorkflowNotFound extends Schema.TaggedErrorClass<WorkflowNotFound>()(
-  "WorkflowNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class WorkflowNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<WorkflowNotFound>()("WorkflowNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10200 }],
 ) {}
-T.applyErrorMatchers(WorkflowNotFound, [{ code: 10200 }]);
 
 // =============================================================================
 // Instance

--- a/packages/cloudflare/src/services/zaraz.ts
+++ b/packages/cloudflare/src/services/zaraz.ts
@@ -16,17 +16,21 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
-  code: Schema.Number,
-  message: Schema.String,
-}) {}
-T.applyErrorMatchers(NotFound, [{ status: 404 }]);
+export class NotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<NotFound>()("NotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404 }],
+) {}
 
 // =============================================================================
 // Config

--- a/packages/cloudflare/src/services/zero-trust.ts
+++ b/packages/cloudflare/src/services/zero-trust.ts
@@ -17,278 +17,355 @@ import { SensitiveString } from "../sensitive.ts";
 // Errors
 // =============================================================================
 
-export class AccessBookmarkNotFound extends Schema.TaggedErrorClass<AccessBookmarkNotFound>()(
-  "AccessBookmarkNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class AccessBookmarkNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<AccessBookmarkNotFound>()("AccessBookmarkNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 12045 }, { code: 12135 }, { code: 11021 }],
 ) {}
-T.applyErrorMatchers(AccessBookmarkNotFound, [
-  { code: 12045 },
-  { code: 12135 },
-  { code: 11021 },
-]);
 
-export class AccessCertificateNotFound extends Schema.TaggedErrorClass<AccessCertificateNotFound>()(
-  "AccessCertificateNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class AccessCertificateNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<AccessCertificateNotFound>()(
+    "AccessCertificateNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 12135 }],
 ) {}
-T.applyErrorMatchers(AccessCertificateNotFound, [{ code: 12135 }]);
 
-export class AccessCertificateQuotaExceeded extends Schema.TaggedErrorClass<AccessCertificateQuotaExceeded>()(
-  "AccessCertificateQuotaExceeded",
-  { code: Schema.Number, message: Schema.String },
+export class AccessCertificateQuotaExceeded extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<AccessCertificateQuotaExceeded>()(
+    "AccessCertificateQuotaExceeded",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 12130, message: { includes: "maximum number of certificates" } }],
 ) {}
-T.applyErrorMatchers(AccessCertificateQuotaExceeded, [
-  { code: 12130, message: { includes: "maximum number of certificates" } },
-]);
 
-export class AccessCustomPageNotFound extends Schema.TaggedErrorClass<AccessCustomPageNotFound>()(
-  "AccessCustomPageNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class AccessCustomPageNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<AccessCustomPageNotFound>()(
+    "AccessCustomPageNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 12135 }],
 ) {}
-T.applyErrorMatchers(AccessCustomPageNotFound, [{ code: 12135 }]);
 
-export class AccessCustomPagesNotEntitled extends Schema.TaggedErrorClass<AccessCustomPagesNotEntitled>()(
-  "AccessCustomPagesNotEntitled",
-  { code: Schema.Number, message: Schema.String },
-) {}
-T.applyErrorMatchers(AccessCustomPagesNotEntitled, [
-  {
-    code: 12133,
-    message: { includes: "does not have permission for custom pages" },
-  },
-]);
-
-export class AccessGroupNotFound extends Schema.TaggedErrorClass<AccessGroupNotFound>()(
-  "AccessGroupNotFound",
-  { code: Schema.Number, message: Schema.String },
-) {}
-T.applyErrorMatchers(AccessGroupNotFound, [{ code: 12152 }]);
-
-export class AccessIdentityProviderNotFound extends Schema.TaggedErrorClass<AccessIdentityProviderNotFound>()(
-  "AccessIdentityProviderNotFound",
-  { code: Schema.Number, message: Schema.String },
-) {}
-T.applyErrorMatchers(AccessIdentityProviderNotFound, [{ code: 12135 }]);
-
-export class AccessServiceTokenNotFound extends Schema.TaggedErrorClass<AccessServiceTokenNotFound>()(
-  "AccessServiceTokenNotFound",
-  { code: Schema.Number, message: Schema.String },
-) {}
-T.applyErrorMatchers(AccessServiceTokenNotFound, [{ code: 12135 }]);
-
-export class AccessTagNotFound extends Schema.TaggedErrorClass<AccessTagNotFound>()(
-  "AccessTagNotFound",
-  { code: Schema.Number, message: Schema.String },
-) {}
-T.applyErrorMatchers(AccessTagNotFound, [{ code: 12135 }]);
-
-export class CannotDeleteDefaultGatewayLocation extends Schema.TaggedErrorClass<CannotDeleteDefaultGatewayLocation>()(
-  "CannotDeleteDefaultGatewayLocation",
-  { code: Schema.Number, message: Schema.String },
-) {}
-T.applyErrorMatchers(CannotDeleteDefaultGatewayLocation, [{ code: 1217 }]);
-
-export class CannotDemoteDefaultGatewayLocation extends Schema.TaggedErrorClass<CannotDemoteDefaultGatewayLocation>()(
-  "CannotDemoteDefaultGatewayLocation",
-  { code: Schema.Number, message: Schema.String },
-) {}
-T.applyErrorMatchers(CannotDemoteDefaultGatewayLocation, [{ code: 1216 }]);
-
-export class DeviceNetworkNotFound extends Schema.TaggedErrorClass<DeviceNetworkNotFound>()(
-  "DeviceNetworkNotFound",
-  { code: Schema.Number, message: Schema.String },
-) {}
-T.applyErrorMatchers(DeviceNetworkNotFound, [{ code: 2053 }]);
-
-export class DevicePolicyNotFound extends Schema.TaggedErrorClass<DevicePolicyNotFound>()(
-  "DevicePolicyNotFound",
-  { code: Schema.Number, message: Schema.String },
-) {}
-T.applyErrorMatchers(DevicePolicyNotFound, [{ code: 2052 }]);
-
-export class DevicePostureIntegrationNotFound extends Schema.TaggedErrorClass<DevicePostureIntegrationNotFound>()(
-  "DevicePostureIntegrationNotFound",
-  { code: Schema.Number, message: Schema.String },
-) {}
-T.applyErrorMatchers(DevicePostureIntegrationNotFound, [{ status: 404 }]);
-
-export class DexTestNotFound extends Schema.TaggedErrorClass<DexTestNotFound>()(
-  "DexTestNotFound",
-  { code: Schema.Number, message: Schema.String },
-) {}
-T.applyErrorMatchers(DexTestNotFound, [{ status: 404 }]);
-
-export class DlpEntryNotFound extends Schema.TaggedErrorClass<DlpEntryNotFound>()(
-  "DlpEntryNotFound",
-  { code: Schema.Number, message: Schema.String },
-) {}
-T.applyErrorMatchers(DlpEntryNotFound, [{ status: 404 }]);
-
-export class DlpProfileNotFound extends Schema.TaggedErrorClass<DlpProfileNotFound>()(
-  "DlpProfileNotFound",
-  { code: Schema.Number, message: Schema.String },
-) {}
-T.applyErrorMatchers(DlpProfileNotFound, [{ status: 404 }]);
-
-export class DuplicateTunnelName extends Schema.TaggedErrorClass<DuplicateTunnelName>()(
-  "DuplicateTunnelName",
-  { code: Schema.Number, message: Schema.String },
-) {}
-T.applyErrorMatchers(DuplicateTunnelName, [{ code: 1013 }]);
-
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
-) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
-
-export class GatewayCertificateInUse extends Schema.TaggedErrorClass<GatewayCertificateInUse>()(
-  "GatewayCertificateInUse",
-  { code: Schema.Number, message: Schema.String },
-) {}
-T.applyErrorMatchers(GatewayCertificateInUse, [{ code: 2118 }]);
-
-export class GatewayCertificateNotFound extends Schema.TaggedErrorClass<GatewayCertificateNotFound>()(
-  "GatewayCertificateNotFound",
-  { code: Schema.Number, message: Schema.String },
-) {}
-T.applyErrorMatchers(GatewayCertificateNotFound, [{ code: 2027 }]);
-
-export class GatewayCertificateQuotaReached extends Schema.TaggedErrorClass<GatewayCertificateQuotaReached>()(
-  "GatewayCertificateQuotaReached",
-  { code: Schema.Number, message: Schema.String },
-) {}
-T.applyErrorMatchers(GatewayCertificateQuotaReached, [
-  {
-    status: 400,
-    message: {
-      includes: "Up to 3 certificates may be created in a 24 hour period",
+export class AccessCustomPagesNotEntitled extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<AccessCustomPagesNotEntitled>()(
+    "AccessCustomPagesNotEntitled",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [
+    {
+      code: 12133,
+      message: { includes: "does not have permission for custom pages" },
     },
-  },
-]);
-
-export class GatewayListNotFound extends Schema.TaggedErrorClass<GatewayListNotFound>()(
-  "GatewayListNotFound",
-  { code: Schema.Number, message: Schema.String },
+  ],
 ) {}
-T.applyErrorMatchers(GatewayListNotFound, [{ code: 2218 }]);
 
-export class GatewayLocationNotFound extends Schema.TaggedErrorClass<GatewayLocationNotFound>()(
-  "GatewayLocationNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class AccessGroupNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<AccessGroupNotFound>()("AccessGroupNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 12152 }],
 ) {}
-T.applyErrorMatchers(GatewayLocationNotFound, [{ code: 1103 }]);
 
-export class HostnameRouteAlreadyRouted extends Schema.TaggedErrorClass<HostnameRouteAlreadyRouted>()(
-  "HostnameRouteAlreadyRouted",
-  { code: Schema.Number, message: Schema.String },
+export class AccessIdentityProviderNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<AccessIdentityProviderNotFound>()(
+    "AccessIdentityProviderNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 12135 }],
 ) {}
-T.applyErrorMatchers(HostnameRouteAlreadyRouted, [
-  { status: 409, message: { includes: "already routed to another tunnel" } },
-]);
 
-export class HostnameRouteNotFound extends Schema.TaggedErrorClass<HostnameRouteNotFound>()(
-  "HostnameRouteNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class AccessServiceTokenNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<AccessServiceTokenNotFound>()(
+    "AccessServiceTokenNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 12135 }],
 ) {}
-T.applyErrorMatchers(HostnameRouteNotFound, [{ status: 404 }]);
 
-export class InvalidPostureIntegrationConfig extends Schema.TaggedErrorClass<InvalidPostureIntegrationConfig>()(
-  "InvalidPostureIntegrationConfig",
-  { code: Schema.Number, message: Schema.String },
+export class AccessTagNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<AccessTagNotFound>()("AccessTagNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 12135 }],
 ) {}
-T.applyErrorMatchers(InvalidPostureIntegrationConfig, [
-  { status: 400, message: { includes: "invalid posture integration request" } },
-]);
 
-export class IpProxyEndpointsRequireEnterprise extends Schema.TaggedErrorClass<IpProxyEndpointsRequireEnterprise>()(
-  "IpProxyEndpointsRequireEnterprise",
-  { code: Schema.Number, message: Schema.String },
+export class CannotDeleteDefaultGatewayLocation extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<CannotDeleteDefaultGatewayLocation>()(
+    "CannotDeleteDefaultGatewayLocation",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1217 }],
 ) {}
-T.applyErrorMatchers(IpProxyEndpointsRequireEnterprise, [{ code: 2009 }]);
 
-export class McpPortalHostnameInUse extends Schema.TaggedErrorClass<McpPortalHostnameInUse>()(
-  "McpPortalHostnameInUse",
-  { code: Schema.Number, message: Schema.String },
+export class CannotDemoteDefaultGatewayLocation extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<CannotDemoteDefaultGatewayLocation>()(
+    "CannotDemoteDefaultGatewayLocation",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1216 }],
 ) {}
-T.applyErrorMatchers(McpPortalHostnameInUse, [
-  {
-    status: 400,
-    message: { includes: "already in use in a different MCP Portal" },
-  },
-]);
 
-export class McpPortalNotFound extends Schema.TaggedErrorClass<McpPortalNotFound>()(
-  "McpPortalNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class DeviceNetworkNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DeviceNetworkNotFound>()("DeviceNetworkNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 2053 }],
 ) {}
-T.applyErrorMatchers(McpPortalNotFound, [{ status: 404 }]);
 
-export class OrganizationAlreadyExists extends Schema.TaggedErrorClass<OrganizationAlreadyExists>()(
-  "OrganizationAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class DevicePolicyNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DevicePolicyNotFound>()("DevicePolicyNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 2052 }],
 ) {}
-T.applyErrorMatchers(OrganizationAlreadyExists, [{ code: 11002 }]);
 
-export class OrganizationNotFound extends Schema.TaggedErrorClass<OrganizationNotFound>()(
-  "OrganizationNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class DevicePostureIntegrationNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DevicePostureIntegrationNotFound>()(
+    "DevicePostureIntegrationNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(OrganizationNotFound, [{ status: 404 }]);
 
-export class PostureRuleNotFound extends Schema.TaggedErrorClass<PostureRuleNotFound>()(
-  "PostureRuleNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class DexTestNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DexTestNotFound>()("DexTestNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(PostureRuleNotFound, [{ code: 6024 }]);
 
-export class ProxyEndpointNotFound extends Schema.TaggedErrorClass<ProxyEndpointNotFound>()(
-  "ProxyEndpointNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class DlpEntryNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DlpEntryNotFound>()("DlpEntryNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(ProxyEndpointNotFound, [{ code: 2002 }]);
 
-export class RiskScoringIntegrationNotFound extends Schema.TaggedErrorClass<RiskScoringIntegrationNotFound>()(
-  "RiskScoringIntegrationNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class DlpProfileNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DlpProfileNotFound>()("DlpProfileNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404 }],
 ) {}
-T.applyErrorMatchers(RiskScoringIntegrationNotFound, [{ status: 404 }]);
 
-export class TargetNotFound extends Schema.TaggedErrorClass<TargetNotFound>()(
-  "TargetNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class DuplicateTunnelName extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DuplicateTunnelName>()("DuplicateTunnelName", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1013 }],
 ) {}
-T.applyErrorMatchers(TargetNotFound, [{ status: 404 }]);
 
-export class TunnelConfigurationNotFound extends Schema.TaggedErrorClass<TunnelConfigurationNotFound>()(
-  "TunnelConfigurationNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(TunnelConfigurationNotFound, [{ code: 1055 }]);
 
-export class TunnelNotFound extends Schema.TaggedErrorClass<TunnelNotFound>()(
-  "TunnelNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class GatewayCertificateInUse extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<GatewayCertificateInUse>()(
+    "GatewayCertificateInUse",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 2118 }],
 ) {}
-T.applyErrorMatchers(TunnelNotFound, [{ code: 1002 }, { status: 404 }]);
 
-export class TunnelTokenNotFound extends Schema.TaggedErrorClass<TunnelTokenNotFound>()(
-  "TunnelTokenNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class GatewayCertificateNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<GatewayCertificateNotFound>()(
+    "GatewayCertificateNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 2027 }],
 ) {}
-T.applyErrorMatchers(TunnelTokenNotFound, [{ code: 1054 }]);
 
-export class VirtualNetworkConflict extends Schema.TaggedErrorClass<VirtualNetworkConflict>()(
-  "VirtualNetworkConflict",
-  { code: Schema.Number, message: Schema.String },
+export class GatewayCertificateQuotaReached extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<GatewayCertificateQuotaReached>()(
+    "GatewayCertificateQuotaReached",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [
+    {
+      status: 400,
+      message: {
+        includes: "Up to 3 certificates may be created in a 24 hour period",
+      },
+    },
+  ],
 ) {}
-T.applyErrorMatchers(VirtualNetworkConflict, [{ code: 1014 }]);
 
-export class VirtualNetworkNotFound extends Schema.TaggedErrorClass<VirtualNetworkNotFound>()(
-  "VirtualNetworkNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class GatewayListNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<GatewayListNotFound>()("GatewayListNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 2218 }],
 ) {}
-T.applyErrorMatchers(VirtualNetworkNotFound, [{ code: 1046 }]);
+
+export class GatewayLocationNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<GatewayLocationNotFound>()(
+    "GatewayLocationNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1103 }],
+) {}
+
+export class HostnameRouteAlreadyRouted extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<HostnameRouteAlreadyRouted>()(
+    "HostnameRouteAlreadyRouted",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 409, message: { includes: "already routed to another tunnel" } }],
+) {}
+
+export class HostnameRouteNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<HostnameRouteNotFound>()("HostnameRouteNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404 }],
+) {}
+
+export class InvalidPostureIntegrationConfig extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidPostureIntegrationConfig>()(
+    "InvalidPostureIntegrationConfig",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [
+    {
+      status: 400,
+      message: { includes: "invalid posture integration request" },
+    },
+  ],
+) {}
+
+export class IpProxyEndpointsRequireEnterprise extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<IpProxyEndpointsRequireEnterprise>()(
+    "IpProxyEndpointsRequireEnterprise",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 2009 }],
+) {}
+
+export class McpPortalHostnameInUse extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<McpPortalHostnameInUse>()("McpPortalHostnameInUse", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [
+    {
+      status: 400,
+      message: { includes: "already in use in a different MCP Portal" },
+    },
+  ],
+) {}
+
+export class McpPortalNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<McpPortalNotFound>()("McpPortalNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404 }],
+) {}
+
+export class OrganizationAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<OrganizationAlreadyExists>()(
+    "OrganizationAlreadyExists",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 11002 }],
+) {}
+
+export class OrganizationNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<OrganizationNotFound>()("OrganizationNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404 }],
+) {}
+
+export class PostureRuleNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<PostureRuleNotFound>()("PostureRuleNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 6024 }],
+) {}
+
+export class ProxyEndpointNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ProxyEndpointNotFound>()("ProxyEndpointNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 2002 }],
+) {}
+
+export class RiskScoringIntegrationNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<RiskScoringIntegrationNotFound>()(
+    "RiskScoringIntegrationNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ status: 404 }],
+) {}
+
+export class TargetNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<TargetNotFound>()("TargetNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404 }],
+) {}
+
+export class TunnelConfigurationNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<TunnelConfigurationNotFound>()(
+    "TunnelConfigurationNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 1055 }],
+) {}
+
+export class TunnelNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<TunnelNotFound>()("TunnelNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1002 }, { status: 404 }],
+) {}
+
+export class TunnelTokenNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<TunnelTokenNotFound>()("TunnelTokenNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1054 }],
+) {}
+
+export class VirtualNetworkConflict extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<VirtualNetworkConflict>()("VirtualNetworkConflict", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1014 }],
+) {}
+
+export class VirtualNetworkNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<VirtualNetworkNotFound>()("VirtualNetworkNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1046 }],
+) {}
 
 // =============================================================================
 // AccessAiControlMcpPortal

--- a/packages/cloudflare/src/services/zones.ts
+++ b/packages/cloudflare/src/services/zones.ts
@@ -16,70 +16,89 @@ import { type DefaultErrors } from "../errors.ts";
 // Errors
 // =============================================================================
 
-export class CustomNameserverSetNotFound extends Schema.TaggedErrorClass<CustomNameserverSetNotFound>()(
-  "CustomNameserverSetNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class CustomNameserverSetNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<CustomNameserverSetNotFound>()(
+    "CustomNameserverSetNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [
+    {
+      code: 1001,
+      message: { includes: "Custom Nameserver set doesn't exist" },
+    },
+  ],
 ) {}
-T.applyErrorMatchers(CustomNameserverSetNotFound, [
-  { code: 1001, message: { includes: "Custom Nameserver set doesn't exist" } },
-]);
 
-export class DomainNotRegistered extends Schema.TaggedErrorClass<DomainNotRegistered>()(
-  "DomainNotRegistered",
-  { code: Schema.Number, message: Schema.String },
+export class DomainNotRegistered extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DomainNotRegistered>()("DomainNotRegistered", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1099 }],
 ) {}
-T.applyErrorMatchers(DomainNotRegistered, [{ code: 1099 }]);
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
-  "Forbidden",
-  { code: Schema.Number, message: Schema.String },
+export class Forbidden extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 403 }],
 ) {}
-T.applyErrorMatchers(Forbidden, [{ status: 403 }]);
 
-export class InvalidDomain extends Schema.TaggedErrorClass<InvalidDomain>()(
-  "InvalidDomain",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidDomain extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidDomain>()("InvalidDomain", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1002 }],
 ) {}
-T.applyErrorMatchers(InvalidDomain, [{ code: 1002 }]);
 
-export class InvalidZoneIdentifier extends Schema.TaggedErrorClass<InvalidZoneIdentifier>()(
-  "InvalidZoneIdentifier",
-  { code: Schema.Number, message: Schema.String },
+export class InvalidZoneIdentifier extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<InvalidZoneIdentifier>()("InvalidZoneIdentifier", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 9109, message: { includes: "Invalid zone identifier" } }],
 ) {}
-T.applyErrorMatchers(InvalidZoneIdentifier, [
-  { code: 9109, message: { includes: "Invalid zone identifier" } },
-]);
 
-export class SubdomainNotAllowed extends Schema.TaggedErrorClass<SubdomainNotAllowed>()(
-  "SubdomainNotAllowed",
-  { code: Schema.Number, message: Schema.String },
+export class SubdomainNotAllowed extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SubdomainNotAllowed>()("SubdomainNotAllowed", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1116 }],
 ) {}
-T.applyErrorMatchers(SubdomainNotAllowed, [{ code: 1116 }]);
 
-export class ZoneAlreadyExists extends Schema.TaggedErrorClass<ZoneAlreadyExists>()(
-  "ZoneAlreadyExists",
-  { code: Schema.Number, message: Schema.String },
+export class ZoneAlreadyExists extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ZoneAlreadyExists>()("ZoneAlreadyExists", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1061 }],
 ) {}
-T.applyErrorMatchers(ZoneAlreadyExists, [{ code: 1061 }]);
 
-export class ZoneHoldNotFound extends Schema.TaggedErrorClass<ZoneHoldNotFound>()(
-  "ZoneHoldNotFound",
-  { code: Schema.Number, message: Schema.String },
+export class ZoneHoldNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ZoneHoldNotFound>()("ZoneHoldNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 1003, message: { includes: "No Zone Hold Found" } }],
 ) {}
-T.applyErrorMatchers(ZoneHoldNotFound, [
-  { code: 1003, message: { includes: "No Zone Hold Found" } },
-]);
 
-export class ZoneHoldsRequireEnterprise extends Schema.TaggedErrorClass<ZoneHoldsRequireEnterprise>()(
-  "ZoneHoldsRequireEnterprise",
-  { code: Schema.Number, message: Schema.String },
+export class ZoneHoldsRequireEnterprise extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ZoneHoldsRequireEnterprise>()(
+    "ZoneHoldsRequireEnterprise",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [
+    {
+      code: 1005,
+      message: {
+        includes: "Zone holds are only available on Enterprise zones",
+      },
+    },
+  ],
 ) {}
-T.applyErrorMatchers(ZoneHoldsRequireEnterprise, [
-  {
-    code: 1005,
-    message: { includes: "Zone holds are only available on Enterprise zones" },
-  },
-]);
 
 // =============================================================================
 // ActivationCheck

--- a/packages/cloudflare/src/traits.ts
+++ b/packages/cloudflare/src/traits.ts
@@ -22,16 +22,33 @@ export interface ErrorMatcher {
 }
 
 /**
- * Apply error matchers directly to a class's AST annotations.
- * Used for TaggedErrorClass where .pipe() on a class returns a schema
- * (not a class), breaking `extends ... .pipe(...)`.
+ * Apply error matchers to a class's AST annotations, returning the class so it
+ * can be used directly in an `extends` clause:
+ *
+ * ```ts
+ * export class Foo extends T.applyErrorMatchers(
+ *   Schema.TaggedErrorClass<Foo>()("Foo", { ... }),
+ *   [{ code: 1234 }],
+ * ) {}
+ * ```
+ *
+ * Mutating the base class's annotations propagates to the subclass — Effect's
+ * Class API reuses the same AST reference — so matchers stay readable via
+ * `getErrorMatchers(Foo.ast)`. Returning the class (instead of running as a
+ * void top-level statement) keeps the module free of bare side-effect
+ * statements, so the bundler can tree-shake unused error classes out of Worker
+ * bundles.
+ *
+ * `.pipe()` is deliberately not used: piping a class returns a schema (not a
+ * class), which can't appear in an `extends` clause.
  */
-export const applyErrorMatchers = (
-  cls: { ast: AST.AST },
+export const applyErrorMatchers = <C extends { ast: AST.AST }>(
+  cls: C,
   matchers: ErrorMatcher[],
-): void => {
+): C => {
   const annotations = cls.ast.annotations as Record<symbol, unknown>;
   annotations[errorMatchersSymbol] = matchers;
+  return cls;
 };
 
 export const getErrorMatchers = (ast: AST.AST) =>


### PR DESCRIPTION
Error classes were annotated with a bare top-level `applyErrorMatchers` statement, which is a module side effect. The bundler therefore keeps the whole service module — and its `@distilled.cloud/cloudflare/<svc>` import — alive in Worker bundles even when none of its exports are used. A Worker that only touches the binding registry (e.g. `alchemy/Cloudflare` → `isFlagshipApp`) ends up shipping a dangling `import "@distilled.cloud/cloudflare/flagship"`, which Cloudflare rejects at upload with `ScriptModuleNotFound`.

Pipe the matcher onto the class inside the `extends` clause so there is no bare side-effect statement and unused error classes tree-shake away.

```diff
-export class FlagshipAppNotFound extends Schema.TaggedErrorClass<FlagshipAppNotFound>()(
-  "FlagshipAppNotFound",
-  { code: Schema.Number, message: Schema.String },
-) {}
-T.applyErrorMatchers(FlagshipAppNotFound, [
-  { status: 404, message: { includes: "App not found" } },
-]);
+export class FlagshipAppNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<FlagshipAppNotFound>()("FlagshipAppNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ status: 404, message: { includes: "App not found" } }],
+) {}
```

`applyErrorMatchers` now returns the class it annotates:

```diff
-export const applyErrorMatchers = (
-  cls: { ast: AST.AST },
-  matchers: ErrorMatcher[],
-): void => {
+export const applyErrorMatchers = <C extends { ast: AST.AST }>(
+  cls: C,
+  matchers: ErrorMatcher[],
+): C => {
   const annotations = cls.ast.annotations as Record<symbol, unknown>;
   annotations[errorMatchersSymbol] = matchers;
+  return cls;
 };
```

Mutating the base class's AST annotations still propagates to the subclass — Effect's Class API reuses the same AST reference (`Sub.ast === Base.ast`) — so `getErrorMatchers(Foo.ast)` is unchanged and error matching behaves identically.

Changes:

- `traits.ts` — `applyErrorMatchers` returns the class.
- `scripts/generate.ts` — emit the wrapped-`extends` form.
- Regenerated all Cloudflare services (diff confined to error-class declarations).

Verified by bundling a Worker that imports `@alchemy.run/pr-package` (which pulls the full `alchemy/Cloudflare` barrel): before, the bundle contained `import "@distilled.cloud/cloudflare/flagship"` and upload failed with `ScriptModuleNotFound`; after, the import is gone, the Worker deploys, and the auth integration test passes.

Note: the `sharedErrorTags` path (shared error classes imported from another module, mutated per-service) still emits a bare statement — it has no class to extend — and is left as-is; it is not the cause of the observed leak.
