### PR TITLE
feat(aws): generate simpledb from a manual spec

### DIFF
--- a/packages/aws/manual-specs/README.md
+++ b/packages/aws/manual-specs/README.md
@@ -1,0 +1,16 @@
+# manual-specs
+
+Hand-authored Smithy models for AWS APIs that `specs/api-models-aws` does
+not cover. They are **models, not modules**: `scripts/generate.ts` compiles
+them through the identical path as every published model — same `awsSpec`,
+same patch chain (`patches/<sdkId>.json`), same emitter — so the resulting
+`src/services/<sdkId>.ts` is generated output like any other and is
+regenerated on every run.
+
+A file here whose name collides with a directory in
+`specs/api-models-aws/models` fails the run: if AWS publishes the model,
+delete the manual one rather than shadowing it.
+
+| Model          | Why it is here                                                                                                                                                                                 |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `simpledb.json` | Classic Amazon SimpleDB (2009-04-15) predates Smithy and AWS never published a model for it — it survives only in botocore/SDK v2. The published `simpledbv2` model covers only the domain-export migration API, not domain or item operations. |

--- a/packages/aws/manual-specs/simpledb.json
+++ b/packages/aws/manual-specs/simpledb.json
@@ -1,0 +1,852 @@
+{
+  "smithy": "2.0",
+  "metadata": {
+    "note": "Hand-authored: classic Amazon SimpleDB (2009-04-15) predates Smithy and AWS never published a model for it (it survives only in botocore / SDK v2), so scripts/generate.ts cannot derive it from specs/api-models-aws. The published `simpledbv2` model covers ONLY the domain-export migration API. Shapes and wire names transcribed from the SimpleDB API reference and the botocore `sdb-2009-04-15` model; the protocol details (SigV2-only auth, EC2-style error envelope) were verified against the live endpoint.",
+    "httpErrorNote": "Errors returning 404 (AttributeDoesNotExist) or 409 (the Number*Exceeded quota errors) deliberately carry no `smithy.api#httpError`: the generator derives category decorators from that code, and 404 would add BadRequest while 409 would add Conflict — neither of which SimpleDB's error semantics warrant. Their categories come from patches/simpledb.json instead."
+  },
+  "shapes": {
+    "com.amazonaws.simpledb#AmazonSimpleDB": {
+      "type": "service",
+      "version": "2009-04-15",
+      "operations": [
+        { "target": "com.amazonaws.simpledb#CreateDomain" },
+        { "target": "com.amazonaws.simpledb#DeleteDomain" },
+        { "target": "com.amazonaws.simpledb#DomainMetadata" },
+        { "target": "com.amazonaws.simpledb#ListDomains" },
+        { "target": "com.amazonaws.simpledb#GetAttributes" },
+        { "target": "com.amazonaws.simpledb#PutAttributes" },
+        { "target": "com.amazonaws.simpledb#DeleteAttributes" },
+        { "target": "com.amazonaws.simpledb#BatchPutAttributes" },
+        { "target": "com.amazonaws.simpledb#BatchDeleteAttributes" },
+        { "target": "com.amazonaws.simpledb#Select" }
+      ],
+      "traits": {
+        "aws.api#service": {
+          "sdkId": "SimpleDB",
+          "arnNamespace": "sdb"
+        },
+        "aws.auth#sigv2": { "name": "sdb" },
+        "aws.protocols#awsQuery": {},
+        "smithy.api#xmlNamespace": {
+          "uri": "http://sdb.amazonaws.com/doc/2009-04-15/"
+        },
+        "smithy.api#documentation": "Amazon SimpleDB is a web service for running queries on structured data in real time.",
+        "smithy.rules#endpointRuleSet": {
+          "version": "1.0",
+          "parameters": {
+            "UseDualStack": {
+              "type": "Boolean",
+              "required": true,
+              "default": false,
+              "documentation": "When true, use the dual-stack endpoint."
+            },
+            "UseFIPS": {
+              "type": "Boolean",
+              "required": true,
+              "default": false,
+              "documentation": "When true, send this request to the FIPS-compliant regional endpoint."
+            },
+            "Endpoint": {
+              "type": "String",
+              "required": false,
+              "documentation": "Override the endpoint used to send this request."
+            },
+            "Region": {
+              "type": "String",
+              "required": false,
+              "documentation": "The AWS region used to dispatch the request."
+            }
+          },
+          "rules": [
+            {
+              "conditions": [
+                { "fn": "isSet", "argv": [{ "ref": "Endpoint" }] }
+              ],
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "booleanEquals",
+                      "argv": [{ "ref": "UseFIPS" }, true]
+                    }
+                  ],
+                  "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                  "type": "error"
+                },
+                {
+                  "conditions": [
+                    {
+                      "fn": "booleanEquals",
+                      "argv": [{ "ref": "UseDualStack" }, true]
+                    }
+                  ],
+                  "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                  "type": "error"
+                },
+                {
+                  "conditions": [],
+                  "endpoint": {
+                    "url": { "ref": "Endpoint" },
+                    "properties": {},
+                    "headers": {}
+                  },
+                  "type": "endpoint"
+                }
+              ],
+              "type": "tree"
+            },
+            {
+              "conditions": [{ "fn": "isSet", "argv": [{ "ref": "Region" }] }],
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "stringEquals",
+                      "argv": [{ "ref": "Region" }, "us-east-1"]
+                    }
+                  ],
+                  "endpoint": {
+                    "url": "https://sdb.amazonaws.com",
+                    "properties": {},
+                    "headers": {}
+                  },
+                  "type": "endpoint"
+                },
+                {
+                  "conditions": [],
+                  "endpoint": {
+                    "url": "https://sdb.{Region}.amazonaws.com",
+                    "properties": {},
+                    "headers": {}
+                  },
+                  "type": "endpoint"
+                }
+              ],
+              "type": "tree"
+            },
+            {
+              "conditions": [],
+              "error": "Invalid Configuration: Missing Region",
+              "type": "error"
+            }
+          ]
+        }
+      }
+    },
+
+    "com.amazonaws.simpledb#DomainName": { "type": "string" },
+
+    "com.amazonaws.simpledb#DomainNameList": {
+      "type": "list",
+      "member": { "target": "smithy.api#String" }
+    },
+    "com.amazonaws.simpledb#AttributeNameList": {
+      "type": "list",
+      "member": { "target": "smithy.api#String" }
+    },
+    "com.amazonaws.simpledb#AttributeList": {
+      "type": "list",
+      "member": { "target": "com.amazonaws.simpledb#Attribute" }
+    },
+    "com.amazonaws.simpledb#ReplaceableAttributeList": {
+      "type": "list",
+      "member": { "target": "com.amazonaws.simpledb#ReplaceableAttribute" }
+    },
+    "com.amazonaws.simpledb#DeletableAttributeList": {
+      "type": "list",
+      "member": { "target": "com.amazonaws.simpledb#DeletableAttribute" }
+    },
+    "com.amazonaws.simpledb#ReplaceableItemList": {
+      "type": "list",
+      "member": { "target": "com.amazonaws.simpledb#ReplaceableItem" }
+    },
+    "com.amazonaws.simpledb#DeletableItemList": {
+      "type": "list",
+      "member": { "target": "com.amazonaws.simpledb#DeletableItem" }
+    },
+    "com.amazonaws.simpledb#ItemList": {
+      "type": "list",
+      "member": { "target": "com.amazonaws.simpledb#Item" }
+    },
+
+    "com.amazonaws.simpledb#Attribute": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "smithy.api#String",
+          "traits": { "smithy.api#required": {} }
+        },
+        "AlternateNameEncoding": { "target": "smithy.api#String" },
+        "Value": {
+          "target": "smithy.api#String",
+          "traits": { "smithy.api#required": {} }
+        },
+        "AlternateValueEncoding": { "target": "smithy.api#String" }
+      }
+    },
+    "com.amazonaws.simpledb#ReplaceableAttribute": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "smithy.api#String",
+          "traits": { "smithy.api#required": {} }
+        },
+        "Value": {
+          "target": "smithy.api#String",
+          "traits": { "smithy.api#required": {} }
+        },
+        "Replace": { "target": "smithy.api#Boolean" }
+      }
+    },
+    "com.amazonaws.simpledb#DeletableAttribute": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "smithy.api#String",
+          "traits": { "smithy.api#required": {} }
+        },
+        "Value": { "target": "smithy.api#String" }
+      }
+    },
+    "com.amazonaws.simpledb#UpdateCondition": {
+      "type": "structure",
+      "members": {
+        "Name": { "target": "smithy.api#String" },
+        "Value": { "target": "smithy.api#String" },
+        "Exists": { "target": "smithy.api#Boolean" }
+      }
+    },
+    "com.amazonaws.simpledb#ReplaceableItem": {
+      "type": "structure",
+      "members": {
+        "ItemName": {
+          "target": "smithy.api#String",
+          "traits": { "smithy.api#required": {} }
+        },
+        "Attributes": {
+          "target": "com.amazonaws.simpledb#ReplaceableAttributeList",
+          "traits": {
+            "smithy.api#required": {},
+            "smithy.api#xmlName": "Attribute",
+            "smithy.api#xmlFlattened": {}
+          }
+        }
+      }
+    },
+    "com.amazonaws.simpledb#DeletableItem": {
+      "type": "structure",
+      "members": {
+        "ItemName": {
+          "target": "smithy.api#String",
+          "traits": { "smithy.api#required": {} }
+        },
+        "Attributes": {
+          "target": "com.amazonaws.simpledb#DeletableAttributeList",
+          "traits": {
+            "smithy.api#xmlName": "Attribute",
+            "smithy.api#xmlFlattened": {}
+          }
+        }
+      }
+    },
+    "com.amazonaws.simpledb#Item": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "smithy.api#String",
+          "traits": { "smithy.api#required": {} }
+        },
+        "AlternateNameEncoding": { "target": "smithy.api#String" },
+        "Attributes": {
+          "target": "com.amazonaws.simpledb#AttributeList",
+          "traits": {
+            "smithy.api#xmlName": "Attribute",
+            "smithy.api#xmlFlattened": {}
+          }
+        }
+      }
+    },
+
+    "com.amazonaws.simpledb#CreateDomainRequest": {
+      "type": "structure",
+      "members": {
+        "DomainName": {
+          "target": "com.amazonaws.simpledb#DomainName",
+          "traits": { "smithy.api#required": {} }
+        }
+      }
+    },
+    "com.amazonaws.simpledb#CreateDomainResponse": {
+      "type": "structure",
+      "members": {}
+    },
+    "com.amazonaws.simpledb#DeleteDomainRequest": {
+      "type": "structure",
+      "members": {
+        "DomainName": {
+          "target": "com.amazonaws.simpledb#DomainName",
+          "traits": { "smithy.api#required": {} }
+        }
+      }
+    },
+    "com.amazonaws.simpledb#DeleteDomainResponse": {
+      "type": "structure",
+      "members": {}
+    },
+    "com.amazonaws.simpledb#DomainMetadataRequest": {
+      "type": "structure",
+      "members": {
+        "DomainName": {
+          "target": "com.amazonaws.simpledb#DomainName",
+          "traits": { "smithy.api#required": {} }
+        }
+      }
+    },
+    "com.amazonaws.simpledb#DomainMetadataResponse": {
+      "type": "structure",
+      "members": {
+        "ItemCount": { "target": "smithy.api#Integer" },
+        "ItemNamesSizeBytes": { "target": "smithy.api#Long" },
+        "AttributeNameCount": { "target": "smithy.api#Integer" },
+        "AttributeNamesSizeBytes": { "target": "smithy.api#Long" },
+        "AttributeValueCount": { "target": "smithy.api#Integer" },
+        "AttributeValuesSizeBytes": { "target": "smithy.api#Long" },
+        "Timestamp": { "target": "smithy.api#Integer" }
+      }
+    },
+    "com.amazonaws.simpledb#ListDomainsRequest": {
+      "type": "structure",
+      "members": {
+        "MaxNumberOfDomains": { "target": "smithy.api#Integer" },
+        "NextToken": { "target": "smithy.api#String" }
+      }
+    },
+    "com.amazonaws.simpledb#ListDomainsResponse": {
+      "type": "structure",
+      "members": {
+        "DomainNames": {
+          "target": "com.amazonaws.simpledb#DomainNameList",
+          "traits": {
+            "smithy.api#xmlName": "DomainName",
+            "smithy.api#xmlFlattened": {}
+          }
+        },
+        "NextToken": { "target": "smithy.api#String" }
+      }
+    },
+    "com.amazonaws.simpledb#GetAttributesRequest": {
+      "type": "structure",
+      "members": {
+        "DomainName": {
+          "target": "com.amazonaws.simpledb#DomainName",
+          "traits": { "smithy.api#required": {} }
+        },
+        "ItemName": {
+          "target": "smithy.api#String",
+          "traits": { "smithy.api#required": {} }
+        },
+        "AttributeNames": {
+          "target": "com.amazonaws.simpledb#AttributeNameList",
+          "traits": {
+            "smithy.api#xmlName": "AttributeName",
+            "smithy.api#xmlFlattened": {}
+          }
+        },
+        "ConsistentRead": { "target": "smithy.api#Boolean" }
+      }
+    },
+    "com.amazonaws.simpledb#GetAttributesResponse": {
+      "type": "structure",
+      "members": {
+        "Attributes": {
+          "target": "com.amazonaws.simpledb#AttributeList",
+          "traits": {
+            "smithy.api#xmlName": "Attribute",
+            "smithy.api#xmlFlattened": {}
+          }
+        }
+      }
+    },
+    "com.amazonaws.simpledb#PutAttributesRequest": {
+      "type": "structure",
+      "members": {
+        "DomainName": {
+          "target": "com.amazonaws.simpledb#DomainName",
+          "traits": { "smithy.api#required": {} }
+        },
+        "ItemName": {
+          "target": "smithy.api#String",
+          "traits": { "smithy.api#required": {} }
+        },
+        "Attributes": {
+          "target": "com.amazonaws.simpledb#ReplaceableAttributeList",
+          "traits": {
+            "smithy.api#required": {},
+            "smithy.api#xmlName": "Attribute",
+            "smithy.api#xmlFlattened": {}
+          }
+        },
+        "Expected": { "target": "com.amazonaws.simpledb#UpdateCondition" }
+      }
+    },
+    "com.amazonaws.simpledb#PutAttributesResponse": {
+      "type": "structure",
+      "members": {}
+    },
+    "com.amazonaws.simpledb#DeleteAttributesRequest": {
+      "type": "structure",
+      "members": {
+        "DomainName": {
+          "target": "com.amazonaws.simpledb#DomainName",
+          "traits": { "smithy.api#required": {} }
+        },
+        "ItemName": {
+          "target": "smithy.api#String",
+          "traits": { "smithy.api#required": {} }
+        },
+        "Attributes": {
+          "target": "com.amazonaws.simpledb#DeletableAttributeList",
+          "traits": {
+            "smithy.api#xmlName": "Attribute",
+            "smithy.api#xmlFlattened": {}
+          }
+        },
+        "Expected": { "target": "com.amazonaws.simpledb#UpdateCondition" }
+      }
+    },
+    "com.amazonaws.simpledb#DeleteAttributesResponse": {
+      "type": "structure",
+      "members": {}
+    },
+    "com.amazonaws.simpledb#BatchPutAttributesRequest": {
+      "type": "structure",
+      "members": {
+        "DomainName": {
+          "target": "com.amazonaws.simpledb#DomainName",
+          "traits": { "smithy.api#required": {} }
+        },
+        "Items": {
+          "target": "com.amazonaws.simpledb#ReplaceableItemList",
+          "traits": {
+            "smithy.api#required": {},
+            "smithy.api#xmlName": "Item",
+            "smithy.api#xmlFlattened": {}
+          }
+        }
+      }
+    },
+    "com.amazonaws.simpledb#BatchPutAttributesResponse": {
+      "type": "structure",
+      "members": {}
+    },
+    "com.amazonaws.simpledb#BatchDeleteAttributesRequest": {
+      "type": "structure",
+      "members": {
+        "DomainName": {
+          "target": "com.amazonaws.simpledb#DomainName",
+          "traits": { "smithy.api#required": {} }
+        },
+        "Items": {
+          "target": "com.amazonaws.simpledb#DeletableItemList",
+          "traits": {
+            "smithy.api#required": {},
+            "smithy.api#xmlName": "Item",
+            "smithy.api#xmlFlattened": {}
+          }
+        }
+      }
+    },
+    "com.amazonaws.simpledb#BatchDeleteAttributesResponse": {
+      "type": "structure",
+      "members": {}
+    },
+    "com.amazonaws.simpledb#SelectRequest": {
+      "type": "structure",
+      "members": {
+        "SelectExpression": {
+          "target": "smithy.api#String",
+          "traits": { "smithy.api#required": {} }
+        },
+        "NextToken": { "target": "smithy.api#String" },
+        "ConsistentRead": { "target": "smithy.api#Boolean" }
+      }
+    },
+    "com.amazonaws.simpledb#SelectResponse": {
+      "type": "structure",
+      "members": {
+        "Items": {
+          "target": "com.amazonaws.simpledb#ItemList",
+          "traits": {
+            "smithy.api#xmlName": "Item",
+            "smithy.api#xmlFlattened": {}
+          }
+        },
+        "NextToken": { "target": "smithy.api#String" }
+      }
+    },
+
+    "com.amazonaws.simpledb#NoSuchDomain": {
+      "type": "structure",
+      "members": {
+        "message": { "target": "smithy.api#String" },
+        "BoxUsage": { "target": "smithy.api#String" }
+      },
+      "traits": {
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400,
+        "smithy.api#documentation": "The specified domain does not exist."
+      }
+    },
+    "com.amazonaws.simpledb#InvalidParameterValue": {
+      "type": "structure",
+      "members": {
+        "message": { "target": "smithy.api#String" },
+        "BoxUsage": { "target": "smithy.api#String" }
+      },
+      "traits": {
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400,
+        "smithy.api#documentation": "The value for a parameter is invalid."
+      }
+    },
+    "com.amazonaws.simpledb#MissingParameter": {
+      "type": "structure",
+      "members": {
+        "message": { "target": "smithy.api#String" },
+        "BoxUsage": { "target": "smithy.api#String" }
+      },
+      "traits": {
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400,
+        "smithy.api#documentation": "The request must contain the specified missing parameter."
+      }
+    },
+    "com.amazonaws.simpledb#NumberDomainsExceeded": {
+      "type": "structure",
+      "members": {
+        "message": { "target": "smithy.api#String" },
+        "BoxUsage": { "target": "smithy.api#String" }
+      },
+      "traits": {
+        "smithy.api#error": "client",
+        "smithy.api#documentation": "Too many domains exist for this account."
+      }
+    },
+    "com.amazonaws.simpledb#InvalidNextToken": {
+      "type": "structure",
+      "members": {
+        "message": { "target": "smithy.api#String" },
+        "BoxUsage": { "target": "smithy.api#String" }
+      },
+      "traits": {
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400,
+        "smithy.api#documentation": "The specified NextToken is not valid."
+      }
+    },
+    "com.amazonaws.simpledb#AttributeDoesNotExist": {
+      "type": "structure",
+      "members": {
+        "message": { "target": "smithy.api#String" },
+        "BoxUsage": { "target": "smithy.api#String" }
+      },
+      "traits": {
+        "smithy.api#error": "client",
+        "smithy.api#documentation": "The specified attribute does not exist."
+      }
+    },
+    "com.amazonaws.simpledb#DuplicateItemName": {
+      "type": "structure",
+      "members": {
+        "message": { "target": "smithy.api#String" },
+        "BoxUsage": { "target": "smithy.api#String" }
+      },
+      "traits": {
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400,
+        "smithy.api#documentation": "The item name was specified more than once."
+      }
+    },
+    "com.amazonaws.simpledb#InvalidNumberPredicates": {
+      "type": "structure",
+      "members": {
+        "message": { "target": "smithy.api#String" },
+        "BoxUsage": { "target": "smithy.api#String" }
+      },
+      "traits": {
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400,
+        "smithy.api#documentation": "Too many predicates exist in the query expression."
+      }
+    },
+    "com.amazonaws.simpledb#InvalidNumberValueTests": {
+      "type": "structure",
+      "members": {
+        "message": { "target": "smithy.api#String" },
+        "BoxUsage": { "target": "smithy.api#String" }
+      },
+      "traits": {
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400,
+        "smithy.api#documentation": "Too many predicates exist in the query expression."
+      }
+    },
+    "com.amazonaws.simpledb#InvalidQueryExpression": {
+      "type": "structure",
+      "members": {
+        "message": { "target": "smithy.api#String" },
+        "BoxUsage": { "target": "smithy.api#String" }
+      },
+      "traits": {
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400,
+        "smithy.api#documentation": "The specified query expression syntax is not valid."
+      }
+    },
+    "com.amazonaws.simpledb#TooManyRequestedAttributes": {
+      "type": "structure",
+      "members": {
+        "message": { "target": "smithy.api#String" },
+        "BoxUsage": { "target": "smithy.api#String" }
+      },
+      "traits": {
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400,
+        "smithy.api#documentation": "Too many attributes in this request."
+      }
+    },
+    "com.amazonaws.simpledb#RequestTimeout": {
+      "type": "structure",
+      "members": {
+        "message": { "target": "smithy.api#String" },
+        "BoxUsage": { "target": "smithy.api#String" }
+      },
+      "traits": {
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 408,
+        "smithy.api#documentation": "A timeout occurred when attempting to query the specified domain with the specified query expression."
+      }
+    },
+    "com.amazonaws.simpledb#NumberDomainAttributesExceeded": {
+      "type": "structure",
+      "members": {
+        "message": { "target": "smithy.api#String" },
+        "BoxUsage": { "target": "smithy.api#String" }
+      },
+      "traits": {
+        "smithy.api#error": "client",
+        "smithy.api#documentation": "Too many attributes in this domain."
+      }
+    },
+    "com.amazonaws.simpledb#NumberDomainBytesExceeded": {
+      "type": "structure",
+      "members": {
+        "message": { "target": "smithy.api#String" },
+        "BoxUsage": { "target": "smithy.api#String" }
+      },
+      "traits": {
+        "smithy.api#error": "client",
+        "smithy.api#documentation": "Too many bytes in this domain."
+      }
+    },
+    "com.amazonaws.simpledb#NumberItemAttributesExceeded": {
+      "type": "structure",
+      "members": {
+        "message": { "target": "smithy.api#String" },
+        "BoxUsage": { "target": "smithy.api#String" }
+      },
+      "traits": {
+        "smithy.api#error": "client",
+        "smithy.api#documentation": "Too many attributes in this item."
+      }
+    },
+    "com.amazonaws.simpledb#NumberSubmittedAttributesExceeded": {
+      "type": "structure",
+      "members": {
+        "message": { "target": "smithy.api#String" },
+        "BoxUsage": { "target": "smithy.api#String" }
+      },
+      "traits": {
+        "smithy.api#error": "client",
+        "smithy.api#documentation": "Too many attributes exist in a single call."
+      }
+    },
+    "com.amazonaws.simpledb#NumberSubmittedItemsExceeded": {
+      "type": "structure",
+      "members": {
+        "message": { "target": "smithy.api#String" },
+        "BoxUsage": { "target": "smithy.api#String" }
+      },
+      "traits": {
+        "smithy.api#error": "client",
+        "smithy.api#documentation": "Too many items exist in a single call."
+      }
+    },
+
+    "com.amazonaws.simpledb#CreateDomain": {
+      "type": "operation",
+      "input": { "target": "com.amazonaws.simpledb#CreateDomainRequest" },
+      "output": { "target": "com.amazonaws.simpledb#CreateDomainResponse" },
+      "errors": [
+        { "target": "com.amazonaws.simpledb#InvalidParameterValue" },
+        { "target": "com.amazonaws.simpledb#MissingParameter" },
+        { "target": "com.amazonaws.simpledb#NumberDomainsExceeded" }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Creates a new SimpleDB domain. Idempotent — creating an existing domain succeeds without error.",
+        "smithy.api#http": { "method": "POST", "uri": "/" }
+      }
+    },
+    "com.amazonaws.simpledb#DeleteDomain": {
+      "type": "operation",
+      "input": { "target": "com.amazonaws.simpledb#DeleteDomainRequest" },
+      "output": { "target": "com.amazonaws.simpledb#DeleteDomainResponse" },
+      "errors": [{ "target": "com.amazonaws.simpledb#MissingParameter" }],
+      "traits": {
+        "smithy.api#documentation": "Deletes a SimpleDB domain and all of its items. Idempotent — deleting a missing domain succeeds without error.",
+        "smithy.api#http": { "method": "POST", "uri": "/" }
+      }
+    },
+    "com.amazonaws.simpledb#DomainMetadata": {
+      "type": "operation",
+      "input": { "target": "com.amazonaws.simpledb#DomainMetadataRequest" },
+      "output": { "target": "com.amazonaws.simpledb#DomainMetadataResponse" },
+      "errors": [
+        { "target": "com.amazonaws.simpledb#MissingParameter" },
+        { "target": "com.amazonaws.simpledb#NoSuchDomain" }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Returns information about a SimpleDB domain (item count, sizes, timestamp).",
+        "smithy.api#http": { "method": "POST", "uri": "/" }
+      }
+    },
+    "com.amazonaws.simpledb#ListDomains": {
+      "type": "operation",
+      "input": { "target": "com.amazonaws.simpledb#ListDomainsRequest" },
+      "output": { "target": "com.amazonaws.simpledb#ListDomainsResponse" },
+      "errors": [
+        { "target": "com.amazonaws.simpledb#InvalidNextToken" },
+        { "target": "com.amazonaws.simpledb#InvalidParameterValue" }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Lists all SimpleDB domains in the account/region. Paginated.",
+        "smithy.api#http": { "method": "POST", "uri": "/" },
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "DomainNames",
+          "pageSize": "MaxNumberOfDomains"
+        }
+      }
+    },
+    "com.amazonaws.simpledb#GetAttributes": {
+      "type": "operation",
+      "input": { "target": "com.amazonaws.simpledb#GetAttributesRequest" },
+      "output": { "target": "com.amazonaws.simpledb#GetAttributesResponse" },
+      "errors": [
+        { "target": "com.amazonaws.simpledb#InvalidParameterValue" },
+        { "target": "com.amazonaws.simpledb#MissingParameter" },
+        { "target": "com.amazonaws.simpledb#NoSuchDomain" }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Returns all (or the requested subset of) attributes of a SimpleDB item. Reads are eventually consistent unless <code>ConsistentRead</code> is set.",
+        "smithy.api#http": { "method": "POST", "uri": "/" }
+      }
+    },
+    "com.amazonaws.simpledb#PutAttributes": {
+      "type": "operation",
+      "input": { "target": "com.amazonaws.simpledb#PutAttributesRequest" },
+      "output": { "target": "com.amazonaws.simpledb#PutAttributesResponse" },
+      "errors": [
+        { "target": "com.amazonaws.simpledb#AttributeDoesNotExist" },
+        { "target": "com.amazonaws.simpledb#InvalidParameterValue" },
+        { "target": "com.amazonaws.simpledb#MissingParameter" },
+        { "target": "com.amazonaws.simpledb#NoSuchDomain" },
+        { "target": "com.amazonaws.simpledb#NumberDomainAttributesExceeded" },
+        { "target": "com.amazonaws.simpledb#NumberDomainBytesExceeded" },
+        { "target": "com.amazonaws.simpledb#NumberItemAttributesExceeded" }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Creates or replaces attributes of a SimpleDB item. With <code>Replace: true</code> an attribute's existing values are overwritten; otherwise values accumulate.",
+        "smithy.api#http": { "method": "POST", "uri": "/" }
+      }
+    },
+    "com.amazonaws.simpledb#DeleteAttributes": {
+      "type": "operation",
+      "input": { "target": "com.amazonaws.simpledb#DeleteAttributesRequest" },
+      "output": { "target": "com.amazonaws.simpledb#DeleteAttributesResponse" },
+      "errors": [
+        { "target": "com.amazonaws.simpledb#AttributeDoesNotExist" },
+        { "target": "com.amazonaws.simpledb#InvalidParameterValue" },
+        { "target": "com.amazonaws.simpledb#MissingParameter" },
+        { "target": "com.amazonaws.simpledb#NoSuchDomain" }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Deletes one or more attributes of a SimpleDB item — or the whole item when no attributes are named. Idempotent: deleting a missing attribute/item succeeds.",
+        "smithy.api#http": { "method": "POST", "uri": "/" }
+      }
+    },
+    "com.amazonaws.simpledb#BatchPutAttributes": {
+      "type": "operation",
+      "input": { "target": "com.amazonaws.simpledb#BatchPutAttributesRequest" },
+      "output": {
+        "target": "com.amazonaws.simpledb#BatchPutAttributesResponse"
+      },
+      "errors": [
+        { "target": "com.amazonaws.simpledb#DuplicateItemName" },
+        { "target": "com.amazonaws.simpledb#InvalidParameterValue" },
+        { "target": "com.amazonaws.simpledb#MissingParameter" },
+        { "target": "com.amazonaws.simpledb#NoSuchDomain" },
+        { "target": "com.amazonaws.simpledb#NumberDomainAttributesExceeded" },
+        { "target": "com.amazonaws.simpledb#NumberDomainBytesExceeded" },
+        { "target": "com.amazonaws.simpledb#NumberItemAttributesExceeded" },
+        {
+          "target": "com.amazonaws.simpledb#NumberSubmittedAttributesExceeded"
+        },
+        { "target": "com.amazonaws.simpledb#NumberSubmittedItemsExceeded" }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Puts attributes on up to 25 items in a single call.",
+        "smithy.api#http": { "method": "POST", "uri": "/" }
+      }
+    },
+    "com.amazonaws.simpledb#BatchDeleteAttributes": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.simpledb#BatchDeleteAttributesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.simpledb#BatchDeleteAttributesResponse"
+      },
+      "traits": {
+        "smithy.api#documentation": "Deletes attributes (or whole items) on up to 25 items in a single call. Idempotent — missing items/attributes are not an error.",
+        "smithy.api#http": { "method": "POST", "uri": "/" }
+      }
+    },
+    "com.amazonaws.simpledb#Select": {
+      "type": "operation",
+      "input": { "target": "com.amazonaws.simpledb#SelectRequest" },
+      "output": { "target": "com.amazonaws.simpledb#SelectResponse" },
+      "errors": [
+        { "target": "com.amazonaws.simpledb#InvalidNextToken" },
+        { "target": "com.amazonaws.simpledb#InvalidNumberPredicates" },
+        { "target": "com.amazonaws.simpledb#InvalidNumberValueTests" },
+        { "target": "com.amazonaws.simpledb#InvalidParameterValue" },
+        { "target": "com.amazonaws.simpledb#InvalidQueryExpression" },
+        { "target": "com.amazonaws.simpledb#MissingParameter" },
+        { "target": "com.amazonaws.simpledb#NoSuchDomain" },
+        { "target": "com.amazonaws.simpledb#RequestTimeout" },
+        { "target": "com.amazonaws.simpledb#TooManyRequestedAttributes" }
+      ],
+      "traits": {
+        "smithy.api#documentation": "Runs a SimpleDB select expression (<code>select output_list from domain [where ...]</code>). Paginated via <code>NextToken</code>.",
+        "smithy.api#http": { "method": "POST", "uri": "/" },
+        "smithy.api#paginated": {
+          "inputToken": "NextToken",
+          "outputToken": "NextToken",
+          "items": "Items"
+        }
+      }
+    }
+  }
+}

