### PR TITLE
feat(cloudflare/workers): add cache_options to putScript metadata

### DIFF
--- a/packages/cloudflare/patches/workers/putScript.json
+++ b/packages/cloudflare/patches/workers/putScript.json
@@ -163,6 +163,24 @@
             }
           ]
         }
+      },
+      "metadata.cache_options": {
+        "optional": true,
+        "definition": {
+          "kind": "object",
+          "properties": [
+            {
+              "name": "enabled",
+              "required": true,
+              "type": { "kind": "primitive", "value": "boolean" }
+            },
+            {
+              "name": "cross_version_cache",
+              "required": false,
+              "type": { "kind": "primitive", "value": "boolean" }
+            }
+          ]
+        }
       }
     }
   },

--- a/packages/cloudflare/specs/cloudflare/workers.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/workers.openapi.yml
@@ -12319,6 +12319,15 @@ paths:
                             type: string
                         required:
                           - class_name
+                    cache_options:
+                      type: object
+                      properties:
+                        enabled:
+                          type: boolean
+                        cross_version_cache:
+                          type: boolean
+                      required:
+                        - enabled
                   description: "Body param: JSON-encoded metadata about the uploaded parts and
                     Worker configuration."
                 files:

--- a/packages/cloudflare/src/services/workers.ts
+++ b/packages/cloudflare/src/services/workers.ts
@@ -6479,6 +6479,25 @@ const PutScriptRequestMetadataBinding37 =
     ),
   ) as unknown as Schema.Codec<PutScriptRequestMetadataBinding37>;
 
+interface PutScriptRequestMetadataCacheOptions {
+  enabled: boolean;
+  crossVersionCache?: boolean | null;
+}
+const PutScriptRequestMetadataCacheOptions =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.suspend(() =>
+    Schema.Struct({
+      enabled: Schema.Boolean,
+      crossVersionCache: Schema.optional(
+        Schema.Union([Schema.Boolean, Schema.Null]),
+      ),
+    }).pipe(
+      Schema.encodeKeys({
+        enabled: "enabled",
+        crossVersionCache: "cross_version_cache",
+      }),
+    ),
+  ) as unknown as Schema.Codec<PutScriptRequestMetadataCacheOptions>;
+
 interface Metadata2 {
   /** Annotations for the version created by this upload. */
   annotations?: {
@@ -6756,6 +6775,10 @@ interface Metadata2 {
   /** Usage model for the Worker invocations. */
   usageModel?: "standard" | "bundled" | "unbound" | (string & {}) | null;
   containers?: { className: string }[] | null;
+  cacheOptions?: {
+    enabled: boolean;
+    crossVersionCache?: boolean | null;
+  } | null;
 }
 const Metadata2 = /*@__PURE__*/ /*#__PURE__*/ Schema.suspend(() =>
   Schema.Struct({
@@ -6862,6 +6885,9 @@ const Metadata2 = /*@__PURE__*/ /*#__PURE__*/ Schema.suspend(() =>
     containers: Schema.optional(
       Schema.Union([Schema.Array(Container), Schema.Null]),
     ),
+    cacheOptions: Schema.optional(
+      Schema.Union([PutScriptRequestMetadataCacheOptions, Schema.Null]),
+    ),
   }).pipe(
     Schema.encodeKeys({
       annotations: "annotations",
@@ -6882,6 +6908,7 @@ const Metadata2 = /*@__PURE__*/ /*#__PURE__*/ Schema.suspend(() =>
       tailConsumers: "tail_consumers",
       usageModel: "usage_model",
       containers: "containers",
+      cacheOptions: "cache_options",
     }),
   ),
 ) as unknown as Schema.Codec<Metadata2>;
@@ -14814,6 +14841,7 @@ export interface PutScriptRequest {
       | null;
     usageModel?: "standard" | "bundled" | "unbound" | (string & {});
     containers?: { className: string }[];
+    cacheOptions?: { enabled: boolean; crossVersionCache?: boolean };
   };
   /** Body param: An array of modules (often JavaScript files) comprising a Worker script. At least one module must be present and referenced in the metadata as `main_module` or `body_part` by filename.<br/ */
   files?: (File | Blob)[];


### PR DESCRIPTION
Add `cache_options` to the `putScript` upload metadata so consumers can enable [Workers Cache](https://blog.cloudflare.com/workers-cache/) per script version.

```ts
yield* workers.putScript({
  accountId,
  scriptName,
  metadata: {
    // ...
    cacheOptions: { enabled: true, crossVersionCache: true },
  },
});
```

The vendor `cloudflare-typescript` SDK (HEAD, June 23) and `cloudflare/api-schemas` don't model the field yet, so this lands as a patch in `patches/workers/putScript.json`. The wire shape (`cache_options: { enabled, cross_version_cache }`, snake_case) matches what wrangler ≥4.69 uploads (see `create-worker-upload-form` tests in cloudflare/workers-sdk).

Verified live from alchemy: a worker deployed with `cacheOptions: { enabled: true }` serves repeat requests from cache (identical invocation ids across fetches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
