### PR TITLE
feat(planetscale): add keyspace resize request operations

### DIFF
--- a/packages/planetscale/patches/keyspace-resize.patch.json
+++ b/packages/planetscale/patches/keyspace-resize.patch.json
@@ -1,0 +1,354 @@
+{
+  "description": "Add the (undocumented but stable) keyspace resize request endpoints used by planetscale-go and the pscale CLI: PUT/GET/DELETE /organizations/{organization}/databases/{database}/branches/{branch}/keyspaces/{keyspace}/resizes. This is the only API for changing a Vitess keyspace's replica count in place (createDatabase rejects `replicas` for mysql databases with 422 'Replicas param is not supported for mysql databases'). Field shapes were captured from live API responses (2026-07): PUT returns the created KeyspaceResizeRequest, GET returns the standard paginated envelope of them, DELETE cancels a queued resize. A PUT while a resize is finalizing is rejected 422 'Database branch keyspace has a resize in progress'; a no-op PUT is rejected 422 'Keyspace is already configured with the requested values'.",
+  "patches": [
+    {
+      "op": "add",
+      "path": "/definitions/KeyspaceResizeRequest",
+      "value": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The ID of the keyspace resize request"
+          },
+          "state": {
+            "type": "string",
+            "description": "The state of the keyspace resize request: pending, resizing, completed, or cancelled"
+          },
+          "started_at": {
+            "type": "string",
+            "description": "The time the resize started, or null when still queued",
+            "x-nullable": true
+          },
+          "completed_at": {
+            "type": "string",
+            "description": "The time the resize completed, or null while in progress",
+            "x-nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "description": "The time the resize request was created"
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "The time the resize request was last updated"
+          },
+          "replicas": {
+            "type": "integer",
+            "description": "The total number of replicas after the resize"
+          },
+          "extra_replicas": {
+            "type": "integer",
+            "description": "The number of additional replicas beyond the cluster size's included default after the resize"
+          },
+          "previous_replicas": {
+            "type": "integer",
+            "description": "The total number of replicas before the resize"
+          },
+          "cluster_name": {
+            "type": "string",
+            "description": "The SKU representing the keyspace's cluster after the resize"
+          },
+          "cluster_display_name": {
+            "type": "string",
+            "description": "The SKU representing the keyspace's cluster after the resize, for display"
+          },
+          "previous_cluster_name": {
+            "type": "string",
+            "description": "The SKU representing the keyspace's cluster before the resize"
+          },
+          "previous_cluster_display_name": {
+            "type": "string",
+            "description": "The SKU representing the keyspace's cluster before the resize, for display"
+          },
+          "rdonly_replicas": {
+            "type": "integer",
+            "description": "The number of read-only replicas after the resize",
+            "x-nullable": true
+          },
+          "previous_rdonly_replicas": {
+            "type": "integer",
+            "description": "The number of read-only replicas before the resize",
+            "x-nullable": true
+          },
+          "vector_pool_allocation": {
+            "type": "integer",
+            "description": "The vector pool allocation after the resize",
+            "x-nullable": true
+          },
+          "previous_vector_pool_allocation": {
+            "type": "integer",
+            "description": "The vector pool allocation before the resize",
+            "x-nullable": true
+          },
+          "actor": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "The ID of the actor"
+              },
+              "display_name": {
+                "type": "string",
+                "description": "The name of the actor"
+              },
+              "avatar_url": {
+                "type": "string",
+                "description": "The URL of the actor's avatar"
+              }
+            },
+            "required": ["id", "display_name", "avatar_url"]
+          }
+        },
+        "required": [
+          "id",
+          "state",
+          "started_at",
+          "completed_at",
+          "created_at",
+          "updated_at",
+          "replicas",
+          "extra_replicas",
+          "previous_replicas",
+          "cluster_name",
+          "previous_cluster_name"
+        ]
+      }
+    },
+    {
+      "op": "add",
+      "path": "/definitions/PaginatedKeyspaceResizeRequest",
+      "value": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "The response type. Always \"list\" for paginated responses."
+          },
+          "current_page": {
+            "type": "integer",
+            "description": "The current page number"
+          },
+          "next_page": {
+            "type": "integer",
+            "description": "The next page number, or null when this is the last page",
+            "x-nullable": true
+          },
+          "next_page_url": {
+            "type": "string",
+            "description": "The next page of results, or null when this is the last page",
+            "x-nullable": true
+          },
+          "prev_page": {
+            "type": "integer",
+            "description": "The previous page number, or null when this is the first page",
+            "x-nullable": true
+          },
+          "prev_page_url": {
+            "type": "string",
+            "description": "The previous page of results, or null when this is the first page",
+            "x-nullable": true
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/KeyspaceResizeRequest"
+            }
+          }
+        },
+        "required": [
+          "type",
+          "current_page",
+          "next_page",
+          "next_page_url",
+          "prev_page",
+          "prev_page_url",
+          "data"
+        ]
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1organizations~1{organization}~1databases~1{database}~1branches~1{branch}~1keyspaces~1{keyspace}~1resizes",
+      "value": {
+        "put": {
+          "tags": ["Database branch keyspaces"],
+          "consumes": ["application/json"],
+          "operationId": "create_keyspace_resize_request",
+          "summary": "Create a keyspace resize request",
+          "description": "Starts or queues an in-place resize of a branch keyspace's cluster size and/or replica count. Rejected with 422 while another resize is in progress or when the keyspace is already configured with the requested values.",
+          "parameters": [
+            {
+              "name": "organization",
+              "type": "string",
+              "in": "path",
+              "required": true,
+              "description": "The name of the organization the branch belongs to"
+            },
+            {
+              "name": "database",
+              "type": "string",
+              "in": "path",
+              "required": true,
+              "description": "The name of the database the branch belongs to"
+            },
+            {
+              "name": "branch",
+              "type": "string",
+              "in": "path",
+              "required": true,
+              "description": "The name of the branch"
+            },
+            {
+              "name": "keyspace",
+              "type": "string",
+              "in": "path",
+              "required": true,
+              "description": "The name of the keyspace"
+            },
+            {
+              "name": "body",
+              "in": "body",
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "cluster_size": {
+                    "type": "string",
+                    "description": "The new cluster size for the keyspace: PS_10, PS_20,…"
+                  },
+                  "extra_replicas": {
+                    "type": "integer",
+                    "description": "The number of additional replicas per shard beyond the cluster size's included default (each production cluster includes 2 replicas)"
+                  }
+                }
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Returns the created keyspace resize request",
+              "schema": {
+                "$ref": "#/definitions/KeyspaceResizeRequest"
+              },
+              "headers": {}
+            },
+            "401": { "description": "Unauthorized" },
+            "403": { "description": "Forbidden" },
+            "404": { "description": "Not Found" },
+            "422": { "description": "Unprocessable Entity" },
+            "500": { "description": "Internal Server Error" }
+          }
+        },
+        "get": {
+          "tags": ["Database branch keyspaces"],
+          "consumes": ["application/json"],
+          "operationId": "list_keyspace_resize_requests",
+          "summary": "List keyspace resize requests",
+          "description": "Lists resize requests for a branch keyspace, most recent first.",
+          "parameters": [
+            {
+              "name": "organization",
+              "type": "string",
+              "in": "path",
+              "required": true,
+              "description": "The name of the organization the branch belongs to"
+            },
+            {
+              "name": "database",
+              "type": "string",
+              "in": "path",
+              "required": true,
+              "description": "The name of the database the branch belongs to"
+            },
+            {
+              "name": "branch",
+              "type": "string",
+              "in": "path",
+              "required": true,
+              "description": "The name of the branch"
+            },
+            {
+              "name": "keyspace",
+              "type": "string",
+              "in": "path",
+              "required": true,
+              "description": "The name of the keyspace"
+            },
+            {
+              "name": "page",
+              "type": "integer",
+              "in": "query",
+              "required": false,
+              "description": "If provided, specifies the page offset of returned results"
+            },
+            {
+              "name": "per_page",
+              "type": "integer",
+              "in": "query",
+              "required": false,
+              "description": "If provided, specifies the number of returned results"
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Returns keyspace resize requests",
+              "schema": {
+                "$ref": "#/definitions/PaginatedKeyspaceResizeRequest"
+              },
+              "headers": {}
+            },
+            "401": { "description": "Unauthorized" },
+            "403": { "description": "Forbidden" },
+            "404": { "description": "Not Found" },
+            "500": { "description": "Internal Server Error" }
+          }
+        },
+        "delete": {
+          "tags": ["Database branch keyspaces"],
+          "consumes": ["application/json"],
+          "operationId": "cancel_keyspace_resize_request",
+          "summary": "Cancel a queued keyspace resize request",
+          "description": "Cancels a queued resize of a branch keyspace.",
+          "parameters": [
+            {
+              "name": "organization",
+              "type": "string",
+              "in": "path",
+              "required": true,
+              "description": "The name of the organization the branch belongs to"
+            },
+            {
+              "name": "database",
+              "type": "string",
+              "in": "path",
+              "required": true,
+              "description": "The name of the database the branch belongs to"
+            },
+            {
+              "name": "branch",
+              "type": "string",
+              "in": "path",
+              "required": true,
+              "description": "The name of the branch"
+            },
+            {
+              "name": "keyspace",
+              "type": "string",
+              "in": "path",
+              "required": true,
+              "description": "The name of the keyspace"
+            }
+          ],
+          "responses": {
+            "204": { "description": "No Content" },
+            "401": { "description": "Unauthorized" },
+            "403": { "description": "Forbidden" },
+            "404": { "description": "Not Found" },
+            "422": { "description": "Unprocessable Entity" },
+            "500": { "description": "Internal Server Error" }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/packages/planetscale/src/operations/cancelKeyspaceResizeRequest.ts
+++ b/packages/planetscale/src/operations/cancelKeyspaceResizeRequest.ts
@@ -1,0 +1,48 @@
+import * as Schema from "effect/Schema";
+import { API } from "../client.ts";
+import * as T from "../traits.ts";
+import { Forbidden, NotFound, UnprocessableEntity } from "../errors.ts";
+
+// Input Schema
+export interface CancelKeyspaceResizeRequestInput {
+  organization: string;
+  database: string;
+  branch: string;
+  keyspace: string;
+}
+export const CancelKeyspaceResizeRequestInput =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    organization: Schema.String.pipe(T.PathParam()),
+    database: Schema.String.pipe(T.PathParam()),
+    branch: Schema.String.pipe(T.PathParam()),
+    keyspace: Schema.String.pipe(T.PathParam()),
+  }).pipe(
+    T.Http({
+      method: "DELETE",
+      path: "/organizations/{organization}/databases/{database}/branches/{branch}/keyspaces/{keyspace}/resizes",
+    }),
+  ) as unknown as Schema.Codec<CancelKeyspaceResizeRequestInput>;
+
+// Output Schema
+export type CancelKeyspaceResizeRequestOutput = void;
+export const CancelKeyspaceResizeRequestOutput =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Void as unknown as Schema.Codec<CancelKeyspaceResizeRequestOutput>;
+
+// The operation
+/**
+ * Cancel a queued keyspace resize request
+ *
+ * Cancels a queued resize of a branch keyspace.
+ *
+ * @param organization - The name of the organization the branch belongs to
+ * @param database - The name of the database the branch belongs to
+ * @param branch - The name of the branch
+ * @param keyspace - The name of the keyspace
+ */
+export const cancelKeyspaceResizeRequest = /*@__PURE__*/ /*#__PURE__*/ API.make(
+  () => ({
+    inputSchema: CancelKeyspaceResizeRequestInput,
+    outputSchema: CancelKeyspaceResizeRequestOutput,
+    errors: [Forbidden, NotFound, UnprocessableEntity] as const,
+  }),
+);