--- a/packages/aws/patches/simpledb.json
+++ b/packages/aws/patches/simpledb.json
@@ -1,0 +1,12 @@
+{
+  "errorCategories": {
+    "NoSuchDomain": ["NotFoundError"],
+    "AttributeDoesNotExist": ["NotFoundError"],
+    "NumberDomainsExceeded": ["QuotaError"],
+    "NumberDomainAttributesExceeded": ["QuotaError"],
+    "NumberDomainBytesExceeded": ["QuotaError"],
+    "NumberItemAttributesExceeded": ["QuotaError"],
+    "NumberSubmittedAttributesExceeded": ["QuotaError"],
+    "NumberSubmittedItemsExceeded": ["QuotaError"]
+  }
+}

--- a/packages/aws/scripts/generate.ts
+++ b/packages/aws/scripts/generate.ts
@@ -3,6 +3,8 @@
  * generate — turn the AWS Smithy models into an Effect SDK.
  *
  * Input:  specs/api-models-aws/models/<service>/service/<version>/<service>-<version>.json
+ *         manual-specs/<service>.json  (hand-authored models for APIs AWS
+ *         never published a Smithy model for — see manual-specs/README.md)
  * Output: src/services/<sdkId>.ts  +  services/index.ts
  *
  * The smithy→SDK compiler lives in `@distilled.cloud/core/codegen`; the
