### PR TITLE
fix(cloudflare/workers): serialize metadata.cache as cache_options on the wire

### DIFF
--- a/packages/cloudflare/patches/workers/createScriptVersion.json
+++ b/packages/cloudflare/patches/workers/createScriptVersion.json
@@ -52,6 +52,7 @@
       },
       "metadata.cache": {
         "optional": true,
+        "wireKey": "cache_options",
         "definition": {
           "kind": "object",
           "properties": [

--- a/packages/cloudflare/patches/workers/putScript.json
+++ b/packages/cloudflare/patches/workers/putScript.json
@@ -177,6 +177,7 @@
       },
       "metadata.cache": {
         "optional": true,
+        "wireKey": "cache_options",
         "definition": {
           "kind": "object",
           "properties": [

--- a/packages/cloudflare/specs/cloudflare/workers.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/workers.openapi.yml
@@ -12319,7 +12319,7 @@ paths:
                             type: string
                         required:
                           - class_name
-                    cache:
+                    cache_options:
                       type: object
                       properties:
                         enabled:
@@ -21371,7 +21371,7 @@ paths:
                         - bundled
                         - unbound
                       description: Usage model for the Worker invocations.
-                    cache:
+                    cache_options:
                       type: object
                       properties:
                         enabled:

--- a/packages/cloudflare/src/services/workers.ts
+++ b/packages/cloudflare/src/services/workers.ts
@@ -6996,7 +6996,7 @@ const Metadata2 = /*@__PURE__*/ /*#__PURE__*/ Schema.suspend(() =>
       tailConsumers: "tail_consumers",
       usageModel: "usage_model",
       containers: "containers",
-      cache: "cache",
+      cache: "cache_options",
     }),
   ),
 ) as unknown as Schema.Codec<Metadata2>;
@@ -9293,7 +9293,7 @@ const Metadata5 = /*@__PURE__*/ /*#__PURE__*/ Schema.suspend(() =>
       compatibilityFlags: "compatibility_flags",
       keepBindings: "keep_bindings",
       usageModel: "usage_model",
-      cache: "cache",
+      cache: "cache_options",
     }),
   ),
 ) as unknown as Schema.Codec<Metadata5>;


### PR DESCRIPTION
#366 named the Workers Cache upload-metadata field `cache` both in TypeScript and on the wire, but the API silently ignores that key — the wire field is `cache_options` (what wrangler ≥4.69 uploads; see the `create-worker-upload-form` tests in cloudflare/workers-sdk). This keeps the TS-side name and fixes the serialization:

```diff
 "metadata.cache": {
   "optional": true,
+  "wireKey": "cache_options",
```

Applied to both `putScript` and `createScriptVersion`.

Verified live from alchemy's Workers Cache test: with `cache` on the wire, repeat requests never hit the cache (the setting is dropped); with `cache_options`, the second request serves the cached body and `Cache-Tag` purges work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
