### PR TITLE
fix(cloudflare/turnstile): tag a bare 404 as WidgetNotFound

### DIFF
--- a/packages/cloudflare/patches/turnstile/widgetNotFoundBareStatus.manual.json
+++ b/packages/cloudflare/patches/turnstile/widgetNotFoundBareStatus.manual.json
@@ -1,0 +1,10 @@
+{
+  "description": "Turnstile answers a missing widget two different ways. Inside the standard envelope it is `{ success: false, errors: [{ code: 10404 | 10407 }] }`, which the imported matchers already cover. But getWidget/deleteWidget also return a BARE 404 — no envelope, so no error code at all — and that response matched nothing, fell through to the generic HTTP-status class, and surfaced as a `NotFound` that the operation's error union does not even declare. Callers were left testing for CloudflareError + status 404 instead of catching the typed error. A status matcher is only ever consulted among the operation's own declared error classes, and WidgetNotFound is declared by exactly those two operations, so matching 404 there means \"this widget is missing\" and nothing else.",
+  "patches": [
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.turnstile#WidgetNotFound/traits/com.cloudflare.protocols#errorMatchers/-",
+      "value": { "status": 404 }
+    }
+  ]
+}

--- a/packages/cloudflare/src/services/turnstile.ts
+++ b/packages/cloudflare/src/services/turnstile.ts
@@ -40,7 +40,7 @@ export class WidgetNotFound extends T.applyErrorMatchers(
     code: S.Number,
     message: S.String,
   }),
-  [{ code: 10404 }, { code: 10407 }],
+  [{ code: 10404 }, { code: 10407 }, { status: 404 }],
 ) {}
 
 export type WidgetsCreateRequestDirection = "asc" | "desc";


### PR DESCRIPTION
Ports the intent of #303 to v1. That PR is open against the v0 client and
needed runtime changes there; in v1 the runtime already does the right
thing, so this is one line of model data.

### The bug

Turnstile answers a missing widget two different ways:

- inside the standard envelope — `{ success: false, errors: [{ code: 10404 | 10407 }] }` — which the imported matchers already cover; and
- as a **bare 404**, no envelope, so no error code at all.

The bare form matched nothing, fell through to the generic HTTP-status
class, and surfaced as a `NotFound` that the operation's error union does
not declare: `GetWidgetError = WidgetNotFound | Forbidden | CloudflareOpError`,
and `NotFound` is not among core's `DefaultErrors`. So
`catchTag("WidgetNotFound")` never fired on exactly the case the error
exists for, and callers had to test `CloudflareError` + status 404 — which
is what #303's description complains about.

### Why no runtime change is needed

Everything #303 had to build into the v0 client already exists here:

- `ErrorMatcher` already carries `status`, and `code` is already optional
- `matchTypedError` treats a missing code as "don't constrain on code"
- the cloudflare protocol runs per-operation matchers **first**, before the
  envelope/non-JSON split — a non-JSON body just arrives as
  `code: undefined`, `message: <raw text>`

Turnstile's own `Forbidden` is already `{ status: 403 }`, so this is an
established idiom in the patch set, not a new capability.

### Scope

A status matcher is only ever consulted among an operation's own declared
error classes. `WidgetNotFound` is declared by exactly `getWidget` and
`deleteWidget`, so matching 404 there means "this widget is missing" and
nothing else — it cannot leak into another operation.

The patch is `.manual.json` because `patches/turnstile/{get,delete}Widget.json`
are regenerated by `import-distilled-patches.ts`; manual patches apply last
and survive the next import.

Generated diff is one line:

```diff
-  [{ code: 10404 }, { code: 10407 }],
+  [{ code: 10404 }, { code: 10407 }, { status: 404 }],
```

`typecheck:ci` and `format:check` are clean.
