### PR TITLE
fix(core): emit boolean OpenAPI enum literals

### DIFF
--- a/packages/core/scripts/generate-openapi.ts
+++ b/packages/core/scripts/generate-openapi.ts
@@ -244,8 +244,13 @@ function renderEnumLiterals(
   type: string | undefined,
 ): string {
   const isNumeric = type === "integer" || type === "number";
+  const isBoolean = type === "boolean";
   const literals = values
-    .map((v) => (isNumeric ? String(v) : `"${escapeStringLiteral(String(v))}"`))
+    .map((v) =>
+      isBoolean || isNumeric
+        ? String(v)
+        : `"${escapeStringLiteral(String(v))}"`,
+    )
     .join(", ");
   return `Schema.Literals([${literals}])`;
 }

--- a/packages/posthog/src/operations/endpoints/endpointsLastExecutionTimesCreate.ts
+++ b/packages/posthog/src/operations/endpoints/endpointsLastExecutionTimesCreate.ts
@@ -32,7 +32,7 @@ export const EndpointsLastExecutionTimesCreateOutput =
         insight_id: Schema.optional(Schema.NullOr(Schema.Number)),
         labels: Schema.optional(Schema.NullOr(Schema.Array(Schema.String))),
         pickup_time: Schema.optional(Schema.NullOr(Schema.String)),
-        query_async: Schema.optional(Schema.Literals(["true"])),
+        query_async: Schema.optional(Schema.Literals([true])),
         query_progress: Schema.optional(
           Schema.Struct({
             active_cpu_time: Schema.optional(Schema.Number),

--- a/packages/posthog/src/operations/query/queryRetrieve.ts
+++ b/packages/posthog/src/operations/query/queryRetrieve.ts
@@ -26,7 +26,7 @@ export const QueryRetrieveOutput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       insight_id: Schema.optional(Schema.NullOr(Schema.Number)),
       labels: Schema.optional(Schema.NullOr(Schema.Array(Schema.String))),
       pickup_time: Schema.optional(Schema.NullOr(Schema.String)),
-      query_async: Schema.optional(Schema.Literals(["true"])),
+      query_async: Schema.optional(Schema.Literals([true])),
       query_progress: Schema.optional(
         Schema.Struct({
           active_cpu_time: Schema.optional(Schema.Number),

--- a/packages/stripe/src/operations/DeleteAccountsAccount.ts
+++ b/packages/stripe/src/operations/DeleteAccountsAccount.ts
@@ -18,7 +18,7 @@ export type DeleteAccountsAccountInput = typeof DeleteAccountsAccountInput.Type;
 // Output Schema
 export const DeleteAccountsAccountOutput =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    deleted: Schema.Literals(["true"]),
+    deleted: Schema.Literals([true]),
     id: Schema.String,
     object: Schema.Literals(["account"]),
   });

--- a/packages/stripe/src/operations/DeleteAccountsAccountPersonsPerson.ts
+++ b/packages/stripe/src/operations/DeleteAccountsAccountPersonsPerson.ts
@@ -20,7 +20,7 @@ export type DeleteAccountsAccountPersonsPersonInput =
 // Output Schema
 export const DeleteAccountsAccountPersonsPersonOutput =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    deleted: Schema.Literals(["true"]),
+    deleted: Schema.Literals([true]),
     id: Schema.String,
     object: Schema.Literals(["person"]),
   });

--- a/packages/stripe/src/operations/DeleteApplePayDomainsDomain.ts
+++ b/packages/stripe/src/operations/DeleteApplePayDomainsDomain.ts
@@ -19,7 +19,7 @@ export type DeleteApplePayDomainsDomainInput =
 // Output Schema
 export const DeleteApplePayDomainsDomainOutput =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    deleted: Schema.Literals(["true"]),
+    deleted: Schema.Literals([true]),
     id: Schema.String,
     object: Schema.Literals(["apple_pay_domain"]),
   });

