### PR TITLE
fix(cloudflare): surface null-body 429 as retryable TooManyRequests

### DIFF
--- a/packages/cloudflare/src/client/api.ts
+++ b/packages/cloudflare/src/client/api.ts
@@ -412,6 +412,17 @@ const matchError = (
       bodyStr,
     );
     if (matchedRaw) return matchedRaw;
+    // The global API rate limiter can respond 429 with an empty/non-envelope
+    // body (e.g. `null`); surface it as the retryable TooManyRequests instead
+    // of the catch-all CloudflareHttpError so the retry policy backs off.
+    if (status === 429) {
+      return Effect.fail(
+        new TooManyRequests({
+          message: bodyStr,
+          retryAfter: parseServerRetryHint(headers),
+        }),
+      );
+    }
     return Effect.fail(
       new CloudflareHttpError({
         status,


### PR DESCRIPTION
The global API rate limiter can respond `429` with an empty / non-envelope body (e.g. a literal `null`). That path fell through to the catch-all `CloudflareHttpError`, which is not retryable, so the bounded retry policy never backed off and callers saw a hard failure under rate-limit pressure.

Map a non-envelope 429 to the typed, retryable `TooManyRequests` (honoring the server retry hint) the same way the enveloped path already does:

```diff
 if (matchedRaw) return matchedRaw;
+if (status === 429) {
+  return Effect.fail(
+    new TooManyRequests({
+      message: bodyStr,
+      retryAfter: parseServerRetryHint(headers),
+    }),
+  );
+}
 return Effect.fail(new CloudflareHttpError({ status, ... }));
```

Surfaced while running the alchemy Cloudflare suite at high concurrency, where the account's global rate limit returned null-body 429s that failed hard instead of backing off.
