### PR TITLE
fix(aws/emr-containers): type TooManyRequestsException as retryable throttling

### DIFF
--- a/packages/aws/patches/emr-containers.json
+++ b/packages/aws/patches/emr-containers.json
@@ -1,6 +1,33 @@
 {
+  "errorCategories": {
+    "TooManyRequestsException": ["ThrottlingError", "RetryableError"]
+  },
   "operations": {
+    "cancelJobRun": { "errors": ["TooManyRequestsException"] },
+    "createJobTemplate": { "errors": ["TooManyRequestsException"] },
+    "createManagedEndpoint": { "errors": ["TooManyRequestsException"] },
+    "createSecurityConfiguration": { "errors": ["TooManyRequestsException"] },
+    "createVirtualCluster": { "errors": ["TooManyRequestsException"] },
+    "deleteJobTemplate": { "errors": ["TooManyRequestsException"] },
+    "deleteManagedEndpoint": { "errors": ["TooManyRequestsException"] },
+    "deleteVirtualCluster": { "errors": ["TooManyRequestsException"] },
+    "describeJobRun": { "errors": ["TooManyRequestsException"] },
+    "describeJobTemplate": { "errors": ["TooManyRequestsException"] },
+    "describeManagedEndpoint": { "errors": ["TooManyRequestsException"] },
+    "describeSecurityConfiguration": { "errors": ["TooManyRequestsException"] },
+    "describeVirtualCluster": { "errors": ["TooManyRequestsException"] },
+    "getManagedEndpointSessionCredentials": {
+      "errors": ["TooManyRequestsException"]
+    },
+    "listJobRuns": { "errors": ["TooManyRequestsException"] },
+    "listJobTemplates": { "errors": ["TooManyRequestsException"] },
+    "listManagedEndpoints": { "errors": ["TooManyRequestsException"] },
+    "listSecurityConfigurations": { "errors": ["TooManyRequestsException"] },
+    "listTagsForResource": { "errors": ["TooManyRequestsException"] },
+    "listVirtualClusters": { "errors": ["TooManyRequestsException"] },
+    "startJobRun": { "errors": ["TooManyRequestsException"] },
     "tagResource": {
+      "errors": ["TooManyRequestsException"],
       "syntheticErrors": [
         {
           "name": "InvalidResourceArn",
@@ -12,6 +39,7 @@
       ]
     },
     "untagResource": {
+      "errors": ["TooManyRequestsException"],
       "syntheticErrors": [
         {
           "name": "InvalidResourceArn",

--- a/packages/aws/src/services/emr-containers.ts
+++ b/packages/aws/src/services/emr-containers.ts
@@ -1626,6 +1626,10 @@ export class ValidationException extends S.TaggedErrorClass<ValidationException>
   { message: S.optional(S.String) },
   T.HttpError(400),
 ).pipe(C.withBadRequestError) {}
+export class TooManyRequestsException extends S.TaggedErrorClass<TooManyRequestsException>()(
+  "TooManyRequestsException",
+  {},
+).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class ResourceNotFoundException extends S.TaggedErrorClass<ResourceNotFoundException>()(
   "ResourceNotFoundException",
   { message: S.optional(S.String) },
@@ -1654,6 +1658,7 @@ export class InvalidResourceArn extends S.TaggedErrorClass<InvalidResourceArn>()
 export type CancelJobRunError =
   | InternalServerException
   | ValidationException
+  | TooManyRequestsException
   | CommonErrors;
 /**
  * Cancels a job run. A job run is a unit of work, such as a Spark jar, PySpark script, or
@@ -1667,13 +1672,18 @@ export const cancelJobRun: API.OperationMethod<
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelJobRunRequest,
   output: CancelJobRunResponse,
-  errors: [InternalServerException, ValidationException],
+  errors: [
+    InternalServerException,
+    ValidationException,
+    TooManyRequestsException,
+  ],
   operationName: "CancelJobRun",
 }));
 export type CreateJobTemplateError =
   | InternalServerException
   | ResourceNotFoundException
   | ValidationException
+  | TooManyRequestsException
   | CommonErrors;
 /**
  * Creates a job template. Job template stores values of StartJobRun API request in a
@@ -1693,6 +1703,7 @@ export const createJobTemplate: API.OperationMethod<
     InternalServerException,
     ResourceNotFoundException,
     ValidationException,
+    TooManyRequestsException,
   ],
   operationName: "CreateJobTemplate",
 }));
@@ -1700,6 +1711,7 @@ export type CreateManagedEndpointError =
   | InternalServerException
   | ResourceNotFoundException
   | ValidationException
+  | TooManyRequestsException
   | CommonErrors;
 /**
  * Creates a managed endpoint. A managed endpoint is a gateway that connects Amazon EMR Studio to Amazon EMR on EKS so that Amazon EMR Studio can
@@ -1717,12 +1729,14 @@ export const createManagedEndpoint: API.OperationMethod<
     InternalServerException,
     ResourceNotFoundException,
     ValidationException,
+    TooManyRequestsException,
   ],
   operationName: "CreateManagedEndpoint",
 }));
 export type CreateSecurityConfigurationError =
   | InternalServerException
   | ValidationException
+  | TooManyRequestsException
   | CommonErrors;
 /**
  * Creates a security configuration. Security configurations in Amazon EMR on EKS are
@@ -1738,7 +1752,11 @@ export const createSecurityConfiguration: API.OperationMethod<
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSecurityConfigurationRequest,
   output: CreateSecurityConfigurationResponse,
-  errors: [InternalServerException, ValidationException],
+  errors: [
+    InternalServerException,
+    ValidationException,
+    TooManyRequestsException,
+  ],
   operationName: "CreateSecurityConfiguration",
 }));
 export type CreateVirtualClusterError =
@@ -1746,6 +1764,7 @@ export type CreateVirtualClusterError =
   | InternalServerException
   | ResourceNotFoundException
   | ValidationException
+  | TooManyRequestsException
   | CommonErrors;
 /**
  * Creates a virtual cluster. Virtual cluster is a managed entity on Amazon EMR on EKS. You can create, describe, list and delete virtual clusters. They do not consume any
@@ -1766,12 +1785,14 @@ export const createVirtualCluster: API.OperationMethod<
     InternalServerException,
     ResourceNotFoundException,
     ValidationException,
+    TooManyRequestsException,
   ],
   operationName: "CreateVirtualCluster",
 }));
 export type DeleteJobTemplateError =
   | InternalServerException
   | ValidationException
+  | TooManyRequestsException
   | CommonErrors;
 /**
  * Deletes a job template. Job template stores values of StartJobRun API request in a
@@ -1787,12 +1808,17 @@ export const deleteJobTemplate: API.OperationMethod<
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteJobTemplateRequest,
   output: DeleteJobTemplateResponse,
-  errors: [InternalServerException, ValidationException],
+  errors: [
+    InternalServerException,
+    ValidationException,
+    TooManyRequestsException,
+  ],
   operationName: "DeleteJobTemplate",
 }));
 export type DeleteManagedEndpointError =
   | InternalServerException
   | ValidationException
+  | TooManyRequestsException
   | CommonErrors;
 /**
  * Deletes a managed endpoint. A managed endpoint is a gateway that connects Amazon EMR Studio to Amazon EMR on EKS so that Amazon EMR Studio can
@@ -1806,12 +1832,17 @@ export const deleteManagedEndpoint: API.OperationMethod<
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteManagedEndpointRequest,
   output: DeleteManagedEndpointResponse,
-  errors: [InternalServerException, ValidationException],
+  errors: [
+    InternalServerException,
+    ValidationException,
+    TooManyRequestsException,
+  ],
   operationName: "DeleteManagedEndpoint",
 }));
 export type DeleteVirtualClusterError =
   | InternalServerException
   | ValidationException
+  | TooManyRequestsException
   | CommonErrors;
 /**
  * Deletes a virtual cluster. Virtual cluster is a managed entity on Amazon EMR on EKS. You can create, describe, list and delete virtual clusters. They do not consume any
@@ -1827,13 +1858,18 @@ export const deleteVirtualCluster: API.OperationMethod<
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVirtualClusterRequest,
   output: DeleteVirtualClusterResponse,
-  errors: [InternalServerException, ValidationException],
+  errors: [
+    InternalServerException,
+    ValidationException,
+    TooManyRequestsException,
+  ],
   operationName: "DeleteVirtualCluster",
 }));
 export type DescribeJobRunError =
   | InternalServerException
   | ResourceNotFoundException
   | ValidationException
+  | TooManyRequestsException
   | CommonErrors;
 /**
  * Displays detailed information about a job run. A job run is a unit of work, such as a
@@ -1851,6 +1887,7 @@ export const describeJobRun: API.OperationMethod<
     InternalServerException,
     ResourceNotFoundException,
     ValidationException,
+    TooManyRequestsException,
   ],
   operationName: "DescribeJobRun",
 }));
@@ -1858,6 +1895,7 @@ export type DescribeJobTemplateError =
   | InternalServerException
   | ResourceNotFoundException
   | ValidationException
+  | TooManyRequestsException
   | CommonErrors;
 /**
  * Displays detailed information about a specified job template. Job template stores values
@@ -1877,6 +1915,7 @@ export const describeJobTemplate: API.OperationMethod<
     InternalServerException,
     ResourceNotFoundException,
     ValidationException,
+    TooManyRequestsException,
   ],
   operationName: "DescribeJobTemplate",
 }));
@@ -1884,6 +1923,7 @@ export type DescribeManagedEndpointError =
   | InternalServerException
   | ResourceNotFoundException
   | ValidationException
+  | TooManyRequestsException
   | CommonErrors;
 /**
  * Displays detailed information about a managed endpoint. A managed endpoint is a gateway
@@ -1901,6 +1941,7 @@ export const describeManagedEndpoint: API.OperationMethod<
     InternalServerException,
     ResourceNotFoundException,
     ValidationException,
+    TooManyRequestsException,
   ],
   operationName: "DescribeManagedEndpoint",
 }));
@@ -1908,6 +1949,7 @@ export type DescribeSecurityConfigurationError =
   | InternalServerException
   | ResourceNotFoundException
   | ValidationException
+  | TooManyRequestsException
   | CommonErrors;
 /**
  * Displays detailed information about a specified security configuration. Security
@@ -1928,6 +1970,7 @@ export const describeSecurityConfiguration: API.OperationMethod<
     InternalServerException,
     ResourceNotFoundException,
     ValidationException,
+    TooManyRequestsException,
   ],
   operationName: "DescribeSecurityConfiguration",
 }));
@@ -1935,6 +1978,7 @@ export type DescribeVirtualClusterError =
   | InternalServerException
   | ResourceNotFoundException
   | ValidationException
+  | TooManyRequestsException
   | CommonErrors;
 /**
  * Displays detailed information about a specified virtual cluster. Virtual cluster is a
@@ -1956,6 +2000,7 @@ export const describeVirtualCluster: API.OperationMethod<
     InternalServerException,
     ResourceNotFoundException,
     ValidationException,
+    TooManyRequestsException,
   ],
   operationName: "DescribeVirtualCluster",
 }));
@@ -1964,6 +2009,7 @@ export type GetManagedEndpointSessionCredentialsError =
   | RequestThrottledException
   | ResourceNotFoundException
   | ValidationException
+  | TooManyRequestsException
   | CommonErrors;
 /**
  * Generate a session token to connect to a managed endpoint.
@@ -1981,12 +2027,14 @@ export const getManagedEndpointSessionCredentials: API.OperationMethod<
     RequestThrottledException,
     ResourceNotFoundException,
     ValidationException,
+    TooManyRequestsException,
   ],
   operationName: "GetManagedEndpointSessionCredentials",
 }));
 export type ListJobRunsError =
   | InternalServerException
   | ValidationException
+  | TooManyRequestsException
   | CommonErrors;
 /**
  * Lists job runs based on a set of parameters. A job run is a unit of work, such as a
@@ -2015,7 +2063,11 @@ export const listJobRuns: API.OperationMethod<
 } = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListJobRunsRequest,
   output: ListJobRunsResponse,
-  errors: [InternalServerException, ValidationException],
+  errors: [
+    InternalServerException,
+    ValidationException,
+    TooManyRequestsException,
+  ],
   operationName: "ListJobRuns",
   pagination: {
     inputToken: "nextToken",
@@ -2027,6 +2079,7 @@ export const listJobRuns: API.OperationMethod<
 export type ListJobTemplatesError =
   | InternalServerException
   | ValidationException
+  | TooManyRequestsException
   | CommonErrors;
 /**
  * Lists job templates based on a set of parameters. Job template stores values of
@@ -2057,7 +2110,11 @@ export const listJobTemplates: API.OperationMethod<
 } = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListJobTemplatesRequest,
   output: ListJobTemplatesResponse,
-  errors: [InternalServerException, ValidationException],
+  errors: [
+    InternalServerException,
+    ValidationException,
+    TooManyRequestsException,
+  ],
   operationName: "ListJobTemplates",
   pagination: {
     inputToken: "nextToken",
@@ -2069,6 +2126,7 @@ export const listJobTemplates: API.OperationMethod<
 export type ListManagedEndpointsError =
   | InternalServerException
   | ValidationException
+  | TooManyRequestsException
   | CommonErrors;
 /**
  * Lists managed endpoints based on a set of parameters. A managed endpoint is a gateway
@@ -2097,7 +2155,11 @@ export const listManagedEndpoints: API.OperationMethod<
 } = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListManagedEndpointsRequest,
   output: ListManagedEndpointsResponse,
-  errors: [InternalServerException, ValidationException],
+  errors: [
+    InternalServerException,
+    ValidationException,
+    TooManyRequestsException,
+  ],
   operationName: "ListManagedEndpoints",
   pagination: {
     inputToken: "nextToken",
@@ -2109,6 +2171,7 @@ export const listManagedEndpoints: API.OperationMethod<
 export type ListSecurityConfigurationsError =
   | InternalServerException
   | ValidationException
+  | TooManyRequestsException
   | CommonErrors;
 /**
  * Lists security configurations based on a set of parameters. Security configurations in
@@ -2140,7 +2203,11 @@ export const listSecurityConfigurations: API.OperationMethod<
 } = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSecurityConfigurationsRequest,
   output: ListSecurityConfigurationsResponse,
-  errors: [InternalServerException, ValidationException],
+  errors: [
+    InternalServerException,
+    ValidationException,
+    TooManyRequestsException,
+  ],
   operationName: "ListSecurityConfigurations",
   pagination: {
     inputToken: "nextToken",
@@ -2153,6 +2220,7 @@ export type ListTagsForResourceError =
   | InternalServerException
   | ResourceNotFoundException
   | ValidationException
+  | TooManyRequestsException
   | CommonErrors;
 /**
  * Lists the tags assigned to the resources.
@@ -2169,12 +2237,14 @@ export const listTagsForResource: API.OperationMethod<
     InternalServerException,
     ResourceNotFoundException,
     ValidationException,
+    TooManyRequestsException,
   ],
   operationName: "ListTagsForResource",
 }));
 export type ListVirtualClustersError =
   | InternalServerException
   | ValidationException
+  | TooManyRequestsException
   | CommonErrors;
 /**
  * Lists information about the specified virtual cluster. Virtual cluster is a managed
@@ -2207,7 +2277,11 @@ export const listVirtualClusters: API.OperationMethod<
 } = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListVirtualClustersRequest,
   output: ListVirtualClustersResponse,
-  errors: [InternalServerException, ValidationException],
+  errors: [
+    InternalServerException,
+    ValidationException,
+    TooManyRequestsException,
+  ],
   operationName: "ListVirtualClusters",
   pagination: {
     inputToken: "nextToken",
@@ -2220,6 +2294,7 @@ export type StartJobRunError =
   | InternalServerException
   | ResourceNotFoundException
   | ValidationException
+  | TooManyRequestsException
   | CommonErrors;
 /**
  * Starts a job run. A job run is a unit of work, such as a Spark jar, PySpark script, or
@@ -2237,6 +2312,7 @@ export const startJobRun: API.OperationMethod<
     InternalServerException,
     ResourceNotFoundException,
     ValidationException,
+    TooManyRequestsException,
   ],
   operationName: "StartJobRun",
 }));
@@ -2244,6 +2320,7 @@ export type TagResourceError =
   | InternalServerException
   | ResourceNotFoundException
   | ValidationException
+  | TooManyRequestsException
   | InvalidResourceArn
   | CommonErrors;
 /**
@@ -2269,6 +2346,7 @@ export const tagResource: API.OperationMethod<
     InternalServerException,
     ResourceNotFoundException,
     ValidationException,
+    TooManyRequestsException,
     InvalidResourceArn,
   ],
   operationName: "TagResource",
@@ -2277,6 +2355,7 @@ export type UntagResourceError =
   | InternalServerException
   | ResourceNotFoundException
   | ValidationException
+  | TooManyRequestsException
   | InvalidResourceArn
   | CommonErrors;
 /**
@@ -2294,6 +2373,7 @@ export const untagResource: API.OperationMethod<
     InternalServerException,
     ResourceNotFoundException,
     ValidationException,
+    TooManyRequestsException,
     InvalidResourceArn,
   ],
   operationName: "UntagResource",


### PR DESCRIPTION
EMR Containers returns HTTP 429 `TooManyRequestsException` on effectively every operation under concurrent load, but the error was missing from the typed unions — it surfaced as `UnknownAwsError`, which the retry classifier treats as non-retryable, so alchemy's EMRContainers tests failed hard on throttles instead of backing off.

```json
"errorCategories": {
  "TooManyRequestsException": ["ThrottlingError", "RetryableError"]
}
```

- Add `TooManyRequestsException` to every emr-containers operation's error list
- Categorize it as `ThrottlingError` + `RetryableError` so the generated retry metadata backs off automatically

Found via alchemy's `test/AWS/EMRContainers/JobTemplate.test.ts` under a saturated full-suite run; the suite is green with this patch.
