### PR TITLE
feat(cloudflare/workers): streaming_tail_consumers on script-upload metadata

### DIFF
--- a/packages/cloudflare/patches/workers/putScript.manual.json
+++ b/packages/cloudflare/patches/workers/putScript.manual.json
@@ -2823,6 +2823,16 @@
     },
     {
       "op": "add",
+      "path": "/shapes/com.cloudflare.workers#PutScriptMetadataStreamingTailConsumersList",
+      "value": {
+        "type": "list",
+        "member": {
+          "target": "com.cloudflare.workers#PutScriptTailConsumer"
+        }
+      }
+    },
+    {
+      "op": "add",
       "path": "/shapes/com.cloudflare.workers#PutScriptContainer",
       "value": {
         "type": "structure",
@@ -2968,6 +2978,12 @@
           },
           "cache_options": {
             "target": "com.cloudflare.workers#PutScriptMetadataCache"
+          },
+          "streaming_tail_consumers": {
+            "target": "com.cloudflare.workers#PutScriptMetadataStreamingTailConsumersList",
+            "traits": {
+              "com.cloudflare.protocols#nullable": {}
+            }
           }
         }
       }

--- a/packages/cloudflare/src/services/workers.ts
+++ b/packages/cloudflare/src/services/workers.ts
@@ -10128,6 +10128,13 @@ export const PutScriptMetadataCache = /*@__PURE__*/ S.suspend(() =>
   identifier: "PutScriptMetadataCache",
 }) as any as S.Schema<PutScriptMetadataCache>;
 
+export type PutScriptMetadataStreamingTailConsumersList =
+  Array<PutScriptTailConsumer>;
+export const PutScriptMetadataStreamingTailConsumersList =
+  /*@__PURE__*/ S.Array(
+    PutScriptTailConsumer,
+  ) as any as S.Schema<PutScriptMetadataStreamingTailConsumersList>;
+
 export interface PutScriptMetadata {
   annotations?: PutScriptMetadataAnnotations;
   assets?: PutScriptMetadataAssets;
@@ -10148,6 +10155,7 @@ export interface PutScriptMetadata {
   tailConsumers?: PutScriptMetadataTailConsumersList | null;
   usageModel?: PutScriptMetadataUsageModel | (string & {});
   cacheOptions?: PutScriptMetadataCache;
+  streamingTailConsumers?: PutScriptMetadataStreamingTailConsumersList | null;
 }
 export const PutScriptMetadata = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
@@ -10181,6 +10189,11 @@ export const PutScriptMetadata = /*@__PURE__*/ S.suspend(() =>
     ),
     cacheOptions: S.optional(
       PutScriptMetadataCache.pipe(T.Body("cache_options")),
+    ),
+    streamingTailConsumers: S.optional(
+      S.NullOr(PutScriptMetadataStreamingTailConsumersList).pipe(
+        T.Body("streaming_tail_consumers"),
+      ),
     ),
   }),
 ).annotate({


### PR DESCRIPTION
wrangler sends `streaming_tail_consumers` on script upload and version create, but the vendor spec types it only on the edge-preview endpoints. Adds `PutScriptMetadataStreamingTailConsumersList` (reusing the tail-consumer item shape) and the `streaming_tail_consumers` member on `PutScriptMetadata`; the key dictionary already carried the camelCase mapping.

```ts
// PutScriptRequest metadata now accepts
streamingTailConsumers?: Array<{ service: string; ... }> | null
```

Consumed by the alchemy local-emulation campaign (streaming tail workers, follow-up to alchemy#1039).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