--- a/packages/stripe/src/operations/DeleteCouponsCoupon.ts
+++ b/packages/stripe/src/operations/DeleteCouponsCoupon.ts
@@ -18,7 +18,7 @@ export type DeleteCouponsCouponInput = typeof DeleteCouponsCouponInput.Type;
 // Output Schema
 export const DeleteCouponsCouponOutput =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    deleted: Schema.Literals(["true"]),
+    deleted: Schema.Literals([true]),
     id: Schema.String,
     object: Schema.Literals(["coupon"]),
   });

--- a/packages/stripe/src/operations/DeleteCustomersCustomer.ts
+++ b/packages/stripe/src/operations/DeleteCustomersCustomer.ts
@@ -19,7 +19,7 @@ export type DeleteCustomersCustomerInput =
 // Output Schema
 export const DeleteCustomersCustomerOutput =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    deleted: Schema.Literals(["true"]),
+    deleted: Schema.Literals([true]),
     id: Schema.String,
     object: Schema.Literals(["customer"]),
   });

--- a/packages/stripe/src/operations/DeleteCustomersCustomerDiscount.ts
+++ b/packages/stripe/src/operations/DeleteCustomersCustomerDiscount.ts
@@ -22,7 +22,7 @@ export const DeleteCustomersCustomerDiscountOutput =
     checkout_session: Schema.NullOr(Schema.String),
     customer: Schema.Unknown,
     customer_account: Schema.NullOr(Schema.String),
-    deleted: Schema.Literals(["true"]),
+    deleted: Schema.Literals([true]),
     id: Schema.String,
     invoice: Schema.NullOr(Schema.String),
     invoice_item: Schema.NullOr(Schema.String),

--- a/packages/stripe/src/operations/DeleteCustomersCustomerTaxIdsId.ts
+++ b/packages/stripe/src/operations/DeleteCustomersCustomerTaxIdsId.ts
@@ -20,7 +20,7 @@ export type DeleteCustomersCustomerTaxIdsIdInput =
 // Output Schema
 export const DeleteCustomersCustomerTaxIdsIdOutput =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    deleted: Schema.Literals(["true"]),
+    deleted: Schema.Literals([true]),
     id: Schema.String,
     object: Schema.Literals(["tax_id"]),
   });

--- a/packages/stripe/src/operations/DeleteInvoiceitemsInvoiceitem.ts
+++ b/packages/stripe/src/operations/DeleteInvoiceitemsInvoiceitem.ts
@@ -19,7 +19,7 @@ export type DeleteInvoiceitemsInvoiceitemInput =
 // Output Schema
 export const DeleteInvoiceitemsInvoiceitemOutput =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    deleted: Schema.Literals(["true"]),
+    deleted: Schema.Literals([true]),
     id: Schema.String,
     object: Schema.Literals(["invoiceitem"]),
   });

--- a/packages/stripe/src/operations/DeleteInvoicesInvoice.ts
+++ b/packages/stripe/src/operations/DeleteInvoicesInvoice.ts
@@ -18,7 +18,7 @@ export type DeleteInvoicesInvoiceInput = typeof DeleteInvoicesInvoiceInput.Type;
 // Output Schema
 export const DeleteInvoicesInvoiceOutput =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    deleted: Schema.Literals(["true"]),
+    deleted: Schema.Literals([true]),
     id: Schema.String,
     object: Schema.Literals(["invoice"]),
   });

--- a/packages/stripe/src/operations/DeletePlansPlan.ts
+++ b/packages/stripe/src/operations/DeletePlansPlan.ts
@@ -16,7 +16,7 @@ export type DeletePlansPlanInput = typeof DeletePlansPlanInput.Type;
 
 // Output Schema
 export const DeletePlansPlanOutput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  deleted: Schema.Literals(["true"]),
+  deleted: Schema.Literals([true]),
   id: Schema.String,
   object: Schema.Literals(["plan"]),
 });

--- a/packages/stripe/src/operations/DeleteProductsId.ts
+++ b/packages/stripe/src/operations/DeleteProductsId.ts
@@ -17,7 +17,7 @@ export type DeleteProductsIdInput = typeof DeleteProductsIdInput.Type;
 // Output Schema
 export const DeleteProductsIdOutput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
   {
-    deleted: Schema.Literals(["true"]),
+    deleted: Schema.Literals([true]),
     id: Schema.String,
     object: Schema.Literals(["product"]),
   },

