### PR TITLE
fix(cloudflare/workers): type every binding-target-not-found error on script upload

### DIFF
--- a/packages/cloudflare/patches/workers-for-platforms/putDispatchNamespaceScript.json
+++ b/packages/cloudflare/patches/workers-for-platforms/putDispatchNamespaceScript.json
@@ -1,6 +1,16 @@
 {
   "errors": {
     "DispatchNamespaceNotFound": [{ "code": 100119 }],
-    "Forbidden": [{ "status": 403 }]
+    "Forbidden": [{ "status": 403 }],
+    "SecretsStoreBindingNotFound": [{ "code": 10182 }],
+    "KVNamespaceNotFound": [{ "code": 10041 }],
+    "R2BucketNotFound": [{ "code": 10085 }],
+    "D1DatabaseNotFound": [{ "code": 10181 }],
+    "QueueNotFound": [{ "code": 11000 }],
+    "ServiceBindingNotFound": [{ "code": 10144 }],
+    "DurableObjectClassNotFound": [{ "code": 10061 }],
+    "HyperdriveConfigNotFound": [{ "code": 10157 }],
+    "VectorizeIndexNotFound": [{ "code": 10159 }],
+    "MtlsCertificateNotFound": [{ "code": 100143 }]
   }
 }

--- a/packages/cloudflare/patches/workers/putScript.json
+++ b/packages/cloudflare/patches/workers/putScript.json
@@ -29,7 +29,17 @@
         "message": { "includes": "No such module" }
       }
     ],
