### PR TITLE
chore: migrate to typescript@7 stable, drop tsgo/native-preview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ All other packages depend on core via `@distilled.cloud/sdk-core` workspace depe
 | Tool | Purpose | Command |
 |------|---------|---------|
 | **Bun** | Runtime, package manager, test runner | `bun install`, `bun run ...` |
-| **tsgo** | Type checking (native TypeScript compiler) | `tsgo` (check), `tsgo -b` (build) |
+| **tsc** | Type checking (native TypeScript compiler, `typescript@7`) | `tsc` (check), `tsc -b` (build) |
 | **oxlint** | Linter | `oxlint --fix src` |
 | **oxfmt** | Formatter | `oxfmt --write src`, `oxfmt --check src` |
 | **vitest** | Test framework | `bunx vitest run test` |
@@ -75,9 +75,9 @@ Every package has these scripts:
 
 | Script | Command | Description |
 |--------|---------|-------------|
-| `typecheck` | `tsgo` | Type check only (no emit) |
-| `build` | `tsgo -b` | Build to `lib/` (.js + .d.ts + source maps) |
-| `check` | `tsgo && oxlint src && oxfmt --check src` | Full check (types + lint + format) |
+| `typecheck` | `tsc` | Type check only (no emit) |
+| `build` | `tsc -b` | Build to `lib/` (.js + .d.ts + source maps) |
+| `check` | `tsc && oxlint src && oxfmt --check src` | Full check (types + lint + format) |
 | `fmt` | `oxfmt --write src` | Format source |
 | `lint` | `oxlint --fix src` | Lint + autofix |
 | `test` | `bunx vitest run test` | Run tests |

--- a/bun.lock
+++ b/bun.lock
@@ -12,12 +12,12 @@
         "@anthropic-ai/claude-agent-sdk": "^0.2.81",
         "@types/bun": "catalog:",
         "@types/node": "catalog:",
-        "@typescript/native-preview": "catalog:",
         "aws4fetch": "^1.0.20",
         "changelogithub": "^14.0.0",
         "husky": "^9.1.7",
         "oxfmt": "catalog:",
         "oxlint": "catalog:",
+        "typescript": "catalog:",
         "yaml": "catalog:",
       },
     },
@@ -96,7 +96,7 @@
         "@types/bun": "catalog:",
         "@types/node": "catalog:",
         "dotenv": "catalog:",