--- a/packages/stripe/src/operations/DeleteProductsProductFeaturesId.ts
+++ b/packages/stripe/src/operations/DeleteProductsProductFeaturesId.ts
@@ -20,7 +20,7 @@ export type DeleteProductsProductFeaturesIdInput =
 // Output Schema
 export const DeleteProductsProductFeaturesIdOutput =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    deleted: Schema.Literals(["true"]),
+    deleted: Schema.Literals([true]),
     id: Schema.String,
     object: Schema.Literals(["product_feature"]),
   });

--- a/packages/stripe/src/operations/DeleteRadarValueListItemsItem.ts
+++ b/packages/stripe/src/operations/DeleteRadarValueListItemsItem.ts
@@ -19,7 +19,7 @@ export type DeleteRadarValueListItemsItemInput =
 // Output Schema
 export const DeleteRadarValueListItemsItemOutput =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    deleted: Schema.Literals(["true"]),
+    deleted: Schema.Literals([true]),
     id: Schema.String,
     object: Schema.Literals(["radar.value_list_item"]),
   });

--- a/packages/stripe/src/operations/DeleteRadarValueListsValueList.ts
+++ b/packages/stripe/src/operations/DeleteRadarValueListsValueList.ts
@@ -19,7 +19,7 @@ export type DeleteRadarValueListsValueListInput =
 // Output Schema
 export const DeleteRadarValueListsValueListOutput =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    deleted: Schema.Literals(["true"]),
+    deleted: Schema.Literals([true]),
     id: Schema.String,
     object: Schema.Literals(["radar.value_list"]),
   });

--- a/packages/stripe/src/operations/DeleteSubscriptionItemsItem.ts
+++ b/packages/stripe/src/operations/DeleteSubscriptionItemsItem.ts
@@ -32,7 +32,7 @@ export type DeleteSubscriptionItemsItemInput =
 // Output Schema
 export const DeleteSubscriptionItemsItemOutput =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    deleted: Schema.Literals(["true"]),
+    deleted: Schema.Literals([true]),
     id: Schema.String,
     object: Schema.Literals(["subscription_item"]),
   });

--- a/packages/stripe/src/operations/DeleteSubscriptionsSubscriptionExposedIdDiscount.ts
+++ b/packages/stripe/src/operations/DeleteSubscriptionsSubscriptionExposedIdDiscount.ts
@@ -22,7 +22,7 @@ export const DeleteSubscriptionsSubscriptionExposedIdDiscountOutput =
     checkout_session: Schema.NullOr(Schema.String),
     customer: Schema.Unknown,
     customer_account: Schema.NullOr(Schema.String),
-    deleted: Schema.Literals(["true"]),
+    deleted: Schema.Literals([true]),
     id: Schema.String,
     invoice: Schema.NullOr(Schema.String),
     invoice_item: Schema.NullOr(Schema.String),

--- a/packages/stripe/src/operations/DeleteTaxIdsId.ts
+++ b/packages/stripe/src/operations/DeleteTaxIdsId.ts
@@ -16,7 +16,7 @@ export type DeleteTaxIdsIdInput = typeof DeleteTaxIdsIdInput.Type;
 
 // Output Schema
 export const DeleteTaxIdsIdOutput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  deleted: Schema.Literals(["true"]),
+  deleted: Schema.Literals([true]),
   id: Schema.String,
   object: Schema.Literals(["tax_id"]),
 });

--- a/packages/stripe/src/operations/DeleteTerminalConfigurationsConfiguration.ts
+++ b/packages/stripe/src/operations/DeleteTerminalConfigurationsConfiguration.ts
@@ -19,7 +19,7 @@ export type DeleteTerminalConfigurationsConfigurationInput =
 // Output Schema
 export const DeleteTerminalConfigurationsConfigurationOutput =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    deleted: Schema.Literals(["true"]),
+    deleted: Schema.Literals([true]),
     id: Schema.String,
     object: Schema.Literals(["terminal.configuration"]),
   });