@@ -27,6 +29,7 @@ import { awsSpec } from "./spec.ts";
 import path from "pathe";
 
 const AWS_MODELS_PATH = "specs/api-models-aws";
+const MANUAL_SPECS_PATH = "manual-specs";
 const RESULT_ROOT_PATH = path.resolve("src", "services");
 
 function getSdkFlag(): Option.Option<string> {
@@ -145,6 +148,38 @@ BunRuntime.runMain(
             Console.error(
               `❌ ${service}\n\tUnable to generate client: ${error}`,
             ),
+          ),
+        ),
+    );
+
+    // Hand-authored models for APIs `specs/api-models-aws` doesn't cover.
+    // They compile through the identical path — same SdkSpec, same patch
+    // chain — so a manual spec is a MODEL, never a hand-written module.
+    const manualExists = yield* fs.exists(MANUAL_SPECS_PATH);
+    const manualFiles = manualExists
+      ? (yield* fs.readDirectory(MANUAL_SPECS_PATH)).filter((f) =>
+          f.endsWith(".json"),
+        )
+      : [];
+    for (const file of manualFiles) {
+      const service = file.replace(/\.json$/, "");
+      if (folders.includes(service)) {
+        return yield* Effect.die(
+          new Error(
+            `${MANUAL_SPECS_PATH}/${file} shadows a published model — rename or delete it`,
+          ),
+        );
+      }
+    }
+    yield* Effect.forEach(
+      manualFiles.filter(
+        (file) => sdkFlag == null || sdkFlag === file.replace(/\.json$/, ""),
+      ),
+      (file) =>
+        generateClient(p.join(MANUAL_SPECS_PATH, file), RESULT_ROOT_PATH).pipe(
+          Effect.andThen(() => Console.log(`✅ ${file} (manual)`)),
+          Effect.catch((error) =>
+            Console.error(`❌ ${file}\n\tUnable to generate client: ${error}`),
           ),
         ),
     );