--- a/packages/planetscale/src/operations/createKeyspaceResizeRequest.ts
+++ b/packages/planetscale/src/operations/createKeyspaceResizeRequest.ts
@@ -1,0 +1,100 @@
+import * as Schema from "effect/Schema";
+import { API } from "../client.ts";
+import * as T from "../traits.ts";
+import { Forbidden, NotFound, UnprocessableEntity } from "../errors.ts";
+
+// Input Schema
+export interface CreateKeyspaceResizeRequestInput {
+  organization: string;
+  database: string;
+  branch: string;
+  keyspace: string;
+  cluster_size?: string;
+  extra_replicas?: number;
+}
+export const CreateKeyspaceResizeRequestInput =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    organization: Schema.String.pipe(T.PathParam()),
+    database: Schema.String.pipe(T.PathParam()),
+    branch: Schema.String.pipe(T.PathParam()),
+    keyspace: Schema.String.pipe(T.PathParam()),
+    cluster_size: Schema.optional(Schema.String),
+    extra_replicas: Schema.optional(Schema.Number),
+  }).pipe(
+    T.Http({
+      method: "PUT",
+      path: "/organizations/{organization}/databases/{database}/branches/{branch}/keyspaces/{keyspace}/resizes",
+    }),
+  ) as unknown as Schema.Codec<CreateKeyspaceResizeRequestInput>;
+
+// Output Schema
+export interface CreateKeyspaceResizeRequestOutput {
+  id: string;
+  state: string;
+  started_at: string | null;
+  completed_at: string | null;
+  created_at: string;
+  updated_at: string;
+  replicas: number;
+  extra_replicas: number;
+  previous_replicas: number;
+  cluster_name: string;
+  cluster_display_name?: string;
+  previous_cluster_name: string;
+  previous_cluster_display_name?: string;
+  rdonly_replicas?: number | null;
+  previous_rdonly_replicas?: number | null;
+  vector_pool_allocation?: number | null;
+  previous_vector_pool_allocation?: number | null;
+  actor?: { id: string; display_name: string; avatar_url: string };
+}
+export const CreateKeyspaceResizeRequestOutput =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    id: Schema.String,
+    state: Schema.String,
+    started_at: Schema.NullOr(Schema.String),
+    completed_at: Schema.NullOr(Schema.String),
+    created_at: Schema.String,
+    updated_at: Schema.String,
+    replicas: Schema.Number,
+    extra_replicas: Schema.Number,
+    previous_replicas: Schema.Number,
+    cluster_name: Schema.String,
+    cluster_display_name: Schema.optional(Schema.String),
+    previous_cluster_name: Schema.String,
+    previous_cluster_display_name: Schema.optional(Schema.String),
+    rdonly_replicas: Schema.optional(Schema.NullOr(Schema.Number)),
+    previous_rdonly_replicas: Schema.optional(Schema.NullOr(Schema.Number)),
+    vector_pool_allocation: Schema.optional(Schema.NullOr(Schema.Number)),
+    previous_vector_pool_allocation: Schema.optional(
+      Schema.NullOr(Schema.Number),
+    ),
+    actor: Schema.optional(
+      Schema.Struct({
+        id: Schema.String,
+        display_name: Schema.String,
+        avatar_url: Schema.String,
+      }),
+    ),
+  }) as unknown as Schema.Codec<CreateKeyspaceResizeRequestOutput>;
+
+// The operation
+/**
+ * Create a keyspace resize request
+ *
+ * Starts or queues an in-place resize of a branch keyspace's cluster size and/or replica count. Rejected with 422 while another resize is in progress or when the keyspace is already configured with the requested values.
+ *
+ * @param organization - The name of the organization the branch belongs to
+ * @param database - The name of the database the branch belongs to
+ * @param branch - The name of the branch
+ * @param keyspace - The name of the keyspace
+ * @param cluster_size - The new cluster size for the keyspace: PS_10, PS_20,…
+ * @param extra_replicas - The number of additional replicas per shard beyond the cluster size's included default (each production cluster includes 2 replicas)
+ */
+export const createKeyspaceResizeRequest = /*@__PURE__*/ /*#__PURE__*/ API.make(
+  () => ({
+    inputSchema: CreateKeyspaceResizeRequestInput,
+    outputSchema: CreateKeyspaceResizeRequestOutput,
+    errors: [Forbidden, NotFound, UnprocessableEntity] as const,
+  }),
+);