--- a/packages/stripe/src/operations/DeleteTerminalLocationsLocation.ts
+++ b/packages/stripe/src/operations/DeleteTerminalLocationsLocation.ts
@@ -19,7 +19,7 @@ export type DeleteTerminalLocationsLocationInput =
 // Output Schema
 export const DeleteTerminalLocationsLocationOutput =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    deleted: Schema.Literals(["true"]),
+    deleted: Schema.Literals([true]),
     id: Schema.String,
     object: Schema.Literals(["terminal.location"]),
   });

--- a/packages/stripe/src/operations/DeleteTerminalReadersReader.ts
+++ b/packages/stripe/src/operations/DeleteTerminalReadersReader.ts
@@ -19,7 +19,7 @@ export type DeleteTerminalReadersReaderInput =
 // Output Schema
 export const DeleteTerminalReadersReaderOutput =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    deleted: Schema.Literals(["true"]),
+    deleted: Schema.Literals([true]),
     device_type: Schema.Literals([
       "bbpos_chipper2x",
       "bbpos_wisepad3",

--- a/packages/stripe/src/operations/DeleteTestHelpersTestClocksTestClock.ts
+++ b/packages/stripe/src/operations/DeleteTestHelpersTestClocksTestClock.ts
@@ -19,7 +19,7 @@ export type DeleteTestHelpersTestClocksTestClockInput =
 // Output Schema
 export const DeleteTestHelpersTestClocksTestClockOutput =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    deleted: Schema.Literals(["true"]),
+    deleted: Schema.Literals([true]),
     id: Schema.String,
     object: Schema.Literals(["test_helpers.test_clock"]),
   });

--- a/packages/stripe/src/operations/DeleteWebhookEndpointsWebhookEndpoint.ts
+++ b/packages/stripe/src/operations/DeleteWebhookEndpointsWebhookEndpoint.ts
@@ -19,7 +19,7 @@ export type DeleteWebhookEndpointsWebhookEndpointInput =
 // Output Schema
 export const DeleteWebhookEndpointsWebhookEndpointOutput =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    deleted: Schema.Literals(["true"]),
+    deleted: Schema.Literals([true]),
     id: Schema.String,
     object: Schema.Literals(["webhook_endpoint"]),
   });


### PR DESCRIPTION
I ran into this while deleting a Stripe webhook endpoint. The API returned `deleted: true`, but the generated schema expected the string `"true"`:

```text
SchemaError: Expected "true", got true
  at ["deleted"]
```

This happens because the shared OpenAPI generator quotes every non-numeric enum value, so boolean enums are emitted as string literals.

This PR changes the generator to keep boolean enum values as booleans, similar to the existing handling for numeric enums.

Stripe has many deleted-resource response schemas declared as `type: boolean` + `enum: [true]`.
One concrete example is webhook endpoint deletion. The [Stripe delete webhook endpoint docs](https://docs.stripe.com/api/webhook_endpoints/delete) show the response as:

```json
{
  "id": "we_1Mr5jULkdIwHu7ix1ibLTM0x",
  "object": "webhook_endpoint",
  "deleted": true
}
```

But the generated schemas expected `"true"`:

```diff
-deleted: Schema.Literals(["true"])
+deleted: Schema.Literals([true])
```

PostHog has the same shape on query status responses. The [PostHog retrieve query docs](https://posthog.com/docs/api/query#get-api-projects-project_id-query-id) show `query_async` as a boolean:

```json
{
  "query_status": {
    "query_async": true
  }
}
```

```diff
-query_async: Schema.optional(Schema.Literals(["true"]))
+query_async: Schema.optional(Schema.Literals([true]))
```

### Validation

- `bun run generate` in `packages/stripe`
- `bun run generate` in `packages/posthog`
- `bun run typecheck` in `packages/core`
- `bun run typecheck` in `packages/stripe`
- `bun run typecheck` in `packages/posthog`
- `bun run lint` in `packages/core`
- `bun run lint` in `packages/stripe`
- `bun run lint` in `packages/posthog`