### PR TITLE
fix(cloudflare/ai-gateway): type leaked UNIQUE constraint 500 as RouteAlreadyExists

### DIFF
--- a/packages/cloudflare/patches/ai-gateway/createDynamicRouting.json
+++ b/packages/cloudflare/patches/ai-gateway/createDynamicRouting.json
@@ -1,7 +1,11 @@
 {
   "errors": {
     "RouteAlreadyExists": [
-      { "code": 7005, "message": { "includes": "already exists" } }
+      { "code": 7005, "message": { "includes": "already exists" } },
+      {
+        "status": 500,
+        "message": { "includes": "UNIQUE constraint failed: routes.name" }
+      }
     ],
     "GatewayNotFound": [{ "code": 7002 }]
   },

--- a/packages/cloudflare/patches/ai-gateway/patchDynamicRouting.json
+++ b/packages/cloudflare/patches/ai-gateway/patchDynamicRouting.json
@@ -4,7 +4,11 @@
       { "code": 7005, "message": { "includes": "not found" } }
     ],
     "RouteAlreadyExists": [
-      { "code": 7005, "message": { "includes": "already exists" } }
+      { "code": 7005, "message": { "includes": "already exists" } },
+      {
+        "status": 500,
+        "message": { "includes": "UNIQUE constraint failed: routes.name" }
+      }
     ]
   },
   "response": {

--- a/packages/cloudflare/specs/cloudflare/ai-gateway.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/ai-gateway.openapi.yml
@@ -4959,6 +4959,9 @@ paths:
           - code: 7005
             message:
               includes: already exists
+          - status: 500
+            message:
+              includes: "UNIQUE constraint failed: routes.name"
     delete:
       operationId: deleteDynamicRouting
       description: "Delete an AI Gateway Dynamic Route.  @example ```ts const
@@ -6016,6 +6019,9 @@ paths:
           - code: 7005
             message:
               includes: already exists
+          - status: 500
+            message:
+              includes: "UNIQUE constraint failed: routes.name"
         GatewayNotFound:
           - code: 7002
   /accounts/{account_id}/ai-gateway/gateways/{gatewayId}/evaluations/{id}:

--- a/packages/cloudflare/src/services/ai-gateway.ts
+++ b/packages/cloudflare/src/services/ai-gateway.ts
@@ -109,7 +109,13 @@ export class RouteAlreadyExists extends T.applyErrorMatchers(
     code: Schema.Number,
     message: Schema.String,
   }),
-  [{ code: 7005, message: { includes: "already exists" } }],
+  [
+    { code: 7005, message: { includes: "already exists" } },
+    {
+      status: 500,
+      message: { includes: "UNIQUE constraint failed: routes.name" },
+    },
+  ],
 ) {}
 
 export class RouteNotFound extends T.applyErrorMatchers(


### PR DESCRIPTION
Cloudflare's AI Gateway dynamic routing endpoints leak the backing SQLite error as an untyped 500 instead of the typed code-7005 "already exists" error when a route name collides within a gateway:

```
InternalServerError: Error: UNIQUE constraint failed: routes.name, routes.gateway_id: SQLITE_CONSTRAINT (extended: SQLITE_CONSTRAINT_UNIQUE)
```

Hit in practice on `patchDynamicRouting` (rename): Cloudflare does not cascade-delete a gateway's routes when the gateway is deleted, so recreating a gateway with the same id resurrects its old route rows, and renaming onto one of those ghosts trips the constraint.

Match the leaked 500 onto the existing `RouteAlreadyExists` tag on `createDynamicRouting` and `patchDynamicRouting`:

```diff
 "RouteAlreadyExists": [
   { "code": 7005, "message": { "includes": "already exists" } },
+  {
+    "status": 500,
+    "message": { "includes": "UNIQUE constraint failed: routes.name" }
+  }
 ]
```
