### PR TITLE
fix(coinbase): sign CDP requests with URI

### DIFF
--- a/packages/coinbase/src/client.ts
+++ b/packages/coinbase/src/client.ts
@@ -115,9 +115,14 @@ const resolveSigningKey = (
  *
  * The JWT includes:
  * - header: { alg, kid, typ: "JWT", nonce }
- * - payload: { sub, iss: "cdp", iat, nbf, exp }
+ * - payload: { sub, iss: "cdp", aud, nbf, exp, uri }
  */
-const generateJwt = (apiKeyId: string, apiKeySecret: string): string => {
+const generateJwt = (
+  apiKeyId: string,
+  apiKeySecret: string,
+  method: string,
+  uri: string,
+): string => {
   const { jwsAlg, key } = resolveSigningKey(apiKeySecret);
 
   const now = Math.floor(Date.now() / 1000);
@@ -130,9 +135,10 @@ const generateJwt = (apiKeyId: string, apiKeySecret: string): string => {
   const payload = {
     sub: apiKeyId,
     iss: "cdp",
-    iat: now,
+    aud: ["cdp_service"],
     nbf: now,
     exp: now + 120,
+    uri: `${method} ${uri}`,
   };
 
   const headerB64 = base64url(Buffer.from(JSON.stringify(header)));
@@ -218,7 +224,15 @@ const matchError = (
   errorBody: unknown,
   _errors?: readonly unknown[],
   headers?: Record<string, string | undefined>,
-): Effect.Effect<never, unknown> => {
+): Effect.Effect<unknown, unknown> => {
+  if (
+    errorBody &&
+    typeof errorBody === "object" &&
+    ("isValid" in errorBody || "success" in errorBody)
+  ) {
+    return Effect.succeed(errorBody);
+  }
+
   try {
     const parsed = Schema.decodeUnknownSync(CoinbaseErrorResponse)(errorBody);
     const errorProps = {
@@ -289,9 +303,17 @@ const matchError = (
 export const API = makeAPI<Credentials>({
   credentials: Credentials as any,
   getBaseUrl: (creds: any) => (creds as Config).apiBaseUrl,
-  getAuthHeaders: (creds: any) => {
-    const c = creds as Config;
-    const jwt = generateJwt(c.apiKeyId, Redacted.value(c.apiKeySecret));
+  getAuthHeaders: () => ({}),
+  getRequestHeaders: (_requestOptions, { method, parts, credentials }) => {
+    const c = credentials as Config;
+    const baseUrl = new URL(c.apiBaseUrl);
+    const uri = `${baseUrl.host}${baseUrl.pathname}${parts.path}`;
+    const jwt = generateJwt(
+      c.apiKeyId,
+      Redacted.value(c.apiKeySecret),
+      method,
+      uri,
+    );
     return {
       Authorization: `Bearer ${jwt}`,
     };


### PR DESCRIPTION
## Summary
- Include Coinbase current JWT audience and request-bound URI claims when signing CDP REST requests.
- Generate Authorization headers from the resolved request method and path instead of using a static generic token.
- Return x402 protocol result bodies from verify/settle responses even when Coinbase uses non-2xx status codes.

## Context
Coinbase current REST auth docs require JWTs to include an audience claim and a request URI claim. Without those claims, otherwise-valid CDP key id and secret pairs are rejected with 401 Unauthorized. x402 verify/settle can also return protocol results such as invalid or failed payment bodies on HTTP error statuses; those should be surfaced to callers instead of wrapped as generic Coinbase errors.

## Validation
- bunx oxlint packages/coinbase/src/client.ts
- bunx oxfmt --check packages/coinbase/src/client.ts
- bun --filter @distilled.cloud/coinbase check was attempted, but this fresh clone currently fails on unrelated generated-operation/type resolution errors across many generated operation files before this focused client change can be isolated.

## External Reproduction
The same credential pair that failed through the previous SDK auth path succeeds against Coinbase when signed with the documented audience and URI claims; x402 verify then returns the expected protocol body instead of 401 Unauthorized.