### PR TITLE
fix(planetscale): make resize-request restart optional

### DIFF
--- a/packages/planetscale/patches/resize-request.patch.json
+++ b/packages/planetscale/patches/resize-request.patch.json
@@ -1,12 +1,11 @@
 {
-  "description": "Fix PostgresClusterResizeRequest and PaginatedPostgresClusterResizeRequest schema: completed_at can be null",
+  "description": "Fix PostgresClusterResizeRequest and PaginatedPostgresClusterResizeRequest schema: completed_at can be null, and restart is no longer returned (removed from PlanetScale's API and current spec)",
   "patches": [
     {
       "op": "replace",
       "path": "/definitions/PostgresClusterResizeRequest/required",
       "value": [
         "id",
-        "restart",
         "state",
         "started_at",
         "created_at",
@@ -48,7 +47,6 @@
       "path": "/definitions/PaginatedPostgresClusterResizeRequest/properties/data/items/required",
       "value": [
         "id",
-        "restart",
         "state",
         "started_at",
         "created_at",

--- a/packages/planetscale/src/operations/getBranchChangeRequest.ts
+++ b/packages/planetscale/src/operations/getBranchChangeRequest.ts
@@ -26,7 +26,7 @@ export const GetBranchChangeRequestInput =
 // Output Schema
 export interface GetBranchChangeRequestOutput {
   id: string;
-  restart: ReadonlyArray<number>;
+  restart?: ReadonlyArray<number>;
   state: "queued" | "pending" | "resizing" | "canceled" | "completed";
   started_at: string | null;
   completed_at?: string | null;
@@ -61,7 +61,7 @@ export interface GetBranchChangeRequestOutput {
 export const GetBranchChangeRequestOutput =
   /*@__PURE__*/ Schema.Struct({
     id: Schema.String,
-    restart: Schema.Array(Schema.Number),
+    restart: Schema.optional(Schema.Array(Schema.Number)),
     state: Schema.Literals([
       "queued",
       "pending",

--- a/packages/planetscale/src/operations/listBranchChangeRequests.ts
+++ b/packages/planetscale/src/operations/listBranchChangeRequests.ts
@@ -35,7 +35,7 @@ export interface ListBranchChangeRequestsOutput {
   prev_page_url: string | null;
   data: ReadonlyArray<{
     id: string;
-    restart: ReadonlyArray<number>;
+    restart?: ReadonlyArray<number>;
     state: "queued" | "pending" | "resizing" | "canceled" | "completed";
     started_at: string | null;
     completed_at?: string | null;
@@ -79,7 +79,7 @@ export const ListBranchChangeRequestsOutput =
     data: Schema.Array(
       Schema.Struct({
         id: Schema.String,
-        restart: Schema.Array(Schema.Number),
+        restart: Schema.optional(Schema.Array(Schema.Number)),
         state: Schema.Literals([
           "queued",
           "pending",

--- a/packages/planetscale/src/operations/updateBranchChangeRequest.ts
+++ b/packages/planetscale/src/operations/updateBranchChangeRequest.ts
@@ -46,7 +46,7 @@ export const UpdateBranchChangeRequestInput =
 // Output Schema
 export interface UpdateBranchChangeRequestOutput {
   id: string;
-  restart: ReadonlyArray<number>;
+  restart?: ReadonlyArray<number>;
   state: "queued" | "pending" | "resizing" | "canceled" | "completed";
   started_at: string | null;
   completed_at?: string | null;
@@ -81,7 +81,7 @@ export interface UpdateBranchChangeRequestOutput {
 export const UpdateBranchChangeRequestOutput =
   /*@__PURE__*/ Schema.Struct({
     id: Schema.String,
-    restart: Schema.Array(Schema.Number),
+    restart: Schema.optional(Schema.Array(Schema.Number)),
     state: Schema.Literals([
       "queued",
       "pending",


### PR DESCRIPTION
Fixes #384.

PlanetScale removed the `restart` field ("ports requiring a restart") from the branch change-request payload — it is gone from the current published spec (`distilled-spec-planetscale` `main` no longer has it on `PostgresClusterResizeRequest`), and the live API stopped returning it. The generated client still requires it, so every `getBranchChangeRequest` / `listBranchChangeRequests` / `updateBranchChangeRequest` call fails at decode with `SchemaError: Missing key ["restart"]` — the server-side change succeeds, leaving callers (e.g. alchemy's `Planetscale.PostgresBranch` replica reconciliation) half-applied.

Changes:
- `patches/resize-request.patch.json`: drop `restart` from both `required` lists (the patch previously re-asserted it while making `completed_at` nullable). Optional rather than removed, so the client tolerates both old and new API behavior.
- The three generated operations: `restart` → optional (`restart?: ReadonlyArray<number>` / `Schema.optional(Schema.Array(Schema.Number))`), matching the existing optional-field idiom.

Note: the generated files are hand-adjusted to the minimal semantic change rather than fully regenerated — running `bun run generate` today produces ~150 files of unrelated drift (formatting + `SensitiveOutputNullableString` → `SensitiveOutputString` changes), which I did not want to fold into this fix. `bun run check` (tsc + oxlint + oxfmt) passes; the test suite requires live PlanetScale credentials I did not run against.

Verified against the live API: a `PATCH .../branches/{branch}/changes` response today carries no `restart` key, and the patched schema decodes it.