--- a/packages/aws/scripts/model-schema.ts
+++ b/packages/aws/scripts/model-schema.ts
@@ -26,6 +26,9 @@ export const ServiceShape = S.Struct({
         sdkId: S.String,
       }),
       "aws.auth#sigv4": S.optional(S.Struct({ name: S.String })),
+      // Provider-defined: AWS never gave SigV2 a Smithy trait. Only
+      // SimpleDB needs it (its endpoint rejects SigV4).
+      "aws.auth#sigv2": S.optional(S.Struct({ name: S.String })),
     }),
     [S.Record(S.String, S.Unknown)],
   ),

--- a/packages/aws/scripts/spec.ts
+++ b/packages/aws/scripts/spec.ts
@@ -864,6 +864,12 @@ export const awsSpec = (
   const sdkId: string = serviceShape.traits["aws.api#service"].sdkId;
   const sigV4ServiceName: string =
     serviceShape.traits?.["aws.auth#sigv4"]?.name ?? serviceShapeName;
+  // Signature Version 2. AWS never defined a Smithy trait for it (SigV2 was
+  // dead before Smithy existed), so this is provider-defined — but the
+  // runtime trait already exists, and SimpleDB's endpoint rejects SigV4
+  // outright, so a model has to be able to say so.
+  const sigV2ServiceName: string | undefined =
+    serviceShape.traits?.["aws.auth#sigv2"]?.name;
   const version: string = serviceShape.version ?? "";
   const patchFileBase = sdkId.toLowerCase().replaceAll(" ", "-");
 
@@ -2429,7 +2435,9 @@ export const awsSpec = (
         `const svc = T.AwsApiService({ sdkId: "${sdkId}", serviceShapeName: "${serviceShapeName}" });`,
       );
       serviceConstants.push(
-        `const auth = T.AwsAuthSigv4({ name: "${sigV4ServiceName}" });`,
+        sigV2ServiceName !== undefined
+          ? `const auth = T.AwsAuthSigv2({ name: "${sigV2ServiceName}" });`
+          : `const auth = T.AwsAuthSigv4({ name: "${sigV4ServiceName}" });`,
       );
       serviceConstants.push(`const ver = T.ServiceVersion("${version}");`);
 

--- a/packages/aws/src/services/simpledb.ts
+++ b/packages/aws/src/services/simpledb.ts
@@ -1,21 +1,3 @@
-/**
- * Amazon SimpleDB (classic, 2009-04-15) — HAND-WRITTEN service module.
- *
- * AWS never published a Smithy model for classic SimpleDB (it exists only in
- * SDK v2 / botocore), so this module cannot be generated from
- * `specs/api-models-aws` and must not be regenerated. The modern
- * "SimpleDBv2" Smithy model (`simpledbv2.ts`) covers ONLY the domain-export
- * migration API; domain management (CreateDomain / DeleteDomain /
- * DomainMetadata / ListDomains) lives here.
- *
- * Protocol notes (verified against the live endpoint):
- * - awsQuery wire shape with `{Op}Result` response wrappers.
- * - Signature Version 2 ONLY (`T.AwsAuthSigv2`) — the endpoint rejects SigV4
- *   with `AuthFailure: access credentials are missing`.
- * - Errors are wrapped EC2-style:
- *   `<Response><Errors><Error><Code/>..</Error></Errors><RequestID/></Response>`
- *   (handled by the aws-query protocol's legacy fallback).
- */
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as S from "@distilled.cloud/core/schema";
 import * as stream from "effect/Stream";
@@ -67,10 +49,197 @@ const rules = T.EndpointResolver((p, _) => {
   return err("Invalid Configuration: Missing Region");
 });
 
-//# Newtypes
+export class AttributeDoesNotExist extends S.TaggedErrorClass<AttributeDoesNotExist>()(
+  "AttributeDoesNotExist",
+  { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
+).pipe(C.withNotFoundError) {}
+export class DuplicateItemName extends S.TaggedErrorClass<DuplicateItemName>()(
+  "DuplicateItemName",
+  { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
+  T.HttpError(400),
+).pipe(C.withBadRequestError) {}
+export class InvalidNextToken extends S.TaggedErrorClass<InvalidNextToken>()(
+  "InvalidNextToken",
+  { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
+  T.HttpError(400),
+).pipe(C.withBadRequestError) {}
+export class InvalidNumberPredicates extends S.TaggedErrorClass<InvalidNumberPredicates>()(
+  "InvalidNumberPredicates",
+  { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
+  T.HttpError(400),
+).pipe(C.withBadRequestError) {}
+export class InvalidNumberValueTests extends S.TaggedErrorClass<InvalidNumberValueTests>()(
+  "InvalidNumberValueTests",
+  { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
+  T.HttpError(400),
+).pipe(C.withBadRequestError) {}
+export class InvalidParameterValue extends S.TaggedErrorClass<InvalidParameterValue>()(
+  "InvalidParameterValue",
+  { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
+  T.HttpError(400),
+).pipe(C.withBadRequestError) {}
+export class InvalidQueryExpression extends S.TaggedErrorClass<InvalidQueryExpression>()(
+  "InvalidQueryExpression",
+  { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
+  T.HttpError(400),
+).pipe(C.withBadRequestError) {}
+export class MissingParameter extends S.TaggedErrorClass<MissingParameter>()(
+  "MissingParameter",
+  { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
+  T.HttpError(400),
+).pipe(C.withBadRequestError) {}
+export class NoSuchDomain extends S.TaggedErrorClass<NoSuchDomain>()(
+  "NoSuchDomain",
+  { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
+  T.HttpError(400),
+).pipe(C.withBadRequestError, C.withNotFoundError) {}
+export class NumberDomainAttributesExceeded extends S.TaggedErrorClass<NumberDomainAttributesExceeded>()(
+  "NumberDomainAttributesExceeded",
+  { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
+).pipe(C.withQuotaError) {}
+export class NumberDomainBytesExceeded extends S.TaggedErrorClass<NumberDomainBytesExceeded>()(
+  "NumberDomainBytesExceeded",
+  { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
+).pipe(C.withQuotaError) {}
+export class NumberDomainsExceeded extends S.TaggedErrorClass<NumberDomainsExceeded>()(
+  "NumberDomainsExceeded",
+  { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
+).pipe(C.withQuotaError) {}
+export class NumberItemAttributesExceeded extends S.TaggedErrorClass<NumberItemAttributesExceeded>()(
+  "NumberItemAttributesExceeded",
+  { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
+).pipe(C.withQuotaError) {}
+export class NumberSubmittedAttributesExceeded extends S.TaggedErrorClass<NumberSubmittedAttributesExceeded>()(
+  "NumberSubmittedAttributesExceeded",
+  { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
+).pipe(C.withQuotaError) {}
+export class NumberSubmittedItemsExceeded extends S.TaggedErrorClass<NumberSubmittedItemsExceeded>()(
+  "NumberSubmittedItemsExceeded",
+  { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
+).pipe(C.withQuotaError) {}
+export class RequestTimeout extends S.TaggedErrorClass<RequestTimeout>()(
+  "RequestTimeout",
+  { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
+  T.HttpError(408),
+).pipe(C.withTimeoutError) {}
+export class TooManyRequestedAttributes extends S.TaggedErrorClass<TooManyRequestedAttributes>()(
+  "TooManyRequestedAttributes",
+  { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
+  T.HttpError(400),
+).pipe(C.withBadRequestError) {}
 export type DomainName = string;
-
-//# Schemas
+export interface DeletableAttribute {
+  Name: string;
+  Value?: string;
+}
+export const DeletableAttribute = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({ Name: S.String, Value: S.optional(S.String) }),
+).annotate({
+  identifier: "DeletableAttribute",
+}) as any as S.Schema<DeletableAttribute>;
+export type DeletableAttributeList = DeletableAttribute[];
+export const DeletableAttributeList = /*@__PURE__*/ S.Array(DeletableAttribute);
+export interface DeletableItem {
+  ItemName: string;
+  Attributes?: DeletableAttribute[];
+}
+export const DeletableItem = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    ItemName: S.String,
+    Attributes: S.optional(DeletableAttributeList).pipe(
+      T.XmlName("Attribute"),
+      T.XmlFlattened(),
+    ),
+  }),
+).annotate({ identifier: "DeletableItem" }) as any as S.Schema<DeletableItem>;
+export type DeletableItemList = DeletableItem[];
+export const DeletableItemList = /*@__PURE__*/ S.Array(DeletableItem);
+export interface BatchDeleteAttributesRequest {
+  DomainName: string;
+  Items: DeletableItem[];
+}
+export const BatchDeleteAttributesRequest = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    DomainName: S.String,
+    Items: DeletableItemList.pipe(T.XmlName("Item"), T.XmlFlattened()),
+  }).pipe(
+    T.all(
+      ns,
+      T.Http({ method: "POST", uri: "/" }),
+      svc,
+      auth,
+      proto,
+      ver,
+      rules,
+    ),
+  ),
+).annotate({
+  identifier: "BatchDeleteAttributesRequest",
+}) as any as S.Schema<BatchDeleteAttributesRequest>;
+export interface BatchDeleteAttributesResponse {}
+export const BatchDeleteAttributesResponse = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({}).pipe(ns),
+).annotate({
+  identifier: "BatchDeleteAttributesResponse",
+}) as any as S.Schema<BatchDeleteAttributesResponse>;
+export interface ReplaceableAttribute {
+  Name: string;
+  Value: string;
+  Replace?: boolean;
+}
+export const ReplaceableAttribute = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({ Name: S.String, Value: S.String, Replace: S.optional(S.Boolean) }),
+).annotate({
+  identifier: "ReplaceableAttribute",
+}) as any as S.Schema<ReplaceableAttribute>;
+export type ReplaceableAttributeList = ReplaceableAttribute[];
+export const ReplaceableAttributeList =
+  /*@__PURE__*/ S.Array(ReplaceableAttribute);
+export interface ReplaceableItem {
+  ItemName: string;
+  Attributes: ReplaceableAttribute[];
+}
+export const ReplaceableItem = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    ItemName: S.String,
+    Attributes: ReplaceableAttributeList.pipe(
+      T.XmlName("Attribute"),
+      T.XmlFlattened(),
+    ),
+  }),
+).annotate({
+  identifier: "ReplaceableItem",
+}) as any as S.Schema<ReplaceableItem>;
+export type ReplaceableItemList = ReplaceableItem[];
+export const ReplaceableItemList = /*@__PURE__*/ S.Array(ReplaceableItem);
+export interface BatchPutAttributesRequest {
+  DomainName: string;
+  Items: ReplaceableItem[];
+}
+export const BatchPutAttributesRequest = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    DomainName: S.String,
+    Items: ReplaceableItemList.pipe(T.XmlName("Item"), T.XmlFlattened()),
+  }).pipe(
+    T.all(
+      ns,
+      T.Http({ method: "POST", uri: "/" }),
+      svc,
+      auth,
+      proto,
+      ver,
+      rules,
+    ),
+  ),
+).annotate({
+  identifier: "BatchPutAttributesRequest",
+}) as any as S.Schema<BatchPutAttributesRequest>;
+export interface BatchPutAttributesResponse {}
+export const BatchPutAttributesResponse = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({}).pipe(ns),
+).annotate({
+  identifier: "BatchPutAttributesResponse",
+}) as any as S.Schema<BatchPutAttributesResponse>;
 export interface CreateDomainRequest {
   DomainName: string;
 }
@@ -91,11 +260,59 @@ export const CreateDomainRequest = /*@__PURE__*/ S.suspend(() =>
 }) as any as S.Schema<CreateDomainRequest>;
 export interface CreateDomainResponse {}
 export const CreateDomainResponse = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({}),
+  S.Struct({}).pipe(ns),
 ).annotate({
   identifier: "CreateDomainResponse",
 }) as any as S.Schema<CreateDomainResponse>;