-        "typescript": "^5.9.3",
+        "typescript-5": "npm:typescript@^5.9.3",
         "vitest": "catalog:",
       },
       "peerDependencies": {
@@ -389,7 +389,6 @@
     "@smithy/util-base64": "^4.3.0",
     "@types/bun": "^1.3.0",
     "@types/node": "^25.3.5",
-    "@typescript/native-preview": "7.0.0-dev.20260329.1",
     "archiver": "^7.0.1",
     "aws4fetch": "^1.0.20",
     "dedent": "^1.7.0",
@@ -399,6 +398,7 @@
     "oxfmt": "^0.36.0",
     "oxlint": "^1.51.0",
     "pathe": "^2.0.3",
+    "typescript": "^7.0.2",
     "vite": "^7.3.1",
     "vitest": "^3.2.3",
     "yaml": "^2.7.1",
@@ -866,21 +866,45 @@
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
-    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260329.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260329.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260329.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260329.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260329.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260329.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260329.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260329.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-v5lJ0TgSt2m9yVk2xoj9+NH/gTDeWTLaWGPx6MJsUKOYd6bmCJhHbMcWmb8d/zlfhE9ffpixUKYj62CdYfriqA=="],
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
 
-    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260329.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zS1thDk7luD82nXVwvMd97F7FgxAE6jGtSmnHeXdaQ+6hJQcQLOVkfUdaehhdodqKDapWA2jEURxQAYjDGvv3g=="],
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
 
-    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260329.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-3IJ2qmpjQ1OXpZNUhJRjF1+SbDuqGC14Ug8DjWJlPBp06isi1fcJph90f5qW//FxEsNnJPYRcNwpP0A2RbTASg=="],
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
 
-    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260329.1", "", { "os": "linux", "cpu": "arm" }, "sha512-WKSSJrH611DFFAg6YCkgbnkdy0a4RRpzvDpNXtPzLTbMYC5oJdq3Dpvncx5nrJvGh4J4yvzXoMxraGPyygqGLw=="],
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
 
-    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260329.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-gQb6SjB5JlUKDaDuz6mv/m+/OBWVDlcjHINFOykBZZYZtgxBx6nEDjLrT8TiJRjmHEG6hSbv+yisUL9IThWycA=="],
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
 
-    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260329.1", "", { "os": "linux", "cpu": "x64" }, "sha512-kg4r+ssxoEWruBynUg9bFMdcMpo5NupzAPqNBlV8uWbmYGZjaPLonFWAi9ZZMiVJY/x5ZQ9GBl6xskwLdd3PJQ=="],
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
 
-    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260329.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-Qi4lddVxl5MG7Tk67gYhCFnoqqLGd4TvaI8RN4qHFjt3GV8s6c+0cQGsJXJnVgMx27qbyDTdsyAa2pvb42rYcQ=="],
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
 
-    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260329.1", "", { "os": "win32", "cpu": "x64" }, "sha512-+k5+usuB8HZ6Xc+enLdb95ZJd25bQqsnI1zXxfRCHP+RS9mxs70Mi9ezQz3lKOLZFFXShSH7iW9iulm8KwVzCQ=="],
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
@@ -1342,7 +1366,9 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
+
+    "typescript-5": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
 
@@ -1390,7 +1416,7 @@
 
     "yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
-    "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
 
@@ -1407,6 +1433,8 @@
     "@aws-sdk/nested-clients/@smithy/util-utf8": ["@smithy/util-utf8@4.2.2", "", { "dependencies": { "@smithy/util-buffer-from": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw=="],
 
     "@aws-sdk/xml-builder/fast-xml-parser": ["fast-xml-parser@5.4.1", "", { "dependencies": { "fast-xml-builder": "^1.0.0", "strnum": "^2.1.2" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A=="],
+
+    "@distilled.cloud/coinbase/yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 
     "@smithy/core/@smithy/util-utf8": ["@smithy/util-utf8@4.2.2", "", { "dependencies": { "@smithy/util-buffer-from": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw=="],
 
@@ -1435,8 +1463,6 @@
     "changelogen/yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
     "compress-commons/is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
-
-    "effect/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "fs-minipass/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,3 +1,31 @@
 [install]
 minimumReleaseAge = 259200
-minimumReleaseAgeExcludes = ["effect", "fast-check", "@effect/platform-bun", "@effect/platform-node", "@effect/vitest", "@effect/platform-node-shared"]
+minimumReleaseAgeExcludes = [
+  "effect",
+  "fast-check",
+  "@effect/platform-bun",
+  "@effect/platform-node",
+  "@effect/vitest",
+  "@effect/platform-node-shared",
+  "typescript",
+  "@typescript/typescript-win32-x64",
+  "@typescript/typescript-win32-arm64",
+  "@typescript/typescript-linux-x64",
+  "@typescript/typescript-linux-arm",
+  "@typescript/typescript-linux-arm64",
+  "@typescript/typescript-darwin-x64",
+  "@typescript/typescript-darwin-arm64",
+  "@typescript/typescript-aix-ppc64",
+  "@typescript/typescript-freebsd-arm64",
+  "@typescript/typescript-freebsd-x64",
+  "@typescript/typescript-linux-loong64",
+  "@typescript/typescript-linux-mips64el",
+  "@typescript/typescript-linux-ppc64",
+  "@typescript/typescript-linux-riscv64",
+  "@typescript/typescript-linux-s390x",
+  "@typescript/typescript-netbsd-arm64",
+  "@typescript/typescript-netbsd-x64",
+  "@typescript/typescript-openbsd-arm64",
+  "@typescript/typescript-openbsd-x64",
+  "@typescript/typescript-sunos-x64",
+]

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
       "@smithy/util-base64": "^4.3.0",
       "@types/bun": "^1.3.0",
       "@types/node": "^25.3.5",
-      "@typescript/native-preview": "7.0.0-dev.20260329.1",
       "archiver": "^7.0.1",
       "aws4fetch": "^1.0.20",
       "dedent": "^1.7.0",
@@ -52,6 +51,7 @@
       "oxfmt": "^0.36.0",
       "oxlint": "^1.51.0",
       "pathe": "^2.0.3",
+      "typescript": "^7.0.2",
       "vite": "^7.3.1",
       "vitest": "^3.2.3",
       "yaml": "^2.7.1"
@@ -68,12 +68,12 @@
     "@anthropic-ai/claude-agent-sdk": "^0.2.81",
     "@types/bun": "catalog:",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:",
     "aws4fetch": "^1.0.20",
     "changelogithub": "^14.0.0",
     "husky": "^9.1.7",
     "oxfmt": "catalog:",
     "oxlint": "catalog:",
+    "typescript": "catalog:",
     "yaml": "catalog:"
   }
 }

--- a/packages/aws/package.json
+++ b/packages/aws/package.json
@@ -70,11 +70,11 @@
     }
   },
   "scripts": {
-    "typecheck": "tsgo",
-    "build": "tsgo -b",
+    "typecheck": "tsc",
+    "build": "tsc -b",
     "fmt": "oxfmt --write src",
     "lint": "oxlint --fix src",
-    "check": "tsgo && oxlint src && oxfmt --check src",
+    "check": "tsc && oxlint src && oxfmt --check src",
     "test": "bunx vitest run test --exclude specs --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",

--- a/packages/axiom/package.json
+++ b/packages/axiom/package.json
@@ -67,11 +67,11 @@
     }
   },
   "scripts": {
-    "typecheck": "tsgo",
-    "build": "tsgo -b",
+    "typecheck": "tsc",
+    "build": "tsc -b",
     "fmt": "oxfmt --write src",
     "lint": "oxlint --fix src",
-    "check": "tsgo && oxlint src && oxfmt --check src",
+    "check": "tsc && oxlint src && oxfmt --check src",
     "test": "bunx vitest run test --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",

--- a/packages/azure/package.json
+++ b/packages/azure/package.json
@@ -62,11 +62,11 @@
     }
   },
   "scripts": {
-    "typecheck": "tsgo",
-    "build": "tsgo -b",
+    "typecheck": "tsc",
+    "build": "tsc -b",
     "fmt": "oxfmt --write src",
     "lint": "oxlint --fix src",
-    "check": "tsgo && oxlint src && oxfmt --check src",
+    "check": "tsc && oxlint src && oxfmt --check src",
     "test": "bunx vitest run test --exclude specs --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -51,12 +51,12 @@
     }
   },
   "scripts": {
-    "typecheck": "tsgo",
-    "build": "tsgo -b",
+    "typecheck": "tsc",
+    "build": "tsc -b",
     "download:env": "doppler secrets download --no-file --format env > .env",
     "fmt": "oxfmt --write src",
     "lint": "oxlint --fix src",
-    "check": "tsgo && oxlint src && oxfmt --check src",
+    "check": "tsc && oxlint src && oxfmt --check src",
     "test": "vitest run --exclude specs --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",
@@ -72,7 +72,7 @@
     "@types/bun": "catalog:",
     "@types/node": "catalog:",
     "dotenv": "catalog:",
-    "typescript": "^5.9.3",
+    "typescript-5": "npm:typescript@^5.9.3",
     "vitest": "catalog:"
   },
   "peerDependencies": {

--- a/packages/cloudflare/scripts/parse.ts
+++ b/packages/cloudflare/scripts/parse.ts
@@ -4,7 +4,9 @@ import * as path from "node:path";
 import { execSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { fileURLToPath } from "node:url";
-import * as ts from "typescript";
+// typescript@7 (native) ships no JS compiler API — parse.ts needs the TS 5 API,
+// aliased as typescript-5 so its tsc bin cannot shadow the workspace typescript@7.
+import * as ts from "typescript-5";
 import { parse as parseYaml } from "yaml";
 import {
   type ErrorMatcherInfo,

--- a/packages/coinbase/package.json
+++ b/packages/coinbase/package.json
@@ -62,11 +62,11 @@
     }
   },
   "scripts": {
-    "typecheck": "tsgo",
-    "build": "tsgo -b",
+    "typecheck": "tsc",
+    "build": "tsc -b",
     "fmt": "oxfmt --write src",
     "lint": "oxlint --fix src",
-    "check": "tsgo && oxlint src && oxfmt --check src",
+    "check": "tsc && oxlint src && oxfmt --check src",
     "test": "bunx vitest run test --exclude specs --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -79,11 +79,11 @@
     }
   },
   "scripts": {
-    "typecheck": "tsgo",
-    "build": "tsgo -b",
+    "typecheck": "tsc",
+    "build": "tsc -b",
     "fmt": "oxfmt --write src",
     "lint": "oxlint --fix src",
-    "check": "tsgo && oxlint src && oxfmt --check src",
+    "check": "tsc && oxlint src && oxfmt --check src",
     "test": "bunx vitest run test --exclude specs --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public"
   },

--- a/packages/expo-eas/package.json
+++ b/packages/expo-eas/package.json
@@ -62,11 +62,11 @@
     }
   },
   "scripts": {
-    "typecheck": "tsgo",
-    "build": "tsgo -b",
+    "typecheck": "tsc",
+    "build": "tsc -b",
     "fmt": "oxfmt --write src",
     "lint": "oxlint --fix src",
-    "check": "tsgo && oxlint src && oxfmt --check src",
+    "check": "tsc && oxlint src && oxfmt --check src",
     "test": "bunx vitest run test --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",

--- a/packages/fly-io/package.json
+++ b/packages/fly-io/package.json
@@ -62,11 +62,11 @@
     }
   },
   "scripts": {
-    "typecheck": "tsgo",
-    "build": "tsgo -b",
+    "typecheck": "tsc",
+    "build": "tsc -b",
     "fmt": "oxfmt --write src",
     "lint": "oxlint --fix src",
-    "check": "tsgo && oxlint src && oxfmt --check src",
+    "check": "tsc && oxlint src && oxfmt --check src",
     "nuke": "bun scripts/nuke.ts",
     "test": "bunx vitest run test --exclude specs --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",

--- a/packages/gcp/package.json
+++ b/packages/gcp/package.json
@@ -51,11 +51,11 @@
     }
   },
   "scripts": {
-    "typecheck": "tsgo",
-    "build": "tsgo -b",
+    "typecheck": "tsc",
+    "build": "tsc -b",
     "fmt": "oxfmt --write src",
     "lint": "oxlint --fix src",
-    "check": "tsgo && oxlint src && oxfmt --check src",
+    "check": "tsc && oxlint src && oxfmt --check src",
     "test": "bunx vitest run test --exclude specs --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",

--- a/packages/kubernetes/package.json
+++ b/packages/kubernetes/package.json
@@ -62,11 +62,11 @@
     }
   },
   "scripts": {
-    "typecheck": "tsgo",
-    "build": "tsgo -b",
+    "typecheck": "tsc",
+    "build": "tsc -b",
     "fmt": "oxfmt --write src",
     "lint": "oxlint --fix src",
-    "check": "tsgo && oxlint src && oxfmt --check src",
+    "check": "tsc && oxlint src && oxfmt --check src",
     "nuke": "bun scripts/nuke.ts",
     "test": "bunx vitest run test --exclude specs --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",

--- a/packages/mongodb-atlas/package.json
+++ b/packages/mongodb-atlas/package.json
@@ -62,11 +62,11 @@
     }
   },
   "scripts": {
-    "typecheck": "tsgo",
-    "build": "tsgo -b",
+    "typecheck": "tsc",
+    "build": "tsc -b",
     "fmt": "oxfmt --write src",
     "lint": "oxlint --fix src",
-    "check": "tsgo && oxlint src && oxfmt --check src",
+    "check": "tsc && oxlint src && oxfmt --check src",
     "nuke": "bun scripts/nuke.ts",
     "test": "bunx vitest run test --exclude specs --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",

--- a/packages/neon/package.json
+++ b/packages/neon/package.json
@@ -62,11 +62,11 @@
     }
   },
   "scripts": {
-    "typecheck": "tsgo",
-    "build": "tsgo -b",
+    "typecheck": "tsc",
+    "build": "tsc -b",
     "fmt": "oxfmt --write src",
     "lint": "oxlint --fix src",
-    "check": "tsgo && oxlint src && oxfmt --check src",
+    "check": "tsc && oxlint src && oxfmt --check src",
     "nuke": "bun scripts/nuke.ts",
     "test": "bunx vitest run test --exclude specs --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",

--- a/packages/planetscale/package.json
+++ b/packages/planetscale/package.json
@@ -62,11 +62,11 @@
     }
   },
   "scripts": {
-    "typecheck": "tsgo",
-    "build": "tsgo -b",
+    "typecheck": "tsc",
+    "build": "tsc -b",
     "fmt": "oxfmt --write src",
     "lint": "oxlint --fix src",
-    "check": "tsgo && oxlint src && oxfmt --check src",
+    "check": "tsc && oxlint src && oxfmt --check src",
     "test": "bunx vitest run test --exclude specs --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",

--- a/packages/posthog/package.json
+++ b/packages/posthog/package.json
@@ -62,11 +62,11 @@
     }
   },
   "scripts": {
-    "typecheck": "tsgo",
-    "build": "tsgo -b",
+    "typecheck": "tsc",
+    "build": "tsc -b",
     "fmt": "oxfmt --write src",
     "lint": "oxlint --fix src",
-    "check": "tsgo && oxlint src && oxfmt --check src",
+    "check": "tsc && oxlint src && oxfmt --check src",
     "test": "bunx vitest run test --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",

--- a/packages/prisma-postgres/package.json
+++ b/packages/prisma-postgres/package.json
@@ -62,11 +62,11 @@
     }
   },
   "scripts": {
-    "typecheck": "tsgo",
-    "build": "tsgo -b",
+    "typecheck": "tsc",
+    "build": "tsc -b",
     "fmt": "oxfmt --write src",
     "lint": "oxlint --fix src",
-    "check": "tsgo && oxlint src && oxfmt --check src",
+    "check": "tsc && oxlint src && oxfmt --check src",
     "nuke": "bun scripts/nuke.ts",
     "test": "bunx vitest run test --exclude specs --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -67,11 +67,11 @@
     }
   },
   "scripts": {
-    "typecheck": "tsgo",
-    "build": "tsgo -b",
+    "typecheck": "tsc",
+    "build": "tsc -b",
     "fmt": "oxfmt --write src",
     "lint": "oxlint --fix src",
-    "check": "tsgo && oxlint src && oxfmt --check src",
+    "check": "tsc && oxlint src && oxfmt --check src",
     "nuke": "bun scripts/nuke.ts",
     "test": "bunx vitest run test --exclude specs --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",

--- a/packages/supabase/package.json
+++ b/packages/supabase/package.json
@@ -62,11 +62,11 @@
     }
   },
   "scripts": {
-    "typecheck": "tsgo",
-    "build": "tsgo -b",
+    "typecheck": "tsc",
+    "build": "tsc -b",
     "fmt": "oxfmt --write src",
     "lint": "oxlint --fix src",
-    "check": "tsgo && oxlint src && oxfmt --check src",
+    "check": "tsc && oxlint src && oxfmt --check src",
     "nuke": "bun scripts/nuke.ts",
     "test": "bunx vitest run test --exclude specs --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",

--- a/packages/turso/package.json
+++ b/packages/turso/package.json
@@ -62,11 +62,11 @@
     }
   },
   "scripts": {
-    "typecheck": "tsgo",
-    "build": "tsgo -b",
+    "typecheck": "tsc",
+    "build": "tsc -b",
     "fmt": "oxfmt --write src",
     "lint": "oxlint --fix src",
-    "check": "tsgo && oxlint src && oxfmt --check src",
+    "check": "tsc && oxlint src && oxfmt --check src",
     "nuke": "bun scripts/nuke.ts",
     "test": "bunx vitest run test --exclude specs --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",

--- a/packages/typesense/package.json
+++ b/packages/typesense/package.json
@@ -62,11 +62,11 @@
     }
   },
   "scripts": {
-    "typecheck": "tsgo",
-    "build": "tsgo -b",
+    "typecheck": "tsc",
+    "build": "tsc -b",
     "fmt": "oxfmt --write src",
     "lint": "oxlint --fix src",
-    "check": "tsgo && oxlint src && oxfmt --check src",
+    "check": "tsc && oxlint src && oxfmt --check src",
     "test": "bunx vitest run test --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",

--- a/packages/workos/package.json
+++ b/packages/workos/package.json
@@ -62,11 +62,11 @@
     }
   },
   "scripts": {
-    "typecheck": "tsgo",
-    "build": "tsgo -b",
+    "typecheck": "tsc",
+    "build": "tsc -b",
     "fmt": "oxfmt --write src",
     "lint": "oxlint --fix src",
-    "check": "tsgo && oxlint src && oxfmt --check src",
+    "check": "tsc && oxlint src && oxfmt --check src",
     "test": "bunx vitest run test --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public",
     "generate": "bun run scripts/generate.ts && oxlint --fix src && oxfmt --write src && oxfmt --write src",

--- a/scripts/create-sdk.ts
+++ b/scripts/create-sdk.ts
@@ -490,13 +490,13 @@ bun run fetch-specs
           },
           workspaces: {
             catalog: {
-              "@typescript/native-preview": "latest",
+              typescript: "^7.0.2",
               oxfmt: "0.21.0",
               oxlint: "1.36.0",
             },
           },
           dependencies: {
-            "@typescript/native-preview": "catalog:",
+            typescript: "catalog:",
             yaml: "^2.6.0",
           },
           devDependencies: {
@@ -953,11 +953,11 @@ const scaffoldPackage = (
               },
             },
             scripts: {
-              typecheck: "tsgo",
-              build: "tsgo -b",
+              typecheck: "tsc",
+              build: "tsc -b",
               fmt: "oxfmt --write src",
               lint: "oxlint --fix src",
-              check: "tsgo && oxlint src && oxfmt --check src",
+              check: "tsc && oxlint src && oxfmt --check src",
               test: "bunx vitest run test --passWithNoTests",
               "publish:npm": "bun run build && bun publish --access public",
               generate:


### PR DESCRIPTION
TypeScript 7 is stable, so the `@typescript/native-preview` nightly and the `tsgo` binary it shipped are obsolete — the native compiler now ships as plain `tsc` in the `typescript` package.

```diff
 // package.json (catalog + devDependencies)
-"@typescript/native-preview": "7.0.0-dev.20260329.1"
+"typescript": "^7.0.2"

 // every packages/*/package.json
-"typecheck": "tsgo",
-"build": "tsgo -b",
-"check": "tsgo && oxlint src && oxfmt --check src",
+"typecheck": "tsc",
+"build": "tsc -b",
+"check": "tsc && oxlint src && oxfmt --check src",
```

- `create-sdk.ts` scaffolding and `AGENTS.md` updated to match
- `typescript` + its `@typescript/typescript-*` platform binaries added to `bunfig.toml` `minimumReleaseAgeExcludes` (7.0.2 is younger than the 72h gate)
- the cloudflare generator's `parse.ts` uses the TypeScript **JS compiler API**, which the native compiler no longer ships — its TS 5 dependency stays, aliased as `typescript-5` so its `tsc` bin can't shadow the workspace `typescript@7`

All packages typecheck clean with `tsc` 7.0.2 (`bun run typecheck`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