-    "SecretsStoreBindingNotFound": [{ "code": 10182 }]
+    "SecretsStoreBindingNotFound": [{ "code": 10182 }],
+    "KVNamespaceNotFound": [{ "code": 10041 }],
+    "R2BucketNotFound": [{ "code": 10085 }],
+    "D1DatabaseNotFound": [{ "code": 10181 }],
+    "QueueNotFound": [{ "code": 11000 }],
+    "ServiceBindingNotFound": [{ "code": 10144 }],
+    "DurableObjectClassNotFound": [{ "code": 10061 }],
+    "HyperdriveConfigNotFound": [{ "code": 10157 }],
+    "VectorizeIndexNotFound": [{ "code": 10159 }],
+    "DispatchNamespaceNotFound": [{ "code": 100119 }],
+    "MtlsCertificateNotFound": [{ "code": 100143 }]
   },
   "request": {
     "properties": {

--- a/packages/cloudflare/specs/cloudflare/workers-for-platforms.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/workers-for-platforms.openapi.yml
@@ -2345,6 +2345,26 @@ paths:
           - code: 100119
         Forbidden:
           - status: 403
+        SecretsStoreBindingNotFound:
+          - code: 10182
+        KVNamespaceNotFound:
+          - code: 10041
+        R2BucketNotFound:
+          - code: 10085
+        D1DatabaseNotFound:
+          - code: 10181
+        QueueNotFound:
+          - code: 11000
+        ServiceBindingNotFound:
+          - code: 10144
+        DurableObjectClassNotFound:
+          - code: 10061
+        HyperdriveConfigNotFound:
+          - code: 10157
+        VectorizeIndexNotFound:
+          - code: 10159
+        MtlsCertificateNotFound:
+          - code: 100143
     delete:
       operationId: deleteDispatchNamespaceScript
       description: "Delete a worker from a Workers for Platforms namespace. This call

--- a/packages/cloudflare/specs/cloudflare/workers.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/workers.openapi.yml
@@ -12778,6 +12778,26 @@ paths:
               includes: No such module
         SecretsStoreBindingNotFound:
           - code: 10182
+        KVNamespaceNotFound:
+          - code: 10041
+        R2BucketNotFound:
+          - code: 10085
+        D1DatabaseNotFound:
+          - code: 10181
+        QueueNotFound:
+          - code: 11000
+        ServiceBindingNotFound:
+          - code: 10144
+        DurableObjectClassNotFound:
+          - code: 10061
+        HyperdriveConfigNotFound:
+          - code: 10157
+        VectorizeIndexNotFound:
+          - code: 10159
+        DispatchNamespaceNotFound:
+          - code: 100119
+        MtlsCertificateNotFound:
+          - code: 100143
     delete:
       operationId: deleteScript
       description: "Delete your worker. This call has no response body on a successful

--- a/packages/cloudflare/src/services/workers-for-platforms.ts
+++ b/packages/cloudflare/src/services/workers-for-platforms.ts
@@ -17,6 +17,14 @@ import { UploadableSchema } from "../schemas.ts";
 // Errors
 // =============================================================================
 
+export class D1DatabaseNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<D1DatabaseNotFound>()("D1DatabaseNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10181 }],
+) {}
+
 export class DispatchNamespaceAlreadyExists extends T.applyErrorMatchers(
   Schema.TaggedErrorClass<DispatchNamespaceAlreadyExists>()(
     "DispatchNamespaceAlreadyExists",
@@ -41,12 +49,84 @@ export class DispatchNamespaceScriptNotFound extends T.applyErrorMatchers(
   [{ code: 10007 }],
 ) {}
 
+export class DurableObjectClassNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DurableObjectClassNotFound>()(
+    "DurableObjectClassNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 10061 }],
+) {}
+
 export class Forbidden extends T.applyErrorMatchers(
   Schema.TaggedErrorClass<Forbidden>()("Forbidden", {
     code: Schema.Number,
     message: Schema.String,
   }),
   [{ status: 403 }],
+) {}
+
+export class HyperdriveConfigNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<HyperdriveConfigNotFound>()(
+    "HyperdriveConfigNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 10157 }],
+) {}
+
+export class KVNamespaceNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<KVNamespaceNotFound>()("KVNamespaceNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10041 }],
+) {}
+
+export class MtlsCertificateNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<MtlsCertificateNotFound>()(
+    "MtlsCertificateNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 100143 }],
+) {}
+
+export class QueueNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<QueueNotFound>()("QueueNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 11000 }],
+) {}
+
+export class R2BucketNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<R2BucketNotFound>()("R2BucketNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10085 }],
+) {}
+
+export class SecretsStoreBindingNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<SecretsStoreBindingNotFound>()(
+    "SecretsStoreBindingNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 10182 }],
+) {}
+
+export class ServiceBindingNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ServiceBindingNotFound>()("ServiceBindingNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10144 }],
+) {}
+
+export class VectorizeIndexNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<VectorizeIndexNotFound>()("VectorizeIndexNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10159 }],
 ) {}
 
 // =============================================================================
@@ -3963,7 +4043,17 @@ export const PutDispatchNamespaceScriptResponse =
 export type PutDispatchNamespaceScriptError =
   | DefaultErrors
   | DispatchNamespaceNotFound
-  | Forbidden;
+  | Forbidden
+  | SecretsStoreBindingNotFound
+  | KVNamespaceNotFound
+  | R2BucketNotFound
+  | D1DatabaseNotFound
+  | QueueNotFound
+  | ServiceBindingNotFound
+  | DurableObjectClassNotFound
+  | HyperdriveConfigNotFound
+  | VectorizeIndexNotFound
+  | MtlsCertificateNotFound;
 
 export const putDispatchNamespaceScript: API.OperationMethod<
   PutDispatchNamespaceScriptRequest,
@@ -3973,7 +4063,20 @@ export const putDispatchNamespaceScript: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: PutDispatchNamespaceScriptRequest,
   output: PutDispatchNamespaceScriptResponse,
-  errors: [DispatchNamespaceNotFound, Forbidden],
+  errors: [
+    DispatchNamespaceNotFound,
+    Forbidden,
+    SecretsStoreBindingNotFound,
+    KVNamespaceNotFound,
+    R2BucketNotFound,
+    D1DatabaseNotFound,
+    QueueNotFound,
+    ServiceBindingNotFound,
+    DurableObjectClassNotFound,
+    HyperdriveConfigNotFound,
+    VectorizeIndexNotFound,
+    MtlsCertificateNotFound,
+  ],
 }));
 
 export interface DeleteDispatchNamespaceScriptRequest {

--- a/packages/cloudflare/src/services/workers.ts
+++ b/packages/cloudflare/src/services/workers.ts
@@ -25,12 +25,28 @@ export class ContentTypeRequired extends T.applyErrorMatchers(
   [{ code: 10001 }],
 ) {}
 
+export class D1DatabaseNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<D1DatabaseNotFound>()("D1DatabaseNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10181 }],
+) {}
+
 export class DeploymentNotFound extends T.applyErrorMatchers(
   Schema.TaggedErrorClass<DeploymentNotFound>()("DeploymentNotFound", {
     code: Schema.Number,
     message: Schema.String,
   }),
   [{ code: 10336 }],
+) {}
+
+export class DispatchNamespaceNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DispatchNamespaceNotFound>()(
+    "DispatchNamespaceNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 100119 }],
 ) {}
 
 export class DomainNotFound extends T.applyErrorMatchers(
@@ -52,6 +68,14 @@ export class DuplicateMigrationTarget extends T.applyErrorMatchers(
       message: { includes: "cannot be the target of more than one migration" },
     },
   ],
+) {}
+
+export class DurableObjectClassNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<DurableObjectClassNotFound>()(
+    "DurableObjectClassNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 10061 }],
 ) {}
 
 export class DurableObjectMustBeSqlite extends T.applyErrorMatchers(
@@ -76,6 +100,14 @@ export class HostnameAlreadyInUse extends T.applyErrorMatchers(
     message: Schema.String,
   }),
   [{ code: 100116 }],
+) {}
+
+export class HyperdriveConfigNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<HyperdriveConfigNotFound>()(
+    "HyperdriveConfigNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 10157 }],
 ) {}
 
 T.applyErrorMatchers(InternalServerError, [
@@ -104,6 +136,22 @@ export class InvalidWorkerScript extends T.applyErrorMatchers(
     message: Schema.String,
   }),
   [{ code: 10068 }],
+) {}
+
+export class KVNamespaceNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<KVNamespaceNotFound>()("KVNamespaceNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10041 }],
+) {}
+
+export class MtlsCertificateNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<MtlsCertificateNotFound>()(
+    "MtlsCertificateNotFound",
+    { code: Schema.Number, message: Schema.String },
+  ),
+  [{ code: 100143 }],
 ) {}
 
 export class ObservabilityDestinationCreateFailed extends T.applyErrorMatchers(
@@ -136,6 +184,22 @@ export class QueueConsumerConflict extends T.applyErrorMatchers(
     message: Schema.String,
   }),
   [{ code: 10064 }],
