### PR TITLE
fix(aws/amplify): Step.endTime is optional for in-progress job steps

### DIFF
--- a/packages/aws/patches/amplify.json
+++ b/packages/aws/patches/amplify.json
@@ -63,6 +63,11 @@
         "jobType": { "optional": true }
       }
     },
+    "Step": {
+      "members": {
+        "endTime": { "optional": true }
+      }
+    },
     "CreateDeploymentResult": {
       "members": {
         "fileUploadUrls": { "optional": true }

--- a/packages/aws/src/services/amplify.ts
+++ b/packages/aws/src/services/amplify.ts
@@ -1332,7 +1332,7 @@ export interface Step {
   stepName: string;
   startTime: Date;
   status: JobStatus;
-  endTime: Date;
+  endTime?: Date;
   logUrl?: string;
   artifactsUrl?: string;
   testArtifactsUrl?: string;
@@ -1346,7 +1346,7 @@ export const Step = /*@__PURE__*/ S.suspend(() =>
     stepName: S.String,
     startTime: S.Date.pipe(T.TimestampFormat("epoch-seconds")),
     status: JobStatus,
-    endTime: S.Date.pipe(T.TimestampFormat("epoch-seconds")),
+    endTime: S.optional(S.Date.pipe(T.TimestampFormat("epoch-seconds"))),
     logUrl: S.optional(S.String),
     artifactsUrl: S.optional(S.String),
     testArtifactsUrl: S.optional(S.String),


### PR DESCRIPTION
`GetJob` on a job that is still PENDING/RUNNING returns steps without `endTime`, but the schema declared it required, so response decoding failed:

```
SchemaError(Missing key at ["job"]["steps"][0]["endTime"])
```

Mark `Step.endTime` optional via the amplify patch and regenerate.

Found by alchemy's `test/AWS/Amplify/Bindings.test.ts` (manual deployment lifecycle polls `GetJob` while the deployment is in flight); that suite is green with this patch.