-
+export interface UpdateCondition {
+  Name?: string;
+  Value?: string;
+  Exists?: boolean;
+}
+export const UpdateCondition = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    Name: S.optional(S.String),
+    Value: S.optional(S.String),
+    Exists: S.optional(S.Boolean),
+  }),
+).annotate({
+  identifier: "UpdateCondition",
+}) as any as S.Schema<UpdateCondition>;
+export interface DeleteAttributesRequest {
+  DomainName: string;
+  ItemName: string;
+  Attributes?: DeletableAttribute[];
+  Expected?: UpdateCondition;
+}
+export const DeleteAttributesRequest = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    DomainName: S.String,
+    ItemName: S.String,
+    Attributes: S.optional(DeletableAttributeList).pipe(
+      T.XmlName("Attribute"),
+      T.XmlFlattened(),
+    ),
+    Expected: S.optional(UpdateCondition),
+  }).pipe(
+    T.all(
+      ns,
+      T.Http({ method: "POST", uri: "/" }),
+      svc,
+      auth,
+      proto,
+      ver,
+      rules,
+    ),
+  ),
+).annotate({
+  identifier: "DeleteAttributesRequest",
+}) as any as S.Schema<DeleteAttributesRequest>;
+export interface DeleteAttributesResponse {}
+export const DeleteAttributesResponse = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({}).pipe(ns),
+).annotate({
+  identifier: "DeleteAttributesResponse",
+}) as any as S.Schema<DeleteAttributesResponse>;
 export interface DeleteDomainRequest {
   DomainName: string;
 }
@@ -116,11 +333,10 @@ export const DeleteDomainRequest = /*@__PURE__*/ S.suspend(() =>
 }) as any as S.Schema<DeleteDomainRequest>;
 export interface DeleteDomainResponse {}
 export const DeleteDomainResponse = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({}),
+  S.Struct({}).pipe(ns),
 ).annotate({
   identifier: "DeleteDomainResponse",
 }) as any as S.Schema<DeleteDomainResponse>;
-
 export interface DomainMetadataRequest {
   DomainName: string;
 }
@@ -157,11 +373,70 @@ export const DomainMetadataResponse = /*@__PURE__*/ S.suspend(() =>
     AttributeValueCount: S.optional(S.Number),
     AttributeValuesSizeBytes: S.optional(S.Number),
     Timestamp: S.optional(S.Number),
-  }),
+  }).pipe(ns),
 ).annotate({
   identifier: "DomainMetadataResponse",
 }) as any as S.Schema<DomainMetadataResponse>;
-
+export type AttributeNameList = string[];
+export const AttributeNameList = /*@__PURE__*/ S.Array(S.String);
+export interface GetAttributesRequest {
+  DomainName: string;
+  ItemName: string;
+  AttributeNames?: string[];
+  ConsistentRead?: boolean;
+}
+export const GetAttributesRequest = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    DomainName: S.String,
+    ItemName: S.String,
+    AttributeNames: S.optional(AttributeNameList).pipe(
+      T.XmlName("AttributeName"),
+      T.XmlFlattened(),
+    ),
+    ConsistentRead: S.optional(S.Boolean),
+  }).pipe(
+    T.all(
+      ns,
+      T.Http({ method: "POST", uri: "/" }),
+      svc,
+      auth,
+      proto,
+      ver,
+      rules,
+    ),
+  ),
+).annotate({
+  identifier: "GetAttributesRequest",
+}) as any as S.Schema<GetAttributesRequest>;
+export interface Attribute {
+  Name: string;
+  AlternateNameEncoding?: string;
+  Value: string;
+  AlternateValueEncoding?: string;
+}
+export const Attribute = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    Name: S.String,
+    AlternateNameEncoding: S.optional(S.String),
+    Value: S.String,
+    AlternateValueEncoding: S.optional(S.String),
+  }),
+).annotate({ identifier: "Attribute" }) as any as S.Schema<Attribute>;
+export type AttributeList = Attribute[];
+export const AttributeList = /*@__PURE__*/ S.Array(Attribute);
+export interface GetAttributesResponse {
+  Attributes?: Attribute[];
+}
+export const GetAttributesResponse = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    Attributes: S.optional(AttributeList).pipe(
+      T.XmlName("Attribute"),
+      T.XmlFlattened(),
+    ),
+  }).pipe(ns),
+).annotate({
+  identifier: "GetAttributesResponse",
+}) as any as S.Schema<GetAttributesResponse>;
 export interface ListDomainsRequest {
   MaxNumberOfDomains?: number;
   NextToken?: string;
@@ -192,191 +467,15 @@ export interface ListDomainsResponse {
 }
 export const ListDomainsResponse = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    // SimpleDB returns a flattened list of repeated <DomainName> elements
     DomainNames: S.optional(DomainNameList).pipe(
       T.XmlName("DomainName"),
       T.XmlFlattened(),
     ),
     NextToken: S.optional(S.String),
-  }),
+  }).pipe(ns),
 ).annotate({
   identifier: "ListDomainsResponse",
 }) as any as S.Schema<ListDomainsResponse>;
