### PR TITLE
fix(cloudflare/workers-for-platforms): type getDispatchNamespaceScriptSetting errors + loosen placement

### DIFF
--- a/packages/cloudflare/patches/workers-for-platforms/getDispatchNamespaceScriptSetting.json
+++ b/packages/cloudflare/patches/workers-for-platforms/getDispatchNamespaceScriptSetting.json
@@ -1,0 +1,12 @@
+{
+  "errors": {
+    "DispatchNamespaceNotFound": [{ "code": 100119 }],
+    "DispatchNamespaceScriptNotFound": [{ "code": 10007 }],
+    "Forbidden": [{ "status": 403 }]
+  },
+  "response": {
+    "properties": {
+      "placement": { "type": "unknown" }
+    }
+  }
+}

--- a/packages/cloudflare/patches/workers-for-platforms/getDispatchNamespaceScriptSetting.json
+++ b/packages/cloudflare/patches/workers-for-platforms/getDispatchNamespaceScriptSetting.json
@@ -6,7 +6,38 @@
   },
   "response": {
     "properties": {
-      "placement": { "type": "unknown" }
+      "placement": {
+        "optional": true,
+        "nullable": true,
+        "definition": {
+          "kind": "object",
+          "properties": [
+            {
+              "name": "mode",
+              "required": false,
+              "type": { "kind": "literal", "value": "smart" }
+            },
+            {
+              "name": "status",
+              "required": false,
+              "type": {
+                "kind": "union",
+                "values": [
+                  { "kind": "literal", "value": "SUCCESS" },
+                  { "kind": "literal", "value": "UNSUPPORTED_APPLICATION" },
+                  { "kind": "literal", "value": "INSUFFICIENT_INVOCATIONS" }
+                ]
+              }
+            },
+            {
+              "name": "lastAnalyzedAt",
+              "required": false,
+              "wireKey": "last_analyzed_at",
+              "type": { "kind": "primitive", "value": "string" }
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/packages/cloudflare/patches/workers-for-platforms/getDispatchNamespaceScriptSetting.json
+++ b/packages/cloudflare/patches/workers-for-platforms/getDispatchNamespaceScriptSetting.json
@@ -7,36 +7,36 @@
   "response": {
     "properties": {
       "placement": {
-        "optional": true,
-        "nullable": true,
-        "definition": {
-          "kind": "object",
-          "properties": [
-            {
-              "name": "mode",
-              "required": false,
-              "type": { "kind": "literal", "value": "smart" }
-            },
-            {
-              "name": "status",
-              "required": false,
-              "type": {
-                "kind": "union",
-                "values": [
-                  { "kind": "literal", "value": "SUCCESS" },
-                  { "kind": "literal", "value": "UNSUPPORTED_APPLICATION" },
-                  { "kind": "literal", "value": "INSUFFICIENT_INVOCATIONS" }
-                ]
+        "appendUnion": [
+          {
+            "kind": "object",
+            "properties": [
+              {
+                "name": "mode",
+                "required": false,
+                "type": { "kind": "literal", "value": "smart" }
+              },
+              {
+                "name": "status",
+                "required": false,
+                "type": {
+                  "kind": "union",
+                  "values": [
+                    { "kind": "literal", "value": "SUCCESS" },
+                    { "kind": "literal", "value": "UNSUPPORTED_APPLICATION" },
+                    { "kind": "literal", "value": "INSUFFICIENT_INVOCATIONS" }
+                  ]
+                }
+              },
+              {
+                "name": "lastAnalyzedAt",
+                "required": false,
+                "wireKey": "last_analyzed_at",
+                "type": { "kind": "primitive", "value": "string" }
               }
-            },
-            {
-              "name": "lastAnalyzedAt",
-              "required": false,
-              "wireKey": "last_analyzed_at",
-              "type": { "kind": "primitive", "value": "string" }
-            }
-          ]
-        }
+            ]
+          }
+        ]
       }
     }
   }

--- a/packages/cloudflare/scripts/generate.ts
+++ b/packages/cloudflare/scripts/generate.ts
@@ -287,9 +287,7 @@ const loadServicePatches = (
       return yield* Effect.die(
         `Orphaned patch file(s) in ${patchDir}: ${orphans
           .map((o) => `${o}.json`)
-          .join(
-            ", ",
-          )} — no matching operation in the regenerated '${serviceName}' service. ` +
+          .join(", ")} — no matching operation in the regenerated '${serviceName}' service. ` +
           `The upstream spec likely renamed or removed the operation; ` +
           `re-key the patch to the new operation name (available: ${[...opNames].sort().join(", ")}) ` +
           `or delete it, and migrate consumers in packages/alchemy.`,

--- a/packages/cloudflare/scripts/generate.ts
+++ b/packages/cloudflare/scripts/generate.ts
@@ -287,7 +287,9 @@ const loadServicePatches = (
       return yield* Effect.die(
         `Orphaned patch file(s) in ${patchDir}: ${orphans
           .map((o) => `${o}.json`)
-          .join(", ")} — no matching operation in the regenerated '${serviceName}' service. ` +
+          .join(
+            ", ",
+          )} — no matching operation in the regenerated '${serviceName}' service. ` +
           `The upstream spec likely renamed or removed the operation; ` +
           `re-key the patch to the new operation name (available: ${[...opNames].sort().join(", ")}) ` +
           `or delete it, and migrate consumers in packages/alchemy.`,
@@ -570,6 +572,15 @@ function applyPropertyPatch(
     }
     if (patch.wireKey) {
       prop.wireKey = patch.wireKey;
+    }
+    // `definition` replaces the property's type outright (not just when the
+    // property is missing). Used when the vendor SDK models a field with the
+    // wrong shape — e.g. a response field that reuses a request union — and the
+    // correct type can't be expressed by the narrower `type`/`nullable`/
+    // `appendUnion` ops. Applied before the other ops so `nullable` etc. can
+    // still compose on top of the replacement.
+    if (patch.definition) {
+      prop.type = JSON.parse(JSON.stringify(patch.definition)) as TypeInfo;
     }
     applyPatchToTypeInfo(prop.type, patch);
   } else {

--- a/packages/cloudflare/scripts/generate.ts
+++ b/packages/cloudflare/scripts/generate.ts
@@ -573,15 +573,6 @@ function applyPropertyPatch(
     if (patch.wireKey) {
       prop.wireKey = patch.wireKey;
     }
-    // `definition` replaces the property's type outright (not just when the
-    // property is missing). Used when the vendor SDK models a field with the
-    // wrong shape — e.g. a response field that reuses a request union — and the
-    // correct type can't be expressed by the narrower `type`/`nullable`/
-    // `appendUnion` ops. Applied before the other ops so `nullable` etc. can
-    // still compose on top of the replacement.
-    if (patch.definition) {
-      prop.type = JSON.parse(JSON.stringify(patch.definition)) as TypeInfo;
-    }
     applyPatchToTypeInfo(prop.type, patch);
   } else {
     // Need to descend further — unwrap the property type

--- a/packages/cloudflare/specs/cloudflare/workers-for-platforms.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/workers-for-platforms.openapi.yml
@@ -5037,113 +5037,6 @@ paths:
                       - enabled
                     description: Observability settings for the Worker.
                   placement:
-                    oneOf:
-                      - type: object
-                        properties:
-                          mode:
-                            type: string
-                            enum:
-                              - smart
-                            description: Enables [Smart
-                              Placement](https://developers.cloudflare.com/workers/configuration/smart-placement).
-                        required:
-                          - mode
-                      - type: object
-                        properties:
-                          region:
-                            type: string
-                            description: Cloud region for targeted placement in format 'provider:region'.
-                        required:
-                          - region
-                      - type: object
-                        properties:
-                          hostname:
-                            type: string
-                            description: HTTP hostname for targeted placement.
-                        required:
-                          - hostname
-                      - type: object
-                        properties:
-                          host:
-                            type: string
-                            description: TCP host and port for targeted placement.
-                        required:
-                          - host
-                      - type: object
-                        properties:
-                          mode:
-                            type: string
-                            enum:
-                              - targeted
-                            description: Targeted placement mode.
-                          region:
-                            type: string
-                            description: Cloud region for targeted placement in format 'provider:region'.
-                        required:
-                          - mode
-                          - region
-                      - type: object
-                        properties:
-                          hostname:
-                            type: string
-                            description: HTTP hostname for targeted placement.
-                          mode:
-                            type: string
-                            enum:
-                              - targeted
-                            description: Targeted placement mode.
-                        required:
-                          - hostname
-                          - mode
-                      - type: object
-                        properties:
-                          host:
-                            type: string
-                            description: TCP host and port for targeted placement.
-                          mode:
-                            type: string
-                            enum:
-                              - targeted
-                            description: Targeted placement mode.
-                        required:
-                          - host
-                          - mode
-                      - type: object
-                        properties:
-                          mode:
-                            type: string
-                            enum:
-                              - targeted
-                            description: Targeted placement mode.
-                          target:
-                            type: array
-                            items:
-                              oneOf:
-                                - type: object
-                                  properties:
-                                    region:
-                                      type: string
-                                      description: Cloud region in format 'provider:region'.
-                                  required:
-                                    - region
-                                - type: object
-                                  properties:
-                                    hostname:
-                                      type: string
-                                      description: HTTP hostname for targeted placement.
-                                  required:
-                                    - hostname
-                                - type: object
-                                  properties:
-                                    host:
-                                      type: string
-                                      description: TCP host:port for targeted placement.
-                                  required:
-                                    - host
-                            description: Array of placement targets (currently limited to single target).
-                        required:
-                          - mode
-                          - target
                     description: Configuration for [Smart
                       Placement](https://developers.cloudflare.com/workers/configuration/smart-placement).
                       Specify mode='smart' for Smart Placement, or one of
@@ -5182,6 +5075,13 @@ paths:
                       - unbound
                     description: Usage model for the Worker invocations.
       x-distilled-response-path: result
+      x-distilled-errors:
+        DispatchNamespaceNotFound:
+          - code: 100119
+        DispatchNamespaceScriptNotFound:
+          - code: 10007
+        Forbidden:
+          - status: 403
     patch:
       operationId: patchDispatchNamespaceScriptSetting
       description: "Patch script metadata, such as bindings.  @example ```ts const

--- a/packages/cloudflare/specs/cloudflare/workers-for-platforms.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/workers-for-platforms.openapi.yml
@@ -5044,6 +5044,112 @@ paths:
                             type: string
                             enum:
                               - smart
+                            description: Enables [Smart
+                              Placement](https://developers.cloudflare.com/workers/configuration/smart-placement).
+                        required:
+                          - mode
+                      - type: object
+                        properties:
+                          region:
+                            type: string
+                            description: Cloud region for targeted placement in format 'provider:region'.
+                        required:
+                          - region
+                      - type: object
+                        properties:
+                          hostname:
+                            type: string
+                            description: HTTP hostname for targeted placement.
+                        required:
+                          - hostname
+                      - type: object
+                        properties:
+                          host:
+                            type: string
+                            description: TCP host and port for targeted placement.
+                        required:
+                          - host
+                      - type: object
+                        properties:
+                          mode:
+                            type: string
+                            enum:
+                              - targeted
+                            description: Targeted placement mode.
+                          region:
+                            type: string
+                            description: Cloud region for targeted placement in format 'provider:region'.
+                        required:
+                          - mode
+                          - region
+                      - type: object
+                        properties:
+                          hostname:
+                            type: string
+                            description: HTTP hostname for targeted placement.
+                          mode:
+                            type: string
+                            enum:
+                              - targeted
+                            description: Targeted placement mode.
+                        required:
+                          - hostname
+                          - mode
+                      - type: object
+                        properties:
+                          host:
+                            type: string
+                            description: TCP host and port for targeted placement.
+                          mode:
+                            type: string
+                            enum:
+                              - targeted
+                            description: Targeted placement mode.
+                        required:
+                          - host
+                          - mode
+                      - type: object
+                        properties:
+                          mode:
+                            type: string
+                            enum:
+                              - targeted
+                            description: Targeted placement mode.
+                          target:
+                            type: array
+                            items:
+                              oneOf:
+                                - type: object
+                                  properties:
+                                    region:
+                                      type: string
+                                      description: Cloud region in format 'provider:region'.
+                                  required:
+                                    - region
+                                - type: object
+                                  properties:
+                                    hostname:
+                                      type: string
+                                      description: HTTP hostname for targeted placement.
+                                  required:
+                                    - hostname
+                                - type: object
+                                  properties:
+                                    host:
+                                      type: string
+                                      description: TCP host:port for targeted placement.
+                                  required:
+                                    - host
+                            description: Array of placement targets (currently limited to single target).
+                        required:
+                          - mode
+                          - target
+                      - type: object
+                        properties:
+                          mode:
+                            type: string
+                            enum:
+                              - smart
                           status:
                             type: string
                             enum:
@@ -5052,7 +5158,6 @@ paths:
                               - INSUFFICIENT_INVOCATIONS
                           last_analyzed_at:
                             type: string
-                    nullable: true
                     description: Configuration for [Smart
                       Placement](https://developers.cloudflare.com/workers/configuration/smart-placement).
                       Specify mode='smart' for Smart Placement, or one of

--- a/packages/cloudflare/specs/cloudflare/workers-for-platforms.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/workers-for-platforms.openapi.yml
@@ -5037,6 +5037,22 @@ paths:
                       - enabled
                     description: Observability settings for the Worker.
                   placement:
+                    oneOf:
+                      - type: object
+                        properties:
+                          mode:
+                            type: string
+                            enum:
+                              - smart
+                          status:
+                            type: string
+                            enum:
+                              - SUCCESS
+                              - UNSUPPORTED_APPLICATION
+                              - INSUFFICIENT_INVOCATIONS
+                          last_analyzed_at:
+                            type: string
+                    nullable: true
                     description: Configuration for [Smart
                       Placement](https://developers.cloudflare.com/workers/configuration/smart-placement).
                       Specify mode='smart' for Smart Placement, or one of

--- a/packages/cloudflare/src/services/workers-for-platforms.ts
+++ b/packages/cloudflare/src/services/workers-for-platforms.ts
@@ -4563,7 +4563,16 @@ export interface GetDispatchNamespaceScriptSettingResponse {
     } | null;
   } | null;
   /** Configuration for [Smart Placement](https://developers.cloudflare.com/workers/configuration/smart-placement). Specify mode='smart' for Smart Placement, or one of region/hostname/host. */
-  placement?: unknown | null;
+  placement?: {
+    mode?: "smart" | null;
+    status?:
+      | "SUCCESS"
+      | "UNSUPPORTED_APPLICATION"
+      | "INSUFFICIENT_INVOCATIONS"
+      | (string & {})
+      | null;
+    lastAnalyzedAt?: string | null;
+  } | null;
   /** Tags associated with the Worker. */
   tags?: string[] | null;
   /** List of Workers that will consume logs from the attached Worker. */
@@ -5092,7 +5101,38 @@ export const GetDispatchNamespaceScriptSettingResponse =
           Schema.Null,
         ]),
       ),
-      placement: Schema.optional(Schema.Union([Schema.Unknown, Schema.Null])),
+      placement: Schema.optional(
+        Schema.Union([
+          Schema.Struct({
+            mode: Schema.optional(
+              Schema.Union([Schema.Literal("smart"), Schema.Null]),
+            ),
+            status: Schema.optional(
+              Schema.Union([
+                Schema.Union([
+                  Schema.Literals([
+                    "SUCCESS",
+                    "UNSUPPORTED_APPLICATION",
+                    "INSUFFICIENT_INVOCATIONS",
+                  ]),
+                  Schema.String,
+                ]),
+                Schema.Null,
+              ]),
+            ),
+            lastAnalyzedAt: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
+          }).pipe(
+            Schema.encodeKeys({
+              mode: "mode",
+              status: "status",
+              lastAnalyzedAt: "last_analyzed_at",
+            }),
+          ),
+          Schema.Null,
+        ]),
+      ),
       tags: Schema.optional(
         Schema.Union([Schema.Array(Schema.String), Schema.Null]),
       ),

--- a/packages/cloudflare/src/services/workers-for-platforms.ts
+++ b/packages/cloudflare/src/services/workers-for-platforms.ts
@@ -4563,23 +4563,7 @@ export interface GetDispatchNamespaceScriptSettingResponse {
     } | null;
   } | null;
   /** Configuration for [Smart Placement](https://developers.cloudflare.com/workers/configuration/smart-placement). Specify mode='smart' for Smart Placement, or one of region/hostname/host. */
-  placement?:
-    | { mode: "smart" }
-    | { region: string }
-    | { hostname: string }
-    | { host: string }
-    | { mode: "targeted"; region: string }
-    | { hostname: string; mode: "targeted" }
-    | { host: string; mode: "targeted" }
-    | {
-        mode: "targeted";
-        target: (
-          | { region: string }
-          | { hostname: string }
-          | { host: string }
-        )[];
-      }
-    | null;
+  placement?: unknown | null;
   /** Tags associated with the Worker. */
   tags?: string[] | null;
   /** List of Workers that will consume logs from the attached Worker. */
@@ -5108,53 +5092,7 @@ export const GetDispatchNamespaceScriptSettingResponse =
           Schema.Null,
         ]),
       ),
-      placement: Schema.optional(
-        Schema.Union([
-          Schema.Union([
-            Schema.Struct({
-              mode: Schema.Literal("targeted"),
-              region: Schema.String,
-            }),
-            Schema.Struct({
-              hostname: Schema.String,
-              mode: Schema.Literal("targeted"),
-            }),
-            Schema.Struct({
-              host: Schema.String,
-              mode: Schema.Literal("targeted"),
-            }),
-            Schema.Struct({
-              mode: Schema.Literal("targeted"),
-              target: Schema.Array(
-                Schema.Union([
-                  Schema.Struct({
-                    region: Schema.String,
-                  }),
-                  Schema.Struct({
-                    hostname: Schema.String,
-                  }),
-                  Schema.Struct({
-                    host: Schema.String,
-                  }),
-                ]),
-              ),
-            }),
-            Schema.Struct({
-              mode: Schema.Literal("smart"),
-            }),
-            Schema.Struct({
-              region: Schema.String,
-            }),
-            Schema.Struct({
-              hostname: Schema.String,
-            }),
-            Schema.Struct({
-              host: Schema.String,
-            }),
-          ]),
-          Schema.Null,
-        ]),
-      ),
+      placement: Schema.optional(Schema.Union([Schema.Unknown, Schema.Null])),
       tags: Schema.optional(
         Schema.Union([Schema.Array(Schema.String), Schema.Null]),
       ),
@@ -5201,7 +5139,11 @@ export const GetDispatchNamespaceScriptSettingResponse =
       .pipe(T.ResponsePath("result")),
   ) as unknown as Schema.Schema<GetDispatchNamespaceScriptSettingResponse>;
 
-export type GetDispatchNamespaceScriptSettingError = DefaultErrors;
+export type GetDispatchNamespaceScriptSettingError =
+  | DefaultErrors
+  | DispatchNamespaceNotFound
+  | DispatchNamespaceScriptNotFound
+  | Forbidden;
 
 export const getDispatchNamespaceScriptSetting: API.OperationMethod<
   GetDispatchNamespaceScriptSettingRequest,
@@ -5211,7 +5153,11 @@ export const getDispatchNamespaceScriptSetting: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: GetDispatchNamespaceScriptSettingRequest,
   output: GetDispatchNamespaceScriptSettingResponse,
-  errors: [],
+  errors: [
+    DispatchNamespaceNotFound,
+    DispatchNamespaceScriptNotFound,
+    Forbidden,
+  ],
 }));
 
 export interface PatchDispatchNamespaceScriptSettingRequest {

--- a/packages/cloudflare/src/services/workers-for-platforms.ts
+++ b/packages/cloudflare/src/services/workers-for-platforms.ts
@@ -4563,16 +4563,33 @@ export interface GetDispatchNamespaceScriptSettingResponse {
     } | null;
   } | null;
   /** Configuration for [Smart Placement](https://developers.cloudflare.com/workers/configuration/smart-placement). Specify mode='smart' for Smart Placement, or one of region/hostname/host. */
-  placement?: {
-    mode?: "smart" | null;
-    status?:
-      | "SUCCESS"
-      | "UNSUPPORTED_APPLICATION"
-      | "INSUFFICIENT_INVOCATIONS"
-      | (string & {})
-      | null;
-    lastAnalyzedAt?: string | null;
-  } | null;
+  placement?:
+    | { mode: "smart" }
+    | { region: string }
+    | { hostname: string }
+    | { host: string }
+    | { mode: "targeted"; region: string }
+    | { hostname: string; mode: "targeted" }
+    | { host: string; mode: "targeted" }
+    | {
+        mode: "targeted";
+        target: (
+          | { region: string }
+          | { hostname: string }
+          | { host: string }
+        )[];
+      }
+    | {
+        mode?: "smart" | null;
+        status?:
+          | "SUCCESS"
+          | "UNSUPPORTED_APPLICATION"
+          | "INSUFFICIENT_INVOCATIONS"
+          | (string & {})
+          | null;
+        lastAnalyzedAt?: string | null;
+      }
+    | null;
   /** Tags associated with the Worker. */
   tags?: string[] | null;
   /** List of Workers that will consume logs from the attached Worker. */
@@ -5103,33 +5120,75 @@ export const GetDispatchNamespaceScriptSettingResponse =
       ),
       placement: Schema.optional(
         Schema.Union([
-          Schema.Struct({
-            mode: Schema.optional(
-              Schema.Union([Schema.Literal("smart"), Schema.Null]),
-            ),
-            status: Schema.optional(
-              Schema.Union([
-                Schema.Union([
-                  Schema.Literals([
-                    "SUCCESS",
-                    "UNSUPPORTED_APPLICATION",
-                    "INSUFFICIENT_INVOCATIONS",
-                  ]),
-                  Schema.String,
-                ]),
-                Schema.Null,
-              ]),
-            ),
-            lastAnalyzedAt: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-          }).pipe(
-            Schema.encodeKeys({
-              mode: "mode",
-              status: "status",
-              lastAnalyzedAt: "last_analyzed_at",
+          Schema.Union([
+            Schema.Struct({
+              mode: Schema.Literal("targeted"),
+              region: Schema.String,
             }),
-          ),
+            Schema.Struct({
+              hostname: Schema.String,
+              mode: Schema.Literal("targeted"),
+            }),
+            Schema.Struct({
+              host: Schema.String,
+              mode: Schema.Literal("targeted"),
+            }),
+            Schema.Struct({
+              mode: Schema.Literal("targeted"),
+              target: Schema.Array(
+                Schema.Union([
+                  Schema.Struct({
+                    region: Schema.String,
+                  }),
+                  Schema.Struct({
+                    hostname: Schema.String,
+                  }),
+                  Schema.Struct({
+                    host: Schema.String,
+                  }),
+                ]),
+              ),
+            }),
+            Schema.Struct({
+              mode: Schema.Literal("smart"),
+            }),
+            Schema.Struct({
+              region: Schema.String,
+            }),
+            Schema.Struct({
+              hostname: Schema.String,
+            }),
+            Schema.Struct({
+              host: Schema.String,
+            }),
+            Schema.Struct({
+              mode: Schema.optional(
+                Schema.Union([Schema.Literal("smart"), Schema.Null]),
+              ),
+              status: Schema.optional(
+                Schema.Union([
+                  Schema.Union([
+                    Schema.Literals([
+                      "SUCCESS",
+                      "UNSUPPORTED_APPLICATION",
+                      "INSUFFICIENT_INVOCATIONS",
+                    ]),
+                    Schema.String,
+                  ]),
+                  Schema.Null,
+                ]),
+              ),
+              lastAnalyzedAt: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+            }).pipe(
+              Schema.encodeKeys({
+                mode: "mode",
+                status: "status",
+                lastAnalyzedAt: "last_analyzed_at",
+              }),
+            ),
+          ]),
           Schema.Null,
         ]),
       ),


### PR DESCRIPTION
Make the Workers for Platforms script-settings endpoint usable from typed consumers.

`getDispatchNamespaceScriptSetting`:

- Type its error union (it previously carried only the generic HTTP catch-alls):

```json
{ "errors": {
  "DispatchNamespaceNotFound": [{ "code": 100119 }],
  "DispatchNamespaceScriptNotFound": [{ "code": 10007 }],
  "Forbidden": [{ "status": 403 }]
} }
```

- Fix `placement` decoding. The vendor SDK models the **response** placement with the **request** union — every variant requires `mode`/`region`/`hostname`/`host` — so the real response (`{}` when unset, or `{ mode, status, last_analyzed_at }`) matches no variant and fails to decode. The vendor SDK only gets away with it because it never validates the response at runtime.

  We keep the upstream union verbatim and **append** the one variant it omits for the response — the all-optional placement-status object:

  ```ts
  placement?:
    | { mode: "smart" }
    | { region: string }
    | /* …upstream's targeted / hostname / host variants… */
    | {                                  // appended
        mode?: "smart" | null;
        status?: "SUCCESS" | "UNSUPPORTED_APPLICATION" | "INSUFFICIENT_INVOCATIONS" | (string & {}) | null;
        lastAnalyzedAt?: string | null;  // wire: last_analyzed_at
      }
    | null;
  ```

  Uses the existing `appendUnion` patch op — no parser/model/codegen change. (This is a semantic gap in the vendor spec, not a representation gap on our side; the generator already reproduces upstream's union faithfully — which is exactly why it failed.)

Found while wiring the alchemy Cloudflare Worker resource to deploy into a dispatch namespace: the post-upload settings read needed both the typed not-found tags and a response that actually decodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
