### PR TITLE
Fix/worker targeted placement response

### DIFF
--- a/packages/cloudflare/patches/workers/putScript.json
+++ b/packages/cloudflare/patches/workers/putScript.json
@@ -198,6 +198,20 @@
   },
   "response": {
     "properties": {
+      "placement": {
+        "appendUnion": [
+          {
+            "kind": "object",
+            "properties": [
+              {
+                "name": "mode",
+                "required": true,
+                "type": { "kind": "literal", "value": "targeted" }
+              }
+            ]
+          }
+        ]
+      },
       "observability.traces": {
         "optional": true,
         "definition": {

--- a/packages/cloudflare/specs/cloudflare/workers.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/workers.openapi.yml
@@ -12708,6 +12708,14 @@ paths:
                         required:
                           - mode
                           - target
+                      - type: object
+                        properties:
+                          mode:
+                            type: string
+                            enum:
+                              - targeted
+                        required:
+                          - mode
                     description: Configuration for [Smart
                       Placement](https://developers.cloudflare.com/workers/configuration/smart-placement).
                       Specify mode='smart' for Smart Placement, or one of

--- a/packages/cloudflare/src/services/workers.ts
+++ b/packages/cloudflare/src/services/workers.ts
@@ -6979,6 +6979,15 @@ const Metadata2 = /*@__PURE__*/ Schema.suspend(() =>
   ),
 ) as unknown as Schema.Codec<Metadata2>;
 
+interface PutScriptResponsePlacement8 {
+  mode: "targeted";
+}
+const PutScriptResponsePlacement8 = /*@__PURE__*/ Schema.suspend(() =>
+  Schema.Struct({
+    mode: Schema.Literal("targeted"),
+  }),
+) as unknown as Schema.Codec<PutScriptResponsePlacement8>;
+
 interface ScriptSearchResponseItem {
   /** Identifier. */
   id: string;
@@ -15060,6 +15069,7 @@ export interface PutScriptResponse {
           | (string & {})
           | null;
       }
+    | { mode: "targeted" }
     | null;
   /** @deprecated */
   placementMode?: "smart" | "targeted" | (string & {}) | null;
@@ -15125,6 +15135,7 @@ export const PutScriptResponse = /*@__PURE__*/ Schema.suspend(() =>
           ListScriptsResponseResultPlacement1,
           ListScriptsResponseResultPlacement2,
           ListScriptsResponseResultPlacement3,
+          PutScriptResponsePlacement8,
         ]),
         Schema.Null,
       ]),

--- a/packages/cloudflare/test/workers.test.ts
+++ b/packages/cloudflare/test/workers.test.ts
@@ -831,7 +831,7 @@ describe("Workers", () => {
   });
 
   describe("putScript", () => {
-    it("decodes targeted placement responses without the requested target", () => {
+    it("happy path - decodes a targeted placement response without a target", () => {
       expect(
         Schema.decodeUnknownSync(Workers.PutScriptResponse)({
           startup_time_ms: 0,

--- a/packages/cloudflare/test/workers.test.ts
+++ b/packages/cloudflare/test/workers.test.ts
@@ -831,6 +831,18 @@ describe("Workers", () => {
   });
 
   describe("putScript", () => {
+    it("decodes targeted placement responses without the requested target", () => {
+      expect(
+        Schema.decodeUnknownSync(Workers.PutScriptResponse)({
+          startup_time_ms: 0,
+          placement: { mode: "targeted" },
+        }),
+      ).toEqual({
+        startupTimeMs: 0,
+        placement: { mode: "targeted" },
+      });
+    });
+
     test("happy path - uploads a worker script", () =>
       Effect.gen(function* () {
         const name = scriptName("put-script-happy");


### PR DESCRIPTION
 Cloudflare's OpenAPI spec only documents two placement shapes: `{ mode: "smart" }` and `{ mode: "targeted", target: ... }`. In practice the API also seems to return `{ "mode": "targeted" }` with no target, observed on putScript when a worker has targeted placement configured.

The generated schema rejected this shape, so a successful upload (HTTP 200, success: true) surfaced as a decode error. The script was deployed on Cloudflare's side, but the client reports failure for any worker with targeted placement.

Verified end to end by deploying a worker with targeted placement through a real Cloudflare account.