### PR TITLE
fix(cloudflare/workers): type createRoute code 10019 as RouteScriptNotFound

### DIFF
--- a/packages/cloudflare/patches/workers/createRoute.json
+++ b/packages/cloudflare/patches/workers/createRoute.json
@@ -1,6 +1,6 @@
 {
   "errors": {
-    "WorkerNotFound": [{ "code": 10019 }],
+    "RouteScriptNotFound": [{ "code": 10019 }],
     "InvalidRoutePattern": [{ "code": 10022 }],
     "InvalidRoute": [{ "code": 7003 }],
     "Forbidden": [{ "status": 403 }]

--- a/packages/cloudflare/patches/workers/createRoute.json
+++ b/packages/cloudflare/patches/workers/createRoute.json
@@ -1,5 +1,6 @@
 {
   "errors": {
+    "WorkerNotFound": [{ "code": 10019 }],
     "InvalidRoutePattern": [{ "code": 10022 }],
     "InvalidRoute": [{ "code": 7003 }],
     "Forbidden": [{ "status": 403 }]

--- a/packages/cloudflare/specs/cloudflare/workers.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/workers.openapi.yml
@@ -10989,7 +10989,7 @@ paths:
                   - pattern
       x-distilled-response-path: result
       x-distilled-errors:
-        WorkerNotFound:
+        RouteScriptNotFound:
           - code: 10019
         InvalidRoutePattern:
           - code: 10022

--- a/packages/cloudflare/specs/cloudflare/workers.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/workers.openapi.yml
@@ -10989,6 +10989,8 @@ paths:
                   - pattern
       x-distilled-response-path: result
       x-distilled-errors:
+        WorkerNotFound:
+          - code: 10019
         InvalidRoutePattern:
           - code: 10022
         InvalidRoute:

--- a/packages/cloudflare/src/services/workers.ts
+++ b/packages/cloudflare/src/services/workers.ts
@@ -303,7 +303,7 @@ export class WorkerNotFound extends T.applyErrorMatchers(
     code: Schema.Number,
     message: Schema.String,
   }),
-  [{ code: 10007 }],
+  [{ code: 10007 }, { code: 10019 }],
 ) {}
 
 export class WorkerVersionNotFound extends T.applyErrorMatchers(
@@ -14359,6 +14359,7 @@ export const CreateRouteResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.suspend(
 
 export type CreateRouteError =
   | DefaultErrors
+  | WorkerNotFound
   | InvalidRoutePattern
   | InvalidRoute
   | Forbidden;
@@ -14371,7 +14372,7 @@ export const createRoute: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: CreateRouteRequest,
   output: CreateRouteResponse,
-  errors: [InvalidRoutePattern, InvalidRoute, Forbidden],
+  errors: [WorkerNotFound, InvalidRoutePattern, InvalidRoute, Forbidden],
 }));
 
 export interface UpdateRouteRequest {

--- a/packages/cloudflare/src/services/workers.ts
+++ b/packages/cloudflare/src/services/workers.ts
@@ -210,6 +210,14 @@ export class RouteNotFound extends T.applyErrorMatchers(
   [{ code: 10009 }, { status: 404 }],
 ) {}
 
+export class RouteScriptNotFound extends T.applyErrorMatchers(
+  Schema.TaggedErrorClass<RouteScriptNotFound>()("RouteScriptNotFound", {
+    code: Schema.Number,
+    message: Schema.String,
+  }),
+  [{ code: 10019 }],
+) {}
+
 export class ScriptModuleNotFound extends T.applyErrorMatchers(
   Schema.TaggedErrorClass<ScriptModuleNotFound>()("ScriptModuleNotFound", {
     code: Schema.Number,
@@ -303,7 +311,7 @@ export class WorkerNotFound extends T.applyErrorMatchers(
     code: Schema.Number,
     message: Schema.String,
   }),
-  [{ code: 10007 }, { code: 10019 }],
+  [{ code: 10007 }],
 ) {}
 
 export class WorkerVersionNotFound extends T.applyErrorMatchers(
@@ -14359,7 +14367,7 @@ export const CreateRouteResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.suspend(
 
 export type CreateRouteError =
   | DefaultErrors
-  | WorkerNotFound
+  | RouteScriptNotFound
   | InvalidRoutePattern
   | InvalidRoute
   | Forbidden;
@@ -14372,7 +14380,7 @@ export const createRoute: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: CreateRouteRequest,
   output: CreateRouteResponse,
-  errors: [WorkerNotFound, InvalidRoutePattern, InvalidRoute, Forbidden],
+  errors: [RouteScriptNotFound, InvalidRoutePattern, InvalidRoute, Forbidden],
 }));
 
 export interface UpdateRouteRequest {


### PR DESCRIPTION
`POST /zones/{zone}/workers/routes` rejects with code 10019 when the referenced script does not exist (probed live):

```json
{ "code": 10019, "message": "Cannot configure a route for a Worker which does not exist. Please ensure this Worker exists and try again." }
```

Type it as a dedicated `RouteScriptNotFound` tag scoped to `createRoute` so consumers can retry the create-route-right-after-put-script propagation race on a typed tag instead of `UnknownCloudflareError`:

```diff
 export type CreateRouteError =
   | DefaultErrors
+  | RouteScriptNotFound
   | InvalidRoutePattern
   | InvalidRoute
   | Forbidden;
```

A dedicated tag rather than widening the shared `WorkerNotFound` matcher list: `WorkerNotFound` is declared by ~38 workers operations, and code 10019 is only verified for `createRoute` — Cloudflare error codes are not unique across endpoint families (KV uses 10019 for a missing title).

Needed by alchemy-run/alchemy-effect#438 (Worker `routes` prop).
