### PR TITLE
fix(aws/ec2): type duplicate security group rules

### DIFF
--- a/packages/aws/patches/ec2.json
+++ b/packages/aws/patches/ec2.json
@@ -345,6 +345,7 @@
         "RequestLimitExceeded",
         "InvalidGroup.NotFound",
         "InvalidGroupId.Malformed",
+        "InvalidPermission.Duplicate",
         "MissingParameter",
         "UnauthorizedOperation"
       ]
@@ -546,6 +547,7 @@
         "RequestLimitExceeded",
         "InvalidGroup.NotFound",
         "InvalidGroupId.Malformed",
+        "InvalidPermission.Duplicate",
         "MissingParameter",
         "UnauthorizedOperation"
       ]

--- a/packages/aws/src/services/ec2.ts
+++ b/packages/aws/src/services/ec2.ts
@@ -74098,6 +74098,10 @@ export class InvalidGroupNotFound extends S.TaggedErrorClass<InvalidGroupNotFoun
   "InvalidGroup.NotFound",
   {},
 ) {}
+export class InvalidPermissionDuplicate extends S.TaggedErrorClass<InvalidPermissionDuplicate>()(
+  "InvalidPermission.Duplicate",
+  {},
+).pipe(C.withAlreadyExistsError) {}
 export class InvalidBundleIDNotFound extends S.TaggedErrorClass<InvalidBundleIDNotFound>()(
   "InvalidBundleID.NotFound",
   {},
@@ -76098,6 +76102,7 @@ export type AuthorizeSecurityGroupEgressError =
   | RequestLimitExceeded
   | InvalidGroupNotFound
   | InvalidGroupIdMalformed
+  | InvalidPermissionDuplicate
   | MissingParameter
   | UnauthorizedOperation
   | CommonErrors;
@@ -76133,6 +76138,7 @@ export const authorizeSecurityGroupEgress: API.OperationMethod<
     RequestLimitExceeded,
     InvalidGroupNotFound,
     InvalidGroupIdMalformed,
+    InvalidPermissionDuplicate,
     MissingParameter,
     UnauthorizedOperation,
   ],
@@ -76142,6 +76148,7 @@ export type AuthorizeSecurityGroupIngressError =
   | RequestLimitExceeded
   | InvalidGroupNotFound
   | InvalidGroupIdMalformed
+  | InvalidPermissionDuplicate
   | MissingParameter
   | UnauthorizedOperation
   | CommonErrors;
@@ -76177,6 +76184,7 @@ export const authorizeSecurityGroupIngress: API.OperationMethod<
     RequestLimitExceeded,
     InvalidGroupNotFound,
     InvalidGroupIdMalformed,
+    InvalidPermissionDuplicate,
     MissingParameter,
     UnauthorizedOperation,
   ],


### PR DESCRIPTION

Adds AWS's documented `InvalidPermission.Duplicate` error to both EC2 security-group authorization operations.

Closes #382.

- Patches `authorizeSecurityGroupIngress` and `authorizeSecurityGroupEgress`
- Regenerates `InvalidPermissionDuplicate`, both typed error unions, and both runtime error lists
- Preserves the exact AWS wire tag and generator-inferred `AlreadyExistsError` category

### Evidence

AWS defines `InvalidPermission.Duplicate` when an inbound or outbound rule already exists: [EC2 error reference](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html#InvalidPermission.Duplicate). The behavior is also described by the [ingress](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AuthorizeSecurityGroupIngress.html) and [egress](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AuthorizeSecurityGroupEgress.html) API references. The [pinned official EC2 model](https://github.com/aws/api-models-aws/blob/15425c3323323bdac2289f630ffa1418b4455e60/models/ec2/service/2016-11-15/ec2-2016-11-15.json) does not associate modeled errors with these operations, so the Distilled correction layer supplies the live service behavior.

### Testing

- `bun run build` in `packages/core`
- `bun run check` in `packages/aws`
- `LOCAL=1 bunx vitest run --config ./vitest.config.ts ./test/protocols/ec2-query.test.ts` (33 passed)
- Runtime assertions for the exact tag, `AlreadyExistsError` category, and membership in both operation error lists
- TypeScript assertions that both operation error unions include `InvalidPermissionDuplicate`

### Generated Code

`packages/aws/src/services/ec2.ts` reflects the semantic output of the official AWS generator. A full generation run also exposed unrelated pre-existing regeneration drift across hundreds of generated services; that unrelated churn was excluded to keep this patch to the maintained EC2 input and its eight generated additions.

### Compatibility

This is additive. Existing requests and successful responses are unchanged. Duplicate-rule failures become a typed `InvalidPermissionDuplicate` error and gain the existing `AlreadyExistsError` category.