-
-//# Schemas — data plane (Select / GetAttributes / PutAttributes /
-//# DeleteAttributes / BatchPutAttributes / BatchDeleteAttributes)
-//
-// Wire shapes verified against the SimpleDB API reference and the SDK v2 /
-// botocore `sdb-2009-04-15` model: all lists are FLATTENED with singular
-// locationNames (`Attribute.N.*`, `Item.N.*`, `AttributeName.N`), and batch
-// item structures use the `ItemName` member on the wire.
-export interface Attribute {
-  Name: string;
-  AlternateNameEncoding?: string;
-  Value: string;
-  AlternateValueEncoding?: string;
-}
-export const Attribute = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    Name: S.String,
-    AlternateNameEncoding: S.optional(S.String),
-    Value: S.String,
-    AlternateValueEncoding: S.optional(S.String),
-  }),
-).annotate({
-  identifier: "Attribute",
-}) as any as S.Schema<Attribute>;
-export type AttributeList = Attribute[];
-export const AttributeList = /*@__PURE__*/ S.Array(Attribute);
-
-export interface ReplaceableAttribute {
-  Name: string;
-  Value: string;
-  Replace?: boolean;
-}
-export const ReplaceableAttribute = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    Name: S.String,
-    Value: S.String,
-    Replace: S.optional(S.Boolean),
-  }),
-).annotate({
-  identifier: "ReplaceableAttribute",
-}) as any as S.Schema<ReplaceableAttribute>;
-export type ReplaceableAttributeList = ReplaceableAttribute[];
-export const ReplaceableAttributeList =
-  /*@__PURE__*/ S.Array(ReplaceableAttribute);
-
-export interface DeletableAttribute {
-  Name: string;
-  Value?: string;
-}
-export const DeletableAttribute = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    Name: S.String,
-    Value: S.optional(S.String),
-  }),
-).annotate({
-  identifier: "DeletableAttribute",
-}) as any as S.Schema<DeletableAttribute>;
-export type DeletableAttributeList = DeletableAttribute[];
-export const DeletableAttributeList = /*@__PURE__*/ S.Array(DeletableAttribute);
-
-export interface UpdateCondition {
-  Name?: string;
-  Value?: string;
-  Exists?: boolean;
-}
-export const UpdateCondition = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    Name: S.optional(S.String),
-    Value: S.optional(S.String),
-    Exists: S.optional(S.Boolean),
-  }),
-).annotate({
-  identifier: "UpdateCondition",
-}) as any as S.Schema<UpdateCondition>;
-
-export interface ReplaceableItem {
-  ItemName: string;
-  Attributes: ReplaceableAttribute[];
-}
-export const ReplaceableItem = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    ItemName: S.String,
-    Attributes: ReplaceableAttributeList.pipe(
-      T.XmlName("Attribute"),
-      T.XmlFlattened(),
-    ),
-  }),
-).annotate({
-  identifier: "ReplaceableItem",
-}) as any as S.Schema<ReplaceableItem>;
-export type ReplaceableItemList = ReplaceableItem[];
-export const ReplaceableItemList = /*@__PURE__*/ S.Array(ReplaceableItem);
-
-export interface DeletableItem {
-  ItemName: string;
-  Attributes?: DeletableAttribute[];
-}
-export const DeletableItem = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    ItemName: S.String,
-    Attributes: S.optional(DeletableAttributeList).pipe(
-      T.XmlName("Attribute"),
-      T.XmlFlattened(),
-    ),
-  }),
-).annotate({
-  identifier: "DeletableItem",
-}) as any as S.Schema<DeletableItem>;
-export type DeletableItemList = DeletableItem[];
-export const DeletableItemList = /*@__PURE__*/ S.Array(DeletableItem);
-
-export interface Item {
-  Name: string;
-  AlternateNameEncoding?: string;
-  Attributes?: Attribute[];
-}
-export const Item = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    Name: S.String,
-    AlternateNameEncoding: S.optional(S.String),
-    Attributes: S.optional(AttributeList).pipe(
-      T.XmlName("Attribute"),
-      T.XmlFlattened(),
-    ),
-  }),
-).annotate({
-  identifier: "Item",
-}) as any as S.Schema<Item>;
-export type ItemList = Item[];
-export const ItemList = /*@__PURE__*/ S.Array(Item);
-
-export interface GetAttributesRequest {
-  DomainName: string;
-  ItemName: string;
-  AttributeNames?: string[];
-  ConsistentRead?: boolean;
-}
-export const GetAttributesRequest = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    DomainName: S.String,
-    ItemName: S.String,
-    AttributeNames: S.optional(S.Array(S.String)).pipe(
-      T.XmlName("AttributeName"),
-      T.XmlFlattened(),
-    ),
-    ConsistentRead: S.optional(S.Boolean),
-  }).pipe(
-    T.all(
-      ns,
-      T.Http({ method: "POST", uri: "/" }),
-      svc,
-      auth,
-      proto,
-      ver,
-      rules,
-    ),
-  ),
-).annotate({
-  identifier: "GetAttributesRequest",
-}) as any as S.Schema<GetAttributesRequest>;
-export interface GetAttributesResponse {
-  Attributes?: Attribute[];
-}
-export const GetAttributesResponse = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    // SimpleDB returns a flattened list of repeated <Attribute> elements
-    Attributes: S.optional(AttributeList).pipe(
-      T.XmlName("Attribute"),
-      T.XmlFlattened(),
-    ),
-  }),
-).annotate({
-  identifier: "GetAttributesResponse",
-}) as any as S.Schema<GetAttributesResponse>;
-
 export interface PutAttributesRequest {
   DomainName: string;
   ItemName: string;
@@ -408,105 +507,10 @@ export const PutAttributesRequest = /*@__PURE__*/ S.suspend(() =>
 }) as any as S.Schema<PutAttributesRequest>;
 export interface PutAttributesResponse {}
 export const PutAttributesResponse = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({}),
+  S.Struct({}).pipe(ns),
 ).annotate({
   identifier: "PutAttributesResponse",
 }) as any as S.Schema<PutAttributesResponse>;
-
-export interface DeleteAttributesRequest {
-  DomainName: string;
-  ItemName: string;
-  Attributes?: DeletableAttribute[];
-  Expected?: UpdateCondition;
-}
-export const DeleteAttributesRequest = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    DomainName: S.String,
-    ItemName: S.String,
-    Attributes: S.optional(DeletableAttributeList).pipe(
-      T.XmlName("Attribute"),
-      T.XmlFlattened(),
-    ),
-    Expected: S.optional(UpdateCondition),
-  }).pipe(
-    T.all(
-      ns,
-      T.Http({ method: "POST", uri: "/" }),
-      svc,
-      auth,
-      proto,
-      ver,
-      rules,
-    ),
-  ),
-).annotate({
-  identifier: "DeleteAttributesRequest",
-}) as any as S.Schema<DeleteAttributesRequest>;
-export interface DeleteAttributesResponse {}
-export const DeleteAttributesResponse = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({}),
-).annotate({
-  identifier: "DeleteAttributesResponse",
-}) as any as S.Schema<DeleteAttributesResponse>;
-
-export interface BatchPutAttributesRequest {
-  DomainName: string;
-  Items: ReplaceableItem[];
-}
-export const BatchPutAttributesRequest = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    DomainName: S.String,
-    Items: ReplaceableItemList.pipe(T.XmlName("Item"), T.XmlFlattened()),
-  }).pipe(
-    T.all(
-      ns,
-      T.Http({ method: "POST", uri: "/" }),
-      svc,
-      auth,
-      proto,
-      ver,
-      rules,
-    ),
-  ),
-).annotate({
-  identifier: "BatchPutAttributesRequest",
-}) as any as S.Schema<BatchPutAttributesRequest>;
-export interface BatchPutAttributesResponse {}
-export const BatchPutAttributesResponse = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({}),
-).annotate({
-  identifier: "BatchPutAttributesResponse",
-}) as any as S.Schema<BatchPutAttributesResponse>;
-
-export interface BatchDeleteAttributesRequest {
-  DomainName: string;
-  Items: DeletableItem[];
-}
-export const BatchDeleteAttributesRequest = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    DomainName: S.String,
-    Items: DeletableItemList.pipe(T.XmlName("Item"), T.XmlFlattened()),
-  }).pipe(
-    T.all(
-      ns,
-      T.Http({ method: "POST", uri: "/" }),
-      svc,
-      auth,
-      proto,
-      ver,
-      rules,
-    ),
-  ),
-).annotate({
-  identifier: "BatchDeleteAttributesRequest",
-}) as any as S.Schema<BatchDeleteAttributesRequest>;
-export interface BatchDeleteAttributesResponse {}
-export const BatchDeleteAttributesResponse = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({}),
-).annotate({
-  identifier: "BatchDeleteAttributesResponse",
-}) as any as S.Schema<BatchDeleteAttributesResponse>;
-
 export interface SelectRequest {
   SelectExpression: string;
   NextToken?: string;
@@ -528,282 +532,52 @@ export const SelectRequest = /*@__PURE__*/ S.suspend(() =>
       rules,
     ),
   ),
-).annotate({
-  identifier: "SelectRequest",
-}) as any as S.Schema<SelectRequest>;
+).annotate({ identifier: "SelectRequest" }) as any as S.Schema<SelectRequest>;
+export interface Item {
+  Name: string;
+  AlternateNameEncoding?: string;
+  Attributes?: Attribute[];
+}
+export const Item = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    Name: S.String,
+    AlternateNameEncoding: S.optional(S.String),
+    Attributes: S.optional(AttributeList).pipe(
+      T.XmlName("Attribute"),
+      T.XmlFlattened(),
+    ),
+  }),
+).annotate({ identifier: "Item" }) as any as S.Schema<Item>;
+export type ItemList = Item[];
+export const ItemList = /*@__PURE__*/ S.Array(Item);
 export interface SelectResponse {
   Items?: Item[];
   NextToken?: string;
 }
 export const SelectResponse = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    // SimpleDB returns a flattened list of repeated <Item> elements
     Items: S.optional(ItemList).pipe(T.XmlName("Item"), T.XmlFlattened()),
     NextToken: S.optional(S.String),
-  }),
-).annotate({
-  identifier: "SelectResponse",
-}) as any as S.Schema<SelectResponse>;
+  }).pipe(ns),
+).annotate({ identifier: "SelectResponse" }) as any as S.Schema<SelectResponse>;
+export type BatchDeleteAttributesError = CommonErrors;
+/**
+ * Deletes attributes (or whole items) on up to 25 items in a single call. Idempotent — missing items/attributes are not an error.
+ */
+export const batchDeleteAttributes: API.OperationMethod<
+  BatchDeleteAttributesRequest,
+  BatchDeleteAttributesResponse,
+  BatchDeleteAttributesError,
+  Credentials | Region | HttpClient.HttpClient
+> = /*@__PURE__*/ API.make(() => ({
+  input: BatchDeleteAttributesRequest,
+  output: BatchDeleteAttributesResponse,
+  errors: [],
+  protocol: AwsProtocol,
+  retry: Retry,
+  operationName: "BatchDeleteAttributes",
+}));
 