+) {}
+
+export class QueueNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<QueueNotFound>()("QueueNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 11000 }],
+) {}
+
+export class R2BucketNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<R2BucketNotFound>()("R2BucketNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10085 }],
 ) {}
 
 export class RouteNotFound extends T.applyErrorMatchers(
@@ -186,6 +250,14 @@ export class ServiceBindingConflict extends T.applyErrorMatchers(
   [{ code: 10142 }],
 ) {}
 
+export class ServiceBindingNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<ServiceBindingNotFound>()("ServiceBindingNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10144 }],
+) {}
+
 export class SubdomainAlreadyExists extends T.applyErrorMatchers(
   Schema.TaggedErrorClass<SubdomainAlreadyExists>()("SubdomainAlreadyExists", {
     code: Schema.Number,
@@ -200,6 +272,14 @@ export class SubdomainNotFound extends T.applyErrorMatchers(
     message: Schema.String,
   }),
   [{ status: 404 }],
+) {}
+
+export class VectorizeIndexNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<VectorizeIndexNotFound>()("VectorizeIndexNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10159 }],
 ) {}
 
 export class VersionNotFound extends T.applyErrorMatchers(
@@ -15133,7 +15213,17 @@ export type PutScriptError =
   | DuplicateMigrationTarget
   | ScriptStartupError
   | ScriptModuleNotFound
-  | SecretsStoreBindingNotFound;
+  | SecretsStoreBindingNotFound
+  | KVNamespaceNotFound
+  | R2BucketNotFound
+  | D1DatabaseNotFound
+  | QueueNotFound
+  | ServiceBindingNotFound
+  | DurableObjectClassNotFound
+  | HyperdriveConfigNotFound
+  | VectorizeIndexNotFound
+  | DispatchNamespaceNotFound
+  | MtlsCertificateNotFound;
 
 export const putScript: API.OperationMethod<
   PutScriptRequest,
@@ -15152,6 +15242,16 @@ export const putScript: API.OperationMethod<
     ScriptStartupError,
     ScriptModuleNotFound,
     SecretsStoreBindingNotFound,
+    KVNamespaceNotFound,
+    R2BucketNotFound,
+    D1DatabaseNotFound,
+    QueueNotFound,
+    ServiceBindingNotFound,
+    DurableObjectClassNotFound,
+    HyperdriveConfigNotFound,
+    VectorizeIndexNotFound,
+    DispatchNamespaceNotFound,
+    MtlsCertificateNotFound,
   ],
 }));
 


### PR DESCRIPTION
Type every deploy-time "binding references a resource that doesn't exist" rejection on `putScript` and `putDispatchNamespaceScript`. Completes the family started by `SecretsStoreBindingNotFound` (#363); consumed by alchemy's `WorkerProvider` retry.

Each code was captured verbatim from the live API by uploading probe workers with bindings referencing missing targets — the codes are resource-specific, so plain code matchers are sound:

```json
"KVNamespaceNotFound":        [{ "code": 10041 }],
"R2BucketNotFound":           [{ "code": 10085 }],
"D1DatabaseNotFound":         [{ "code": 10181 }],
"QueueNotFound":              [{ "code": 11000 }],
"ServiceBindingNotFound":     [{ "code": 10144 }],
"DurableObjectClassNotFound": [{ "code": 10061 }],
"HyperdriveConfigNotFound":   [{ "code": 10157 }],
"VectorizeIndexNotFound":     [{ "code": 10159 }],
"DispatchNamespaceNotFound":  [{ "code": 100119 }],
"MtlsCertificateNotFound":    [{ "code": 100143 }]
```

- Tag names reuse the established per-service names (`QueueNotFound` in queues, `HyperdriveConfigNotFound` in hyperdrive, `DispatchNamespaceNotFound` in workers-for-platforms)
- `DurableObjectClassNotFound` (10061) covers both variants: class not exported by an existing script, and the target script not existing at all (both probed)
- The dispatch-namespace upload path runs the same validation (probed live with a real dispatch namespace: same code 10041 for a missing KV namespace), so the same set lands on `putDispatchNamespaceScript`
- Workflow bindings are not validated at upload time — a probe referencing a nonexistent workflow deployed successfully — so there is nothing to type for them
