### PR TITLE
fix(cloudflare/workers): type WorkerHasNoVersions and SecretsStoreBindingNotFound

### DIFF
--- a/packages/cloudflare/patches/workers/getScriptSetting.json
+++ b/packages/cloudflare/patches/workers/getScriptSetting.json
@@ -1,6 +1,9 @@
 {
   "errors": {
-    "WorkerNotFound": [{ "code": 10007 }]
+    "WorkerNotFound": [{ "code": 10007 }],
+    "WorkerHasNoVersions": [
+      { "status": 404, "message": { "includes": "has no versions" } }
+    ]
   },
   "response": {
     "properties": {

--- a/packages/cloudflare/patches/workers/putScript.json
+++ b/packages/cloudflare/patches/workers/putScript.json
@@ -28,7 +28,8 @@
         "code": 10021,
         "message": { "includes": "No such module" }
       }
-    ]
+    ],
+    "SecretsStoreBindingNotFound": [{ "code": 10182 }]
   },
   "request": {
     "properties": {

--- a/packages/cloudflare/specs/cloudflare/workers.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/workers.openapi.yml
@@ -12776,6 +12776,8 @@ paths:
           - code: 10021
             message:
               includes: No such module
+        SecretsStoreBindingNotFound:
+          - code: 10182
     delete:
       operationId: deleteScript
       description: "Delete your worker. This call has no response body on a successful
@@ -18919,6 +18921,10 @@ paths:
       x-distilled-errors:
         WorkerNotFound:
           - code: 10007
+        WorkerHasNoVersions:
+          - status: 404
+            message:
+              includes: has no versions
     patch:
       operationId: patchScriptSetting
       description: "Patch script-level settings when using [Worker

--- a/packages/cloudflare/src/client/api.ts
+++ b/packages/cloudflare/src/client/api.ts
@@ -222,8 +222,15 @@ function matchesExpression(
   if (matcher.message !== undefined) {
     if (typeof matcher.message === "string") {
       if (matcher.message !== message) return false;
-    } else if (matcher.message.includes !== undefined) {
-      if (!message.includes(matcher.message.includes)) return false;
+    } else {
+      const { includes, matches } = matcher.message;
+      // An empty message-object constrains nothing and would otherwise
+      // match every error — reject it like the fully-empty matcher above.
+      if (includes === undefined && matches === undefined) return false;
+      if (includes !== undefined && !message.includes(includes)) return false;
+      if (matches !== undefined && !new RegExp(matches).test(message)) {
+        return false;
+      }
     }
   }
   return true;

--- a/packages/cloudflare/src/services/workers.ts
+++ b/packages/cloudflare/src/services/workers.ts
@@ -170,6 +170,14 @@ export class SecretNotFound extends T.applyErrorMatchers(
   [{ code: 10056 }],
 ) {}
 
+export class SecretsStoreBindingNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SecretsStoreBindingNotFound>()(
+    "SecretsStoreBindingNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 10182 }],
+) {}
+
 export class ServiceBindingConflict extends T.applyErrorMatchers(
   Schema.TaggedErrorClass<ServiceBindingConflict>()("ServiceBindingConflict", {
     code: Schema.Number,
@@ -15124,7 +15132,8 @@ export type PutScriptError =
   | DurableObjectMustBeSqlite
   | DuplicateMigrationTarget
   | ScriptStartupError
-  | ScriptModuleNotFound;
+  | ScriptModuleNotFound
+  | SecretsStoreBindingNotFound;
 
 export const putScript: API.OperationMethod<
   PutScriptRequest,
@@ -15142,6 +15151,7 @@ export const putScript: API.OperationMethod<
     DuplicateMigrationTarget,
     ScriptStartupError,
     ScriptModuleNotFound,
+    SecretsStoreBindingNotFound,
   ],
 }));
 
@@ -17624,7 +17634,10 @@ export const GetScriptSettingResponse =
       .pipe(T.ResponsePath("result")),
   ) as unknown as Schema.Codec<GetScriptSettingResponse>;
 
-export type GetScriptSettingError = DefaultErrors | WorkerNotFound;
+export type GetScriptSettingError =
+  | DefaultErrors
+  | WorkerNotFound
+  | WorkerHasNoVersions;
 
 export const getScriptSetting: API.OperationMethod<
   GetScriptSettingRequest,
@@ -17634,7 +17647,7 @@ export const getScriptSetting: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: GetScriptSettingRequest,
   output: GetScriptSettingResponse,
-  errors: [WorkerNotFound],
+  errors: [WorkerNotFound, WorkerHasNoVersions],
 }));
 
 export interface PatchScriptSettingRequest {

--- a/packages/cloudflare/src/traits.ts
+++ b/packages/cloudflare/src/traits.ts
@@ -18,7 +18,7 @@ export const errorMatchersSymbol = Symbol.for(
 export interface ErrorMatcher {
   code?: number;
   status?: number;
-  message?: string | { includes: string };
+  message?: string | { includes?: string; matches?: string };
 }
 
 /**


### PR DESCRIPTION
Type the two workers errors that alchemy's state-store bootstrap flow hits (needed by alchemy-run/alchemy-effect#737), and implement the `message.matches` matcher the patch DSL documents.

- `getScriptSetting`: `WorkerHasNoVersions` — a worker whose deploy was interrupted before any content upload 404s with "has no versions"

  ```json
  "WorkerHasNoVersions": [
    { "status": 404, "message": { "includes": "has no versions" } }
  ]
  ```

- `putScript`: `SecretsStoreBindingNotFound` — a `secrets_store_secret` binding referencing a missing (or still-`pending`) secret or store

  ```json
  "SecretsStoreBindingNotFound": [{ "code": 10182 }]
  ```

  Verified against the live API: both the missing-secret (real store) and missing-store variants fail with code `10182` and message `Secrets Store binding 'SECRET' references store '…' and secret '…' which were not found. …`. The code is unique to Secrets Store bindings — other binding types use their own not-found codes (KV `10041`, R2 `10085`, D1 `10181`, Queue `11000`, Service `10144`).

- `matchesExpression` only ever implemented `includes`, although the patch DSL documents `message.matches` and the generator's patch schema accepts it — a `matches`-only matcher fell through every check and matched **every** error. Implement the regex branch and reject empty message-objects:

  ```diff
       if (typeof matcher.message === "string") {
         if (matcher.message !== message) return false;
  -    } else if (matcher.message.includes !== undefined) {
  -      if (!message.includes(matcher.message.includes)) return false;
  +    } else {
  +      const { includes, matches } = matcher.message;
  +      // An empty message-object constrains nothing and would otherwise
  +      // match every error — reject it like the fully-empty matcher above.
  +      if (includes === undefined && matches === undefined) return false;
  +      if (includes !== undefined && !message.includes(includes)) return false;
  +      if (matches !== undefined && !new RegExp(matches).test(message)) {
  +        return false;
  +      }
       }
  ```

  No generated service currently uses `matches`, so this is behavior-neutral for existing patches.