--- a/packages/planetscale/src/operations/index.ts
+++ b/packages/planetscale/src/operations/index.ts
@@ -163,3 +163,6 @@ export * from "./getOrganizationTeamMember.ts";
 export * from "./removeOrganizationTeamMember.ts";
 export * from "./listPublicRegions.ts";
 export * from "./getCurrentUser.ts";
+export * from "./listKeyspaceResizeRequests.ts";
+export * from "./createKeyspaceResizeRequest.ts";
+export * from "./cancelKeyspaceResizeRequest.ts";

--- a/packages/planetscale/src/operations/listKeyspaceResizeRequests.ts
+++ b/packages/planetscale/src/operations/listKeyspaceResizeRequests.ts
@@ -1,0 +1,123 @@
+import * as Schema from "effect/Schema";
+import { API } from "../client.ts";
+import * as T from "../traits.ts";
+import { Forbidden, NotFound } from "../errors.ts";
+
+// Input Schema
+export interface ListKeyspaceResizeRequestsInput {
+  organization: string;
+  database: string;
+  branch: string;
+  keyspace: string;
+  page?: number;
+  per_page?: number;
+}
+export const ListKeyspaceResizeRequestsInput =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    organization: Schema.String.pipe(T.PathParam()),
+    database: Schema.String.pipe(T.PathParam()),
+    branch: Schema.String.pipe(T.PathParam()),
+    keyspace: Schema.String.pipe(T.PathParam()),
+    page: Schema.optional(Schema.Number),
+    per_page: Schema.optional(Schema.Number),
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/organizations/{organization}/databases/{database}/branches/{branch}/keyspaces/{keyspace}/resizes",
+    }),
+  ) as unknown as Schema.Codec<ListKeyspaceResizeRequestsInput>;
+
+// Output Schema
+export interface ListKeyspaceResizeRequestsOutput {
+  type: string;
+  current_page: number;
+  next_page: number | null;
+  next_page_url: string | null;
+  prev_page: number | null;
+  prev_page_url: string | null;
+  data: ReadonlyArray<{
+    id: string;
+    state: string;
+    started_at: string | null;
+    completed_at: string | null;
+    created_at: string;
+    updated_at: string;
+    replicas: number;
+    extra_replicas: number;
+    previous_replicas: number;
+    cluster_name: string;
+    cluster_display_name?: string;
+    previous_cluster_name: string;
+    previous_cluster_display_name?: string;
+    rdonly_replicas?: number | null;
+    previous_rdonly_replicas?: number | null;
+    vector_pool_allocation?: number | null;
+    previous_vector_pool_allocation?: number | null;
+    actor?: { id: string; display_name: string; avatar_url: string };
+  }>;
+}
+export const ListKeyspaceResizeRequestsOutput =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    type: Schema.String,
+    current_page: Schema.Number,
+    next_page: Schema.NullOr(Schema.Number),
+    next_page_url: Schema.NullOr(Schema.String),
+    prev_page: Schema.NullOr(Schema.Number),
+    prev_page_url: Schema.NullOr(Schema.String),
+    data: Schema.Array(
+      Schema.Struct({
+        id: Schema.String,
+        state: Schema.String,
+        started_at: Schema.NullOr(Schema.String),
+        completed_at: Schema.NullOr(Schema.String),
+        created_at: Schema.String,
+        updated_at: Schema.String,
+        replicas: Schema.Number,
+        extra_replicas: Schema.Number,
+        previous_replicas: Schema.Number,
+        cluster_name: Schema.String,
+        cluster_display_name: Schema.optional(Schema.String),
+        previous_cluster_name: Schema.String,
+        previous_cluster_display_name: Schema.optional(Schema.String),
+        rdonly_replicas: Schema.optional(Schema.NullOr(Schema.Number)),
+        previous_rdonly_replicas: Schema.optional(Schema.NullOr(Schema.Number)),
+        vector_pool_allocation: Schema.optional(Schema.NullOr(Schema.Number)),
+        previous_vector_pool_allocation: Schema.optional(
+          Schema.NullOr(Schema.Number),
+        ),
+        actor: Schema.optional(
+          Schema.Struct({
+            id: Schema.String,
+            display_name: Schema.String,
+            avatar_url: Schema.String,
+          }),
+        ),
+      }),
+    ),
+  }) as unknown as Schema.Codec<ListKeyspaceResizeRequestsOutput>;
+
+// The operation
+/**
+ * List keyspace resize requests
+ *
+ * Lists resize requests for a branch keyspace, most recent first.
+ *
+ * @param organization - The name of the organization the branch belongs to
+ * @param database - The name of the database the branch belongs to
+ * @param branch - The name of the branch
+ * @param keyspace - The name of the keyspace
+ * @param page - If provided, specifies the page offset of returned results
+ * @param per_page - If provided, specifies the number of returned results
+ */
+export const listKeyspaceResizeRequests =
+  /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
+    inputSchema: ListKeyspaceResizeRequestsInput,
+    outputSchema: ListKeyspaceResizeRequestsOutput,
+    errors: [Forbidden, NotFound] as const,
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }));


### PR DESCRIPTION
Add the (undocumented but stable) keyspace resize endpoints used by planetscale-go and the pscale CLI:

- `createKeyspaceResizeRequest` — `PUT .../keyspaces/{keyspace}/resizes` with `cluster_size` / `extra_replicas`
- `listKeyspaceResizeRequests` — `GET` (paginated), for polling resize state
- `cancelKeyspaceResizeRequest` — `DELETE`, cancels a queued resize

This is the only API for changing a Vitess keyspace's replica count in place — `createDatabase` rejects the `replicas` param for mysql databases (422 `Replicas param is not supported for mysql databases`). Response shapes were captured from live API calls; the spec patch documents the two 422 rejections observed live (resize already in progress, keyspace already configured with requested values).

Needed by alchemy-run/alchemy-effect#814 (reconcile MySQL replicas without replacing the database).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
