### PR TITLE
fix(stripe): encode Stripe wire shapes

### DIFF
--- a/packages/core/scripts/generate-openapi.ts
+++ b/packages/core/scripts/generate-openapi.ts
@@ -255,6 +255,18 @@ function renderEnumLiterals(
   return `Schema.Literals([${literals}])`;
 }
 
+function renderParameterSchema3(
+  schema: SchemaObject | undefined,
+  spec: OpenAPI3Spec,
+  ctx: SchemaGenerationContext,
+): string {
+  if (!schema) return "Schema.String";
+  if (schema.enum && schema.enum.length > 0) {
+    return renderEnumLiterals(schema.enum, schema.type);
+  }
+  return openApiTypeToEffectSchema(schema, spec, "", new Set(), ctx);
+}
+
 // ============================================================================
 // Version Detection
 // ============================================================================
@@ -1323,22 +1335,7 @@ function generateInputSchema3(
   const tsFields: string[] = [];
   const paramSchemaTs = (schema: SchemaObject | undefined): string => {
     if (!schema) return "string";
-    if (schema.enum && schema.enum.length > 0) {
-      return schema.enum
-        .map((v) =>
-          schema.type === "integer" ||
-          schema.type === "number" ||
-          schema.type === "boolean"
-            ? String(v)
-            : JSON.stringify(v),
-        )
-        .join(" | ");
-    }
-    return schema.type === "integer" || schema.type === "number"
-      ? "number"
-      : schema.type === "boolean"
-        ? "boolean"
-        : "string";
+    return openApiTypeToTsType(schema, spec, new Set(), ctx);
   };
   const usedNames = new Set<string>();
 
@@ -1362,14 +1359,7 @@ function generateInputSchema3(
     if (usedNames.has(param.name)) continue;
     usedNames.add(param.name);
     const schema = param.schema;
-    let schemaStr =
-      schema?.enum && schema.enum.length > 0
-        ? renderEnumLiterals(schema.enum, schema.type)
-        : schema?.type === "integer" || schema?.type === "number"
-          ? "Schema.Number"
-          : schema?.type === "boolean"
-            ? "Schema.Boolean"
-            : "Schema.String";
+    let schemaStr = renderParameterSchema3(schema, spec, ctx);
 
     if (!param.required) {
       schemaStr = `Schema.optional(${schemaStr})`;

--- a/packages/stripe/patches/post-products-id-shippable-clear.patch.json
+++ b/packages/stripe/patches/post-products-id-shippable-clear.patch.json
@@ -1,0 +1,29 @@
+{
+  "description": "Allow clearing Product.shippable on update with Stripe's empty-string form value.",
+  "patches": [
+    {
+      "op": "test",
+      "path": "/paths/~1v1~1products~1{id}/post/requestBody/content/application~1x-www-form-urlencoded/schema/properties/shippable",
+      "value": {
+        "type": "boolean",
+        "description": "Whether this product is shipped (i.e., physical goods)."
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1v1~1products~1{id}/post/requestBody/content/application~1x-www-form-urlencoded/schema/properties/shippable",
+      "value": {
+        "description": "Whether this product is shipped (i.e., physical goods).",
+        "anyOf": [
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "string",
+            "enum": [""]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/stripe/src/client.ts
+++ b/packages/stripe/src/client.ts
@@ -5,9 +5,11 @@
  * error matching and credential handling.
  */
 import * as Effect from "effect/Effect";
+import * as Predicate from "effect/Predicate";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
+import type * as Traits from "./traits.ts";
 import { parseRetryAfterForStatus } from "@distilled.cloud/core/retry-after";
 import { Retry } from "./retry.ts";
 import {
@@ -39,6 +41,74 @@ export type StripeRequestOptions = {
   readonly idempotencyKey?: string | undefined;
   readonly apiVersion?: string | undefined;
 } & StripeConnectRequestOptions;
+
+const appendQueryValue = (
+  query: Record<string, string | string[]>,
+  key: string,
+  value: unknown,
+): void => {
+  if (Predicate.isNullish(value)) {
+    return;
+  }
+  const encoded = Predicate.isBoolean(value)
+    ? value
+      ? "true"
+      : "false"
+    : String(value);
+  const existing = query[key];
+  if (Predicate.isUndefined(existing)) {
+    query[key] = encoded;
+  } else if (Array.isArray(existing)) {
+    existing.push(encoded);
+  } else {
+    query[key] = [existing, encoded];
+  }
+};
+
+const appendStripeQuery = (
+  query: Record<string, string | string[]>,
+  key: string,
+  value: unknown,
+): void => {
+  if (Predicate.isNullish(value)) {
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      appendQueryValue(query, `${key}[]`, item);
+    }
+    return;
+  }
+  if (Predicate.isObject(value)) {
+    for (const [nestedKey, nestedValue] of Object.entries(value)) {
+      appendStripeQuery(query, `${key}[${nestedKey}]`, nestedValue);
+    }
+    return;
+  }
+  appendQueryValue(query, key, value);
+};
+
+const normalizeStripeGetQuery = ({
+  method,
+  parts,
+}: {
+  method: string;
+  parts: Traits.RequestParts;
+}): Traits.RequestParts => {
+  if (
+    method !== "GET" ||
+    Predicate.isUndefined(parts.body) ||
+    !Predicate.isObject(parts.body)
+  ) {
+    return parts;
+  }
+
+  const query = { ...parts.query };
+  for (const [key, value] of Object.entries(parts.body)) {
+    appendStripeQuery(query, key, value);
+  }
+  return { ...parts, body: undefined, query };
+};
 
 const stripeRequestHeaders = (
   options: StripeRequestOptions | undefined,
@@ -201,6 +271,7 @@ export const API = makeAPI<Credentials, StripeRequestOptions>({
     Authorization: `Bearer ${Redacted.value(creds.apiKey)}`,
   }),
   getRequestHeaders: stripeRequestHeaders,
+  transformRequestParts: normalizeStripeGetQuery,
   matchError,
   ParseError: StripeParseError as any,
   retry: Retry as any,

--- a/packages/stripe/src/operations/GetPrices.ts
+++ b/packages/stripe/src/operations/GetPrices.ts
@@ -5,27 +5,49 @@ import * as T from "../traits.ts";
 // Input Schema
 export interface GetPricesInput {
   active?: boolean;
-  created?: string;
+  created?: { gt?: number; gte?: number; lt?: number; lte?: number } | number;
   currency?: string;
   ending_before?: string;
-  expand?: string;
+  expand?: ReadonlyArray<string>;
   limit?: number;
-  lookup_keys?: string;
+  lookup_keys?: ReadonlyArray<string>;
   product?: string;
-  recurring?: string;
+  recurring?: {
+    interval?: "day" | "month" | "week" | "year";
+    meter?: string;
+    usage_type?: "licensed" | "metered";
+  };
   starting_after?: string;
   type?: "one_time" | "recurring";
 }
 export const GetPricesInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   active: Schema.optional(Schema.Boolean),
-  created: Schema.optional(Schema.String),
+  created: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        gt: Schema.optional(Schema.Number),
+        gte: Schema.optional(Schema.Number),
+        lt: Schema.optional(Schema.Number),
+        lte: Schema.optional(Schema.Number),
+      }),
+      Schema.Number,
+    ]),
+  ),
   currency: Schema.optional(Schema.String),
   ending_before: Schema.optional(Schema.String),
-  expand: Schema.optional(Schema.String),
+  expand: Schema.optional(Schema.Array(Schema.String)),
   limit: Schema.optional(Schema.Number),
-  lookup_keys: Schema.optional(Schema.String),
+  lookup_keys: Schema.optional(Schema.Array(Schema.String)),
   product: Schema.optional(Schema.String),
-  recurring: Schema.optional(Schema.String),
+  recurring: Schema.optional(
+    Schema.Struct({
+      interval: Schema.optional(
+        Schema.Literals(["day", "month", "week", "year"]),
+      ),
+      meter: Schema.optional(Schema.String),
+      usage_type: Schema.optional(Schema.Literals(["licensed", "metered"])),
+    }),
+  ),
   starting_after: Schema.optional(Schema.String),
   type: Schema.optional(Schema.Literals(["one_time", "recurring"])),
 }).pipe(
@@ -34,7 +56,7 @@ export const GetPricesInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 // Output Schema
 export interface GetPricesOutput {
-  data: {
+  data: ReadonlyArray<{
     active: boolean;
     billing_scheme: "per_unit" | "tiered";
     created: number;
@@ -48,13 +70,13 @@ export interface GetPricesOutput {
           preset: number | null;
         } | null;
         tax_behavior: "exclusive" | "inclusive" | "unspecified" | null;
-        tiers?: {
+        tiers?: ReadonlyArray<{
           flat_amount: number | null;
           flat_amount_decimal: string | null;
           unit_amount: number | null;
           unit_amount_decimal: string | null;
           up_to: number | null;
-        }[];
+        }>;
         unit_amount: number | null;
         unit_amount_decimal: string | null;
       }
@@ -78,9 +100,9 @@ export interface GetPricesOutput {
           default_price?: string | unknown | null;
           description: string | null;
           id: string;
-          images: string[];
+          images: ReadonlyArray<string>;
           livemode: boolean;
-          marketing_features: { name?: string }[];
+          marketing_features: ReadonlyArray<{ name?: string }>;
           metadata: Record<string, string>;
           name: string;
           object: "product";
@@ -115,19 +137,19 @@ export interface GetPricesOutput {
       usage_type: "licensed" | "metered";
     } | null;
     tax_behavior: "exclusive" | "inclusive" | "unspecified" | null;
-    tiers?: {
+    tiers?: ReadonlyArray<{
       flat_amount: number | null;
       flat_amount_decimal: string | null;
       unit_amount: number | null;
       unit_amount_decimal: string | null;
       up_to: number | null;
-    }[];
+    }>;
     tiers_mode: "graduated" | "volume" | null;
     transform_quantity: { divide_by: number; round: "down" | "up" } | null;
     type: "one_time" | "recurring";
     unit_amount: number | null;
     unit_amount_decimal: string | null;
-  }[];
+  }>;
   has_more: boolean;
   object: "list";
   url: string;

--- a/packages/stripe/src/operations/PostProductsId.ts
+++ b/packages/stripe/src/operations/PostProductsId.ts
@@ -8,15 +8,15 @@ export interface PostProductsIdInput {
   active?: boolean;
   default_price?: string;
   description?: string | "";
-  expand?: string[];
-  images?: string[] | "";
-  marketing_features?: { name: string }[] | "";
+  expand?: ReadonlyArray<string>;
+  images?: ReadonlyArray<string> | "";
+  marketing_features?: ReadonlyArray<{ name: string }> | "";
   metadata?: Record<string, string> | "";
   name?: string;
   package_dimensions?:
     | { height: number; length: number; weight: number; width: number }
     | "";
-  shippable?: boolean;
+  shippable?: boolean | "";
   statement_descriptor?: string;
   tax_code?: string | "";
   unit_label?: string | "";
@@ -61,7 +61,9 @@ export const PostProductsIdInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       Schema.Literals([""]),
     ]),
   ),
-  shippable: Schema.optional(Schema.Boolean),
+  shippable: Schema.optional(
+    Schema.Union([Schema.Boolean, Schema.Literals([""])]),
+  ),
   statement_descriptor: Schema.optional(Schema.String),
   tax_code: Schema.optional(
     Schema.Union([Schema.String, Schema.Literals([""])]),
@@ -98,13 +100,13 @@ export interface PostProductsIdOutput {
               preset: number | null;
             } | null;
             tax_behavior: "exclusive" | "inclusive" | "unspecified" | null;
-            tiers?: {
+            tiers?: ReadonlyArray<{
               flat_amount: number | null;
               flat_amount_decimal: string | null;
               unit_amount: number | null;
               unit_amount_decimal: string | null;
               up_to: number | null;
-            }[];
+            }>;
             unit_amount: number | null;
             unit_amount_decimal: string | null;
           }
@@ -128,9 +130,9 @@ export interface PostProductsIdOutput {
               default_price?: string | unknown | null;
               description: string | null;
               id: string;
-              images: string[];
+              images: ReadonlyArray<string>;
               livemode: boolean;
-              marketing_features: { name?: string }[];
+              marketing_features: ReadonlyArray<{ name?: string }>;
               metadata: Record<string, string>;
               name: string;
               object: "product";
@@ -165,13 +167,13 @@ export interface PostProductsIdOutput {
           usage_type: "licensed" | "metered";
         } | null;
         tax_behavior: "exclusive" | "inclusive" | "unspecified" | null;
-        tiers?: {
+        tiers?: ReadonlyArray<{
           flat_amount: number | null;
           flat_amount_decimal: string | null;
           unit_amount: number | null;
           unit_amount_decimal: string | null;
           up_to: number | null;
-        }[];
+        }>;
         tiers_mode: "graduated" | "volume" | null;
         transform_quantity: { divide_by: number; round: "down" | "up" } | null;
         type: "one_time" | "recurring";
@@ -181,9 +183,9 @@ export interface PostProductsIdOutput {
     | null;
   description: string | null;
   id: string;
-  images: string[];
+  images: ReadonlyArray<string>;
   livemode: boolean;
-  marketing_features: { name?: string }[];
+  marketing_features: ReadonlyArray<{ name?: string }>;
   metadata: Record<string, string>;
   name: string;
   object: "product";

--- a/packages/stripe/tests/request-options.test.ts
+++ b/packages/stripe/tests/request-options.test.ts
@@ -4,9 +4,13 @@ import * as Redacted from "effect/Redacted";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
 import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
+import * as UrlParams from "effect/unstable/http/UrlParams";
 import { describe, expect, it } from "vitest";
 import { Credentials } from "../src/credentials.ts";
+import { DeleteProductsId } from "../src/operations/DeleteProductsId.ts";
+import { GetPrices } from "../src/operations/GetPrices.ts";
 import { PostCustomers } from "../src/operations/PostCustomers.ts";
+import { PostProductsId } from "../src/operations/PostProductsId.ts";
 
 const fakeCredentials = Layer.succeed(
   Credentials,
@@ -27,6 +31,52 @@ const customerResponse = {
   shipping: null,
 };
 
+const priceListResponse = {
+  data: [],
+  has_more: false,
+  object: "list",
+  url: "/v1/prices",
+};
+
+const productResponse = {
+  active: true,
+  created: 1_700_000_000,
+  default_price: null,
+  description: null,
+  id: "prod_test",
+  images: [],
+  livemode: false,
+  marketing_features: [],
+  metadata: {},
+  name: "Test product",
+  object: "product",
+  package_dimensions: null,
+  shippable: null,
+  tax_code: null,
+  type: "service",
+  updated: 1_700_000_000,
+  url: null,
+};
+
+const deletedProductResponse = {
+  deleted: true,
+  id: "prod_test",
+  object: "product",
+};
+
+const responseForRequest = (request: HttpClientRequest.HttpClientRequest) => {
+  if (request.method === "GET" && request.url.endsWith("/v1/prices")) {
+    return priceListResponse;
+  }
+  if (request.method === "POST" && request.url.endsWith("/v1/products/prod_test")) {
+    return productResponse;
+  }
+  if (request.method === "DELETE" && request.url.endsWith("/v1/products/prod_test")) {
+    return deletedProductResponse;
+  }
+  return customerResponse;
+};
+
 interface CapturedRequest {
   request?: HttpClientRequest.HttpClientRequest;
 }
@@ -38,10 +88,11 @@ const captureRequest = (
     HttpClient.HttpClient,
     HttpClient.make((request) => {
       captured.request = request;
+      const responseBody = responseForRequest(request);
       return Effect.succeed(
         HttpClientResponse.fromWeb(
           request,
-          new Response(JSON.stringify(customerResponse), {
+          new Response(JSON.stringify(responseBody), {
             status: 200,
             headers: { "content-type": "application/json" },
           }),
@@ -152,5 +203,67 @@ describe("Stripe request options", () => {
     expect(textBody(captured.request!)).toBe(
       "email=stripe-context%40example.com",
     );
+  });
+
+  it("serializes Stripe GET arrays and nested filters with bracket notation", async () => {
+    const captured: CapturedRequest = {};
+
+    await runWithMockStripe(
+      GetPrices({
+        active: false,
+        created: { gte: 1_700_000_000, lt: 1_700_003_600 },
+        limit: 100,
+        lookup_keys: ["basic", "pro"],
+      }),
+      captured,
+    );
+
+    expect(captured.request?.method).toBe("GET");
+    expect(captured.request?.url).toBe("https://api.stripe.test/v1/prices");
+    expect(UrlParams.toRecord(captured.request!.urlParams)).toEqual({
+      active: "false",
+      "created[gte]": "1700000000",
+      "created[lt]": "1700003600",
+      "lookup_keys[]": ["basic", "pro"],
+      limit: "100",
+    });
+  });
+
+  it("sends Stripe product field clears through form-encoded operations", async () => {
+    const captured: CapturedRequest = {};
+
+    await runWithMockStripe(
+      PostProductsId({
+        id: "prod_test",
+        description: "",
+        images: "",
+        marketing_features: "",
+        shippable: "",
+      }),
+      captured,
+    );
+
+    expect(captured.request?.method).toBe("POST");
+    expect(captured.request?.url).toBe(
+      "https://api.stripe.test/v1/products/prod_test",
+    );
+    expect(textBody(captured.request!)).toBe(
+      "description=&images=&marketing_features=&shippable=",
+    );
+  });
+
+  it("accepts Stripe boolean delete responses", async () => {
+    const captured: CapturedRequest = {};
+
+    const deleted = await runWithMockStripe(
+      DeleteProductsId({ id: "prod_test" }),
+      captured,
+    );
+
+    expect(captured.request?.method).toBe("DELETE");
+    expect(captured.request?.url).toBe(
+      "https://api.stripe.test/v1/products/prod_test",
+    );
+    expect(deleted).toEqual(deletedProductResponse);
   });
 });


### PR DESCRIPTION
## What

Fixes Stripe wire-shape handling in the generated Distilled Stripe SDK so callers do not need resource-local raw HTTP fallbacks.

- Serializes GET operation body fields as Stripe query params using bracket notation for arrays and nested objects.
- Preserves typed `GetPrices` support for `created` range filters and repeated `lookup_keys`.
- Allows Stripe's empty-string clear value for `PostProductsId.shippable`.
- Updates the OpenAPI 3 generator to preserve parameter schemas instead of collapsing non-enum query params to primitive strings.

## Why

`alchemy-run/alchemy-effect#693` needs Stripe product clears, lookup-key/range price listing, and delete responses to work through the Distilled operations directly.

## Verification

- `bun --filter '@distilled.cloud/stripe' test -- request-options.test.ts`
- `bun --filter '@distilled.cloud/stripe' typecheck`
- `bun --filter '@distilled.cloud/stripe' build`
- `bun --filter '@distilled.cloud/core' typecheck`
- `bun --filter '@distilled.cloud/core' lint`
- `bun --filter '@distilled.cloud/stripe' lint`
- `bun --filter '@distilled.cloud/core' check`
- `bun --filter '@distilled.cloud/stripe' check`
