### PR TITLE
fix(cloudflare/workers): tolerate a null body from deleteDomain

### DIFF
--- a/packages/cloudflare/patches/workers/deleteDomain.json
+++ b/packages/cloudflare/patches/workers/deleteDomain.json
@@ -1,5 +1,10 @@
 {
   "errors": {
     "DomainNotFound": [{ "code": 100114 }]
+  },
+  "response": {
+    "properties": {
+      "$": { "nullable": true }
+    }
   }
 }

--- a/packages/cloudflare/src/services/workers.ts
+++ b/packages/cloudflare/src/services/workers.ts
@@ -5419,7 +5419,7 @@ export const DeleteDomainRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.suspend(
     ),
 ) as unknown as Schema.Schema<DeleteDomainRequest>;
 
-export interface DeleteDomainResponse {
+export type DeleteDomainResponse = {
   errors: {
     code: number;
     message: string;
@@ -5432,67 +5432,69 @@ export interface DeleteDomainResponse {
     documentationUrl?: string | null;
     source?: { pointer?: string | null } | null;
   }[];
-  /** Whether the API call was successful. */
   success: true;
-}
+} | null;
 
 export const DeleteDomainResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.suspend(
   () =>
-    Schema.Struct({
-      errors: Schema.Array(
-        Schema.Struct({
-          code: Schema.Number,
-          message: Schema.String,
-          documentationUrl: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
+    Schema.Union([
+      Schema.Struct({
+        errors: Schema.Array(
+          Schema.Struct({
+            code: Schema.Number,
+            message: Schema.String,
+            documentationUrl: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
+            source: Schema.optional(
+              Schema.Union([
+                Schema.Struct({
+                  pointer: Schema.optional(
+                    Schema.Union([Schema.String, Schema.Null]),
+                  ),
+                }),
+                Schema.Null,
+              ]),
+            ),
+          }).pipe(
+            Schema.encodeKeys({
+              code: "code",
+              message: "message",
+              documentationUrl: "documentation_url",
+              source: "source",
+            }),
           ),
-          source: Schema.optional(
-            Schema.Union([
-              Schema.Struct({
-                pointer: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-              }),
-              Schema.Null,
-            ]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            code: "code",
-            message: "message",
-            documentationUrl: "documentation_url",
-            source: "source",
-          }),
         ),
-      ),
-      messages: Schema.Array(
-        Schema.Struct({
-          code: Schema.Number,
-          message: Schema.String,
-          documentationUrl: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
+        messages: Schema.Array(
+          Schema.Struct({
+            code: Schema.Number,
+            message: Schema.String,
+            documentationUrl: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
+            source: Schema.optional(
+              Schema.Union([
+                Schema.Struct({
+                  pointer: Schema.optional(
+                    Schema.Union([Schema.String, Schema.Null]),
+                  ),
+                }),
+                Schema.Null,
+              ]),
+            ),
+          }).pipe(
+            Schema.encodeKeys({
+              code: "code",
+              message: "message",
+              documentationUrl: "documentation_url",
+              source: "source",
+            }),
           ),
-          source: Schema.optional(
-            Schema.Union([
-              Schema.Struct({
-                pointer: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-              }),
-              Schema.Null,
-            ]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            code: "code",
-            message: "message",
-            documentationUrl: "documentation_url",
-            source: "source",
-          }),
         ),
-      ),
-      success: Schema.Literal(true),
-    }),
+        success: Schema.Literal(true),
+      }),
+      Schema.Null,
+    ]),
 ) as unknown as Schema.Schema<DeleteDomainResponse>;
 
 export type DeleteDomainError = DefaultErrors | DomainNotFound;


### PR DESCRIPTION
Cloudflare can answer `DELETE /accounts/{account_id}/workers/domains/{domain_id}` with a successful response whose body is JSON `null` instead of the usual `{ success, errors, messages }` envelope. `DeleteDomainResponse` only modeled the envelope, so decoding `null` failed and surfaced as `CloudflareHttpError: null` — a successful delete reported as an error.

Mark the response nullable so the `null` body decodes:

```diff
 // patches/workers/deleteDomain.json
 {
   "errors": { "DomainNotFound": [{ "code": 100114 }] },
+  "response": { "properties": { "$": { "nullable": true } } }
 }
```

`deleteScript`'s response is already `unknown`, so it tolerates the same body and needs no change.