-//# Errors
-export class NoSuchDomain extends S.TaggedErrorClass<NoSuchDomain>()(
-  "NoSuchDomain",
-  { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
-).pipe(C.withBadRequestError, C.withNotFoundError) {}
-export class InvalidParameterValue extends S.TaggedErrorClass<InvalidParameterValue>()(
-  "InvalidParameterValue",
-  { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
-).pipe(C.withBadRequestError) {}
-export class MissingParameter extends S.TaggedErrorClass<MissingParameter>()(
-  "MissingParameter",
-  { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
-).pipe(C.withBadRequestError) {}
-export class NumberDomainsExceeded extends S.TaggedErrorClass<NumberDomainsExceeded>()(
-  "NumberDomainsExceeded",
-  { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
-).pipe(C.withQuotaError) {}
-export class InvalidNextToken extends S.TaggedErrorClass<InvalidNextToken>()(
-  "InvalidNextToken",
-  { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
-).pipe(C.withBadRequestError) {}
-export class AttributeDoesNotExist extends S.TaggedErrorClass<AttributeDoesNotExist>()(
-  "AttributeDoesNotExist",
-  { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
-).pipe(C.withNotFoundError) {}
-export class DuplicateItemName extends S.TaggedErrorClass<DuplicateItemName>()(
-  "DuplicateItemName",
-  { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
-).pipe(C.withBadRequestError) {}
-export class InvalidNumberPredicates extends S.TaggedErrorClass<InvalidNumberPredicates>()(
-  "InvalidNumberPredicates",
-  { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
-).pipe(C.withBadRequestError) {}
-export class InvalidNumberValueTests extends S.TaggedErrorClass<InvalidNumberValueTests>()(
-  "InvalidNumberValueTests",
-  { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
-).pipe(C.withBadRequestError) {}
-export class InvalidQueryExpression extends S.TaggedErrorClass<InvalidQueryExpression>()(
-  "InvalidQueryExpression",
-  { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
-).pipe(C.withBadRequestError) {}
-export class TooManyRequestedAttributes extends S.TaggedErrorClass<TooManyRequestedAttributes>()(
-  "TooManyRequestedAttributes",
-  { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
-).pipe(C.withBadRequestError) {}
-export class RequestTimeout extends S.TaggedErrorClass<RequestTimeout>()(
-  "RequestTimeout",
-  { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
-).pipe(C.withTimeoutError) {}
-export class NumberDomainAttributesExceeded extends S.TaggedErrorClass<NumberDomainAttributesExceeded>()(
-  "NumberDomainAttributesExceeded",
-  { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
-).pipe(C.withQuotaError) {}
-export class NumberDomainBytesExceeded extends S.TaggedErrorClass<NumberDomainBytesExceeded>()(
-  "NumberDomainBytesExceeded",
-  { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
-).pipe(C.withQuotaError) {}
-export class NumberItemAttributesExceeded extends S.TaggedErrorClass<NumberItemAttributesExceeded>()(
-  "NumberItemAttributesExceeded",
-  { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
-).pipe(C.withQuotaError) {}
-export class NumberSubmittedAttributesExceeded extends S.TaggedErrorClass<NumberSubmittedAttributesExceeded>()(
-  "NumberSubmittedAttributesExceeded",
-  { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
-).pipe(C.withQuotaError) {}
-export class NumberSubmittedItemsExceeded extends S.TaggedErrorClass<NumberSubmittedItemsExceeded>()(
-  "NumberSubmittedItemsExceeded",
-  { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
-).pipe(C.withQuotaError) {}
-
-//# Operations
-export type CreateDomainError =
-  | InvalidParameterValue
-  | MissingParameter
-  | NumberDomainsExceeded
-  | CommonErrors;
-/**
- * Creates a new SimpleDB domain. Idempotent — creating an existing domain
- * succeeds without error.
- */
-export const createDomain: API.OperationMethod<
-  CreateDomainRequest,
-  CreateDomainResponse,
-  CreateDomainError,
-  Credentials | Region | HttpClient.HttpClient
-> = /*@__PURE__*/ API.make(() => ({
-  input: CreateDomainRequest,
-  output: CreateDomainResponse,
-  errors: [InvalidParameterValue, MissingParameter, NumberDomainsExceeded],
-  protocol: AwsProtocol,
-  retry: Retry,
-  operationName: "CreateDomain",
-}));
-export type DeleteDomainError = MissingParameter | CommonErrors;
-/**
- * Deletes a SimpleDB domain and all of its items. Idempotent — deleting a
- * missing domain succeeds without error.
- */
-export const deleteDomain: API.OperationMethod<
-  DeleteDomainRequest,
-  DeleteDomainResponse,
-  DeleteDomainError,
-  Credentials | Region | HttpClient.HttpClient
-> = /*@__PURE__*/ API.make(() => ({
-  input: DeleteDomainRequest,
-  output: DeleteDomainResponse,
-  errors: [MissingParameter],
-  protocol: AwsProtocol,
-  retry: Retry,
-  operationName: "DeleteDomain",
-}));
-export type DomainMetadataError =
-  | MissingParameter
-  | NoSuchDomain
-  | CommonErrors;
-/**
- * Returns information about a SimpleDB domain (item count, sizes, timestamp).
- */
-export const domainMetadata: API.OperationMethod<
-  DomainMetadataRequest,
-  DomainMetadataResponse,
-  DomainMetadataError,
-  Credentials | Region | HttpClient.HttpClient
-> = /*@__PURE__*/ API.make(() => ({
-  input: DomainMetadataRequest,
-  output: DomainMetadataResponse,
-  errors: [MissingParameter, NoSuchDomain],
-  protocol: AwsProtocol,
-  retry: Retry,
-  operationName: "DomainMetadata",
-}));
-export type ListDomainsError =
-  | InvalidNextToken
-  | InvalidParameterValue
-  | CommonErrors;
-/**
- * Lists all SimpleDB domains in the account/region. Paginated.
- */
-type ListDomainsOperation = API.OperationMethod<
-  ListDomainsRequest,
-  ListDomainsResponse,
-  ListDomainsError,
-  Credentials | Region | HttpClient.HttpClient
-> & {
-  pages: (
-    input: ListDomainsRequest,
-  ) => stream.Stream<
-    ListDomainsResponse,
-    ListDomainsError,
-    Credentials | Region | HttpClient.HttpClient
-  >;
-  items: (
-    input: ListDomainsRequest,
-  ) => stream.Stream<
-    string,
-    ListDomainsError,
-    Credentials | Region | HttpClient.HttpClient
-  >;
-};
-export const listDomains: ListDomainsOperation =
-  /*@__PURE__*/ API.makePaginated(() => ({
-    input: ListDomainsRequest,
-    output: ListDomainsResponse,
-    errors: [InvalidNextToken, InvalidParameterValue],
-    protocol: AwsProtocol,
-    retry: Retry,
-    operationName: "ListDomains",
-    pagination: {
-      inputToken: "NextToken",
-      outputToken: "NextToken",
-      items: "DomainNames",
-      pageSize: "MaxNumberOfDomains",
-    } as const,
-  })) as any as ListDomainsOperation;
-export type GetAttributesError =
-  | InvalidParameterValue
-  | MissingParameter
-  | NoSuchDomain
-  | CommonErrors;
-/**
- * Returns all (or the requested subset of) attributes of a SimpleDB item.
- * Reads are eventually consistent unless `ConsistentRead` is set.
- */
-export const getAttributes: API.OperationMethod<
-  GetAttributesRequest,
-  GetAttributesResponse,
-  GetAttributesError,
-  Credentials | Region | HttpClient.HttpClient
-> = /*@__PURE__*/ API.make(() => ({
-  input: GetAttributesRequest,
-  output: GetAttributesResponse,
-  errors: [InvalidParameterValue, MissingParameter, NoSuchDomain],
-  protocol: AwsProtocol,
-  retry: Retry,
-  operationName: "GetAttributes",
-}));
-export type PutAttributesError =
-  | AttributeDoesNotExist
-  | InvalidParameterValue
-  | MissingParameter
-  | NoSuchDomain
-  | NumberDomainAttributesExceeded
-  | NumberDomainBytesExceeded
-  | NumberItemAttributesExceeded
-  | CommonErrors;
-/**
- * Creates or replaces attributes of a SimpleDB item. With `Replace: true` an
- * attribute's existing values are overwritten; otherwise values accumulate.
- */
-export const putAttributes: API.OperationMethod<
-  PutAttributesRequest,
-  PutAttributesResponse,
-  PutAttributesError,
-  Credentials | Region | HttpClient.HttpClient
-> = /*@__PURE__*/ API.make(() => ({
-  input: PutAttributesRequest,
-  output: PutAttributesResponse,
-  errors: [
-    AttributeDoesNotExist,
-    InvalidParameterValue,
-    MissingParameter,
-    NoSuchDomain,
-    NumberDomainAttributesExceeded,
-    NumberDomainBytesExceeded,
-    NumberItemAttributesExceeded,
-  ],
-  protocol: AwsProtocol,
-  retry: Retry,
-  operationName: "PutAttributes",
-}));
-export type DeleteAttributesError =
-  | AttributeDoesNotExist
-  | InvalidParameterValue
-  | MissingParameter
-  | NoSuchDomain
-  | CommonErrors;
-/**
- * Deletes one or more attributes of a SimpleDB item — or the whole item when
- * no attributes are named. Idempotent: deleting a missing attribute/item
- * succeeds.
- */
-export const deleteAttributes: API.OperationMethod<
-  DeleteAttributesRequest,
-  DeleteAttributesResponse,
-  DeleteAttributesError,
-  Credentials | Region | HttpClient.HttpClient
-> = /*@__PURE__*/ API.make(() => ({
-  input: DeleteAttributesRequest,
-  output: DeleteAttributesResponse,
-  errors: [
-    AttributeDoesNotExist,
-    InvalidParameterValue,
-    MissingParameter,
-    NoSuchDomain,
-  ],
-  protocol: AwsProtocol,
-  retry: Retry,
-  operationName: "DeleteAttributes",
-}));
 export type BatchPutAttributesError =
   | DuplicateItemName
   | InvalidParameterValue
@@ -841,24 +615,214 @@ export const batchPutAttributes: API.OperationMethod<
   retry: Retry,
   operationName: "BatchPutAttributes",
 }));
-export type BatchDeleteAttributesError = CommonErrors;
+
+export type CreateDomainError =
+  | InvalidParameterValue
+  | MissingParameter
+  | NumberDomainsExceeded
+  | CommonErrors;
 /**
- * Deletes attributes (or whole items) on up to 25 items in a single call.
- * Idempotent — missing items/attributes are not an error.
+ * Creates a new SimpleDB domain. Idempotent — creating an existing domain succeeds without error.
  */
-export const batchDeleteAttributes: API.OperationMethod<
-  BatchDeleteAttributesRequest,
-  BatchDeleteAttributesResponse,
-  BatchDeleteAttributesError,
+export const createDomain: API.OperationMethod<
+  CreateDomainRequest,
+  CreateDomainResponse,
+  CreateDomainError,
   Credentials | Region | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
-  input: BatchDeleteAttributesRequest,
-  output: BatchDeleteAttributesResponse,
-  errors: [],
+  input: CreateDomainRequest,
+  output: CreateDomainResponse,
+  errors: [InvalidParameterValue, MissingParameter, NumberDomainsExceeded],
   protocol: AwsProtocol,
   retry: Retry,
-  operationName: "BatchDeleteAttributes",
+  operationName: "CreateDomain",
 }));
+
+export type DeleteAttributesError =
+  | AttributeDoesNotExist
+  | InvalidParameterValue
+  | MissingParameter
+  | NoSuchDomain
+  | CommonErrors;
+/**
+ * Deletes one or more attributes of a SimpleDB item — or the whole item when no attributes are named. Idempotent: deleting a missing attribute/item succeeds.
+ */
+export const deleteAttributes: API.OperationMethod<
+  DeleteAttributesRequest,
+  DeleteAttributesResponse,
+  DeleteAttributesError,
+  Credentials | Region | HttpClient.HttpClient
+> = /*@__PURE__*/ API.make(() => ({
+  input: DeleteAttributesRequest,
+  output: DeleteAttributesResponse,
+  errors: [
+    AttributeDoesNotExist,
+    InvalidParameterValue,
+    MissingParameter,
+    NoSuchDomain,
+  ],
+  protocol: AwsProtocol,
+  retry: Retry,
+  operationName: "DeleteAttributes",
+}));
+
+export type DeleteDomainError = MissingParameter | CommonErrors;
+/**
+ * Deletes a SimpleDB domain and all of its items. Idempotent — deleting a missing domain succeeds without error.
+ */
+export const deleteDomain: API.OperationMethod<
+  DeleteDomainRequest,
+  DeleteDomainResponse,
+  DeleteDomainError,
+  Credentials | Region | HttpClient.HttpClient
+> = /*@__PURE__*/ API.make(() => ({
+  input: DeleteDomainRequest,
+  output: DeleteDomainResponse,
+  errors: [MissingParameter],
+  protocol: AwsProtocol,
+  retry: Retry,
+  operationName: "DeleteDomain",
+}));
+
+export type DomainMetadataError =
+  | MissingParameter
+  | NoSuchDomain
+  | CommonErrors;
+/**
+ * Returns information about a SimpleDB domain (item count, sizes, timestamp).
+ */
+export const domainMetadata: API.OperationMethod<
+  DomainMetadataRequest,
+  DomainMetadataResponse,
+  DomainMetadataError,
+  Credentials | Region | HttpClient.HttpClient
+> = /*@__PURE__*/ API.make(() => ({
+  input: DomainMetadataRequest,
+  output: DomainMetadataResponse,
+  errors: [MissingParameter, NoSuchDomain],
+  protocol: AwsProtocol,
+  retry: Retry,
+  operationName: "DomainMetadata",
+}));
+
+export type GetAttributesError =
+  | InvalidParameterValue
+  | MissingParameter
+  | NoSuchDomain
+  | CommonErrors;
+/**
+ * Returns all (or the requested subset of) attributes of a SimpleDB item. Reads are eventually consistent unless `ConsistentRead` is set.
+ */
+export const getAttributes: API.OperationMethod<
+  GetAttributesRequest,
+  GetAttributesResponse,
+  GetAttributesError,
+  Credentials | Region | HttpClient.HttpClient
+> = /*@__PURE__*/ API.make(() => ({
+  input: GetAttributesRequest,
+  output: GetAttributesResponse,
+  errors: [InvalidParameterValue, MissingParameter, NoSuchDomain],
+  protocol: AwsProtocol,
+  retry: Retry,
+  operationName: "GetAttributes",
+}));
+
+export type ListDomainsError =
+  | InvalidNextToken
+  | InvalidParameterValue
+  | CommonErrors;
+/**
+ * Lists all SimpleDB domains in the account/region. Paginated.
+ */
+export const listDomains: API.OperationMethod<
+  ListDomainsRequest,
+  ListDomainsResponse,
+  ListDomainsError,
+  Credentials | Region | HttpClient.HttpClient
+> & {
+  pages: (
+    input: ListDomainsRequest,
+  ) => stream.Stream<
+    ListDomainsResponse,
+    ListDomainsError,
+    Credentials | Region | HttpClient.HttpClient
+  >;
+  items: (
+    input: ListDomainsRequest,
+  ) => stream.Stream<
+    string,
+    ListDomainsError,
+    Credentials | Region | HttpClient.HttpClient
+  >;
+} = /*@__PURE__*/ API.makePaginated(() => ({
+  input: ListDomainsRequest,
+  output: ListDomainsResponse,
+  errors: [InvalidNextToken, InvalidParameterValue],
+  protocol: AwsProtocol,
+  retry: Retry,
+  operationName: "ListDomains",
+  pagination: {
+    inputToken: "NextToken",
+    outputToken: "NextToken",
+    items: "DomainNames",
+    pageSize: "MaxNumberOfDomains",
+  } as const,
+})) as any as API.OperationMethod<
+  ListDomainsRequest,
+  ListDomainsResponse,
+  ListDomainsError,
+  Credentials | Region | HttpClient.HttpClient
+> & {
+  pages: (
+    input: ListDomainsRequest,
+  ) => stream.Stream<
+    ListDomainsResponse,
+    ListDomainsError,
+    Credentials | Region | HttpClient.HttpClient
+  >;
+  items: (
+    input: ListDomainsRequest,
+  ) => stream.Stream<
+    string,
+    ListDomainsError,
+    Credentials | Region | HttpClient.HttpClient
+  >;
+};
+
+export type PutAttributesError =
+  | AttributeDoesNotExist
+  | InvalidParameterValue
+  | MissingParameter
+  | NoSuchDomain
+  | NumberDomainAttributesExceeded
+  | NumberDomainBytesExceeded
+  | NumberItemAttributesExceeded
+  | CommonErrors;
+/**
+ * Creates or replaces attributes of a SimpleDB item. With `Replace: true` an attribute's existing values are overwritten; otherwise values accumulate.
+ */
+export const putAttributes: API.OperationMethod<
+  PutAttributesRequest,
+  PutAttributesResponse,
+  PutAttributesError,
+  Credentials | Region | HttpClient.HttpClient
+> = /*@__PURE__*/ API.make(() => ({
+  input: PutAttributesRequest,
+  output: PutAttributesResponse,
+  errors: [
+    AttributeDoesNotExist,
+    InvalidParameterValue,
+    MissingParameter,
+    NoSuchDomain,
+    NumberDomainAttributesExceeded,
+    NumberDomainBytesExceeded,
+    NumberItemAttributesExceeded,
+  ],
+  protocol: AwsProtocol,
+  retry: Retry,
+  operationName: "PutAttributes",
+}));
+
 export type SelectError =
   | InvalidNextToken
   | InvalidNumberPredicates
@@ -871,10 +835,9 @@ export type SelectError =
   | TooManyRequestedAttributes
   | CommonErrors;
 /**
- * Runs a SimpleDB select expression (`select output_list from domain
- * [where ...]`). Paginated via `NextToken`.
+ * Runs a SimpleDB select expression (`select output_list from domain [where ...]`). Paginated via `NextToken`.
  */
-type SelectOperation = API.OperationMethod<
+export const select: API.OperationMethod<
   SelectRequest,
   SelectResponse,
   SelectError,
@@ -894,8 +857,7 @@ type SelectOperation = API.OperationMethod<
     SelectError,
     Credentials | Region | HttpClient.HttpClient
   >;
-};
-export const select: SelectOperation = /*@__PURE__*/ API.makePaginated(() => ({
+} = /*@__PURE__*/ API.makePaginated(() => ({
   input: SelectRequest,
   output: SelectResponse,
   errors: [
@@ -917,4 +879,24 @@ export const select: SelectOperation = /*@__PURE__*/ API.makePaginated(() => ({
     outputToken: "NextToken",
     items: "Items",
   } as const,
-})) as any as SelectOperation;
+})) as any as API.OperationMethod<
+  SelectRequest,
+  SelectResponse,
+  SelectError,
+  Credentials | Region | HttpClient.HttpClient
+> & {
+  pages: (
+    input: SelectRequest,
+  ) => stream.Stream<
+    SelectResponse,
+    SelectError,
+    Credentials | Region | HttpClient.HttpClient
+  >;
+  items: (
+    input: SelectRequest,
+  ) => stream.Stream<
+    Item,
+    SelectError,
+    Credentials | Region | HttpClient.HttpClient
+  >;
+};


### PR DESCRIPTION
Stacked on #399 — base is `ci/workflows`.

`packages/aws/src/services/simpledb.ts` was the one hand-written service
module in the package. It couldn't be generated because AWS never published
a Smithy model for classic SimpleDB (2009-04-15) — it survives only in
botocore/SDK v2 — and the published `simpledbv2` model covers only the
domain-export migration API, not domain or item operations.

This makes it a model instead, using the same mechanism cloudflare's
`manual-specs/containers.json` already uses.

### The mechanism

`packages/aws/manual-specs/<service>.json` holds a hand-authored Smithy
model. `scripts/generate.ts` compiles it through the identical path as
every published model — same `awsSpec`, same patch chain
(`patches/simpledb.json`), same emitter — so `src/services/simpledb.ts` is
now regenerated output like every other service module. A manual file whose
name collides with a directory in `specs/api-models-aws/models` fails the
run, so the manual copy can never silently shadow a published model.

### Two generator gaps closed first

- **SigV2.** AWS never defined a Smithy trait for it — SigV2 was dead
  before Smithy existed — so the emitter only ever emitted
  `T.AwsAuthSigv4`. The runtime trait already existed (SimpleDB's endpoint
  rejects SigV4 with `AuthFailure`), so this adds the provider-defined
  `aws.auth#sigv2` service trait a model needs to say so.
- **The paginated-operation cast.** #399 added `as any as <Annotation>` to
  the emitter for paginated ops; simpledb previously had it applied by
  hand. Now it comes from the generator.

### Equivalence to the hand-written module

Checked mechanically against the previous file:

- all **37 exported types** identical member-for-member
- all **10 operation configs** byte-identical — input, output, errors,
  `operationName`, `pagination`
- identical **error-category decorators** on all 17 error classes

Three deltas, all of them the generator's house style:

| Delta | Why |
| --- | --- |
| Response schemas now `.pipe(ns)` | Every other awsQuery service does this (sts, cloudformation). The hand-written module was the odd one out. |
| Ten error classes gain `T.HttpError(<code>)` | The status-based fallback every other service carries. Errors whose real status would *change* their category (404 → BadRequest, 409 → Conflict) deliberately carry no `httpError`; their categories come from `patches/simpledb.json` instead, so no decorator changes. |
| `AttributeNameList` is now exported | A named list shape is unavoidable in Smithy. Additive. |

The endpoint resolver compiles from a ruleset to the same function the
hand-written module carried, condition for condition.

`bun run typecheck:ci` is clean; `format:check` is clean.
