### PR TITLE
fix(aws): make `message` the canonical field on every error class

### DIFF
--- a/packages/aws/scripts/spec.ts
+++ b/packages/aws/scripts/spec.ts
@@ -2120,12 +2120,12 @@ export const awsSpec = (
         const keptMembers = errorPatches
           ? members.filter((m) => !(m.name in errorPatches))
           : members;
-        let fields = keptMembers.length
-          ? `{${keptMembers.map((m) => `${m.name}: ${m.schemaExpr}`).join(", ")}}`
-          : "{}";
+
+        const errorFields: Array<{ name: string; expr: string }> =
+          keptMembers.map((m) => ({ name: m.name, expr: m.schemaExpr }));
 
         if (errorPatches) {
-          const patchedFields: string[] = [];
+          const patchedFields: Array<{ name: string; expr: string }> = [];
           for (const [memberName, patch] of Object.entries(errorPatches)) {
             const traitPipes: string[] = [];
             if (patch.httpHeader) {
@@ -2141,19 +2141,51 @@ export const awsSpec = (
               patch.optional !== false
                 ? `S.optional(${schemaType})`
                 : schemaType;
-            patchedFields.push(
-              `${memberName}: ${
+            patchedFields.push({
+              name: memberName,
+              expr:
                 traitPipes.length > 0
                   ? `${optionalWrapped}.pipe(${traitPipes.join(", ")})`
-                  : optionalWrapped
-              }`,
-            );
+                  : optionalWrapped,
+            });
           }
-          fields =
-            fields === "{}"
-              ? `{${patchedFields.join(", ")}}`
-              : fields.replace(/^\{/, `{${patchedFields.join(", ")}, `);
+          // Patched members lead, matching the previous emission order.
+          errorFields.unshift(...patchedFields);
         }
+
+        // Canonical message member. AWS spells this `message` in most models,
+        // `Message` in the XML-era ones, and omits it entirely from others —
+        // every ec2 error shape declares no members at all. The struct decode
+        // in the response parser drops any key the schema doesn't declare, so
+        // an undeclared message is silently discarded and the caller gets a
+        // typed error carrying nothing (distilled #160).
+        //
+        // Normalize to a single tagged `message` member so `Error.message` is
+        // always the service's real message and consumers never have to know
+        // which spelling a given service used. `Message` is renamed rather
+        // than duplicated — carrying the same text on two properties is what
+        // made the old parser heuristics necessary in the first place. The
+        // response parser folds the `Message` wire key onto `message` before
+        // decoding, so the rename costs nothing on the wire.
+        const messageIdx = errorFields.findIndex((f) => f.name === "message");
+        const capitalIdx = errorFields.findIndex((f) => f.name === "Message");
+        if (messageIdx >= 0) {
+          const f = errorFields[messageIdx]!;
+          f.expr = `${f.expr}.pipe(T.ErrorMessage())`;
+        } else if (capitalIdx >= 0) {
+          const f = errorFields[capitalIdx]!;
+          f.name = "message";
+          f.expr = `${f.expr}.pipe(T.ErrorMessage())`;
+        } else {
+          errorFields.push({
+            name: "message",
+            expr: "S.optional(S.String).pipe(T.ErrorMessage())",
+          });
+        }
+
+        const fields = `{${errorFields
+          .map((f) => `${f.name}: ${f.expr}`)
+          .join(", ")}}`;
 
         const errorTraits = errorShapeIds.get(id);
         const annotations: string[] = [];

--- a/packages/aws/src/client/response-parser.ts
+++ b/packages/aws/src/client/response-parser.ts
@@ -25,6 +25,7 @@ import {
   getHttpHeader,
   getProtocol,
   getSyntheticError,
+  hasErrorMessage,
   type SyntheticErrorTrait,
 } from "../traits.ts";
 import {
@@ -211,8 +212,11 @@ export const makeResponseParser = <A>(
     // Error path
     const { errorCode, data } = yield* protocol.deserializeError(response);
 
-    // Normalize XML-style Message (capital M) to message (lowercase) for Error.message
-    // AWS XML protocols use <Message> but JS Error expects .message
+    // Fold the XML-style `Message` wire key onto `message`. AWS XML protocols
+    // send <Message> while JS expects .message, and the generator names every
+    // error class's canonical message member `message` regardless of which
+    // spelling the service model used — so this is what lets a `Message` wire
+    // key reach the renamed member during decode.
     if (
       data &&
       typeof (data as Record<string, unknown>).Message === "string" &&
@@ -318,16 +322,21 @@ export const makeResponseParser = <A>(
       const decoded = yield* Schema.decodeUnknownEffect(errorSchema)(
         dataWithTag,
       ).pipe(Effect.catch(() => Effect.succeed(dataWithTag)));
-      // Set Error.message from Message (capital M) if the schema uses Message instead of message
-      // AWS XML uses <Message> but JS Error expects .message (lowercase)
-      if (
-        decoded instanceof Error &&
-        !decoded.message &&
-        typeof (decoded as unknown as Record<string, unknown>).Message ===
-          "string"
-      ) {
-        decoded.message = (decoded as unknown as Record<string, unknown>)
-          .Message as string;
+      // Ensure the JS `Error.message` carries the service's message. The
+      // generator tags exactly one member per error class as the canonical
+      // message (T.ErrorMessage) and normalizes its name to `message`, so
+      // this reads the tag rather than guessing by spelling the way the old
+      // `Message`-only fallback did. Without it an error whose class carries
+      // the text in a field the Error constructor didn't pick up stringifies
+      // as a bare tag, which is what made a typed error less useful than the
+      // UnknownAwsError it replaced (distilled #160).
+      if (decoded instanceof Error && !decoded.message) {
+        const record = decoded as unknown as Record<string, unknown>;
+        const canonical = errorProps.find(hasErrorMessage);
+        const value = canonical ? record[String(canonical.name)] : undefined;
+        if (typeof value === "string" && value !== "") {
+          decoded.message = value;
+        }
       }
       return yield* Effect.fail(decoded);
     }

--- a/packages/aws/src/error-message.ts
+++ b/packages/aws/src/error-message.ts
@@ -1,0 +1,31 @@
+/**
+ * The canonical-message trait.
+ *
+ * Lives in its own leaf module rather than in `traits.ts` because `errors.ts`
+ * needs it at module-init time to build the common error classes, and
+ * `traits.ts` imports every protocol, each of which imports `errors.ts` — so
+ * pulling it from there would leave the annotation undefined by the time
+ * `errors.ts` evaluated. This module depends only on the core trait
+ * primitive, so it is safe from either direction. `traits.ts` re-exports it,
+ * which is how generated services reach it as `T.ErrorMessage`, and defines
+ * the `hasErrorMessage` lookup alongside the other annotation getters.
+ */
+import { makeAnnotation } from "@distilled.cloud/core/trait";
+
+/**
+ * distilled trait - marks the member of an error shape that carries the
+ * service's human-readable failure text.
+ *
+ * AWS spells this member inconsistently across services (`message` in most,
+ * `Message` in the XML-era ones) and omits it entirely from some models —
+ * every ec2 error shape declares no members at all. Without a marker the
+ * response parser has to guess by spelling, and a shape that declares no
+ * message member at all silently drops the text on decode, leaving callers a
+ * typed error with nothing in it (distilled #160).
+ *
+ * The generator guarantees exactly one tagged member per error class and
+ * normalizes its name to `message`, so `Error.message` is always the real
+ * message and consumers never have to know which spelling a service used.
+ */
+export const errorMessageSymbol = "distilled-aws/error-message" as const;
+export const ErrorMessage = () => makeAnnotation(errorMessageSymbol, true);

--- a/packages/aws/src/errors.ts
+++ b/packages/aws/src/errors.ts
@@ -1,6 +1,18 @@
 import * as S from "effect/Schema";
 import type * as HttpClientError from "effect/unstable/http/HttpClientError";
 import * as Category from "./category.ts";
+// Imported from the leaf module, not `traits.ts`: that one imports every
+// protocol, and each protocol imports this file, so the annotation would not
+// yet exist when these classes are built. See error-message.ts.
+import * as T from "./error-message.ts";
+
+/**
+ * The canonical message member every error class carries.
+ *
+ * Tagged with `T.ErrorMessage` so the response parser can find the message
+ * without guessing at spelling — see the trait's docs and distilled #160.
+ */
+const ErrorMessage = /*@__PURE__*/ S.optional(S.String).pipe(T.ErrorMessage());
 
 //==== Common AWS Errors ====
 export class AccessDeniedException extends S.TaggedErrorClass<AccessDeniedException>()(
@@ -8,90 +20,90 @@ export class AccessDeniedException extends S.TaggedErrorClass<AccessDeniedExcept
   {
     // AWS explains WHICH action/resource was denied in the message — keep it
     // so callers (and test logs) can see the actual authorization failure.
-    Message: S.optional(S.String),
+    message: ErrorMessage,
   },
 ).pipe(Category.withAuthError) {}
 
 export class ExpiredTokenException extends S.TaggedErrorClass<ExpiredTokenException>()(
   "ExpiredTokenException",
-  {},
+  { message: ErrorMessage },
 ).pipe(Category.withAuthError) {}
 
 export class IncompleteSignature extends S.TaggedErrorClass<IncompleteSignature>()(
   "IncompleteSignature",
-  {},
+  { message: ErrorMessage },
 ).pipe(Category.withAuthError) {}
 
 export class InternalFailure extends S.TaggedErrorClass<InternalFailure>()(
   "InternalFailure",
-  {},
+  { message: ErrorMessage },
 ).pipe(Category.withServerError) {}
 
 export class MalformedHttpRequestException extends S.TaggedErrorClass<MalformedHttpRequestException>()(
   "MalformedHttpRequestException",
-  {},
+  { message: ErrorMessage },
 ).pipe(Category.withBadRequestError) {}
 
 export class NotAuthorized extends S.TaggedErrorClass<NotAuthorized>()(
   "NotAuthorized",
-  {},
+  { message: ErrorMessage },
 ).pipe(Category.withAuthError) {}
 
 export class OptInRequired extends S.TaggedErrorClass<OptInRequired>()(
   "OptInRequired",
-  {},
+  { message: ErrorMessage },
 ).pipe(Category.withAuthError) {}
 
 export class RequestAbortedException extends S.TaggedErrorClass<RequestAbortedException>()(
   "RequestAbortedException",
-  {},
+  { message: ErrorMessage },
 ).pipe(Category.withAbortedError) {}
 
 export class RequestEntityTooLargeException extends S.TaggedErrorClass<RequestEntityTooLargeException>()(
   "RequestEntityTooLargeException",
-  {},
+  { message: ErrorMessage },
 ).pipe(Category.withBadRequestError) {}
 
 export class RequestExpired extends S.TaggedErrorClass<RequestExpired>()(
   "RequestExpired",
-  {},
+  { message: ErrorMessage },
 ).pipe(Category.withBadRequestError, Category.withTimeoutError) {}
 
 export class RequestTimeoutException extends S.TaggedErrorClass<RequestTimeoutException>()(
   "RequestTimeoutException",
-  {},
+  { message: ErrorMessage },
 ).pipe(Category.withTimeoutError) {}
 
 export class ServiceUnavailable extends S.TaggedErrorClass<ServiceUnavailable>()(
   "ServiceUnavailable",
-  {},
+  { message: ErrorMessage },
 ).pipe(Category.withServerError) {}
 
 export class ThrottlingException extends S.TaggedErrorClass<ThrottlingException>()(
   "ThrottlingException",
-  {},
+  { message: ErrorMessage },
 ).pipe(Category.withThrottlingError) {}
 
 export class UnrecognizedClientException extends S.TaggedErrorClass<UnrecognizedClientException>()(
   "UnrecognizedClientException",
-  {},
+  { message: ErrorMessage },
 ).pipe(Category.withAuthError) {}
 
 export class UnknownOperationException extends S.TaggedErrorClass<UnknownOperationException>()(
   "UnknownOperationException",
-  {},
+  { message: ErrorMessage },
 ).pipe(Category.withBadRequestError) {}
 
 export class ValidationError extends S.TaggedErrorClass<ValidationError>()(
   "ValidationError",
-  {},
+  { message: ErrorMessage },
 ).pipe(Category.withBadRequestError) {}
 
 export class ValidationException extends S.TaggedErrorClass<ValidationException>()(
   "ValidationException",
   {
     /** The human-readable validation failure reason from the service. */
-    message: S.optional(S.String),
+    message: ErrorMessage,
     /** Machine-readable reason code (e.g. "FIELD_VALIDATION_FAILED"). */
     reason: S.optional(S.String),
     /** Per-field validation failures, when the service reports them. */
@@ -101,7 +113,7 @@ export class ValidationException extends S.TaggedErrorClass<ValidationException>
 
 export class OperationAborted extends S.TaggedErrorClass<OperationAborted>()(
   "OperationAborted",
-  {},
+  { message: ErrorMessage },
 ).pipe(Category.withAbortedError) {}
 
 export class UnknownAwsError extends S.TaggedErrorClass<UnknownAwsError>()(
@@ -113,7 +125,7 @@ export class UnknownAwsError extends S.TaggedErrorClass<UnknownAwsError>()(
     service: S.optional(S.String),
     /** The operation name (e.g., "createBucket", "putObject") */
     operation: S.optional(S.String),
-    message: S.String,
+    message: S.String.pipe(T.ErrorMessage()),
   },
 ) {}
 
@@ -148,30 +160,30 @@ export const isTransientNetworkError = (err: unknown): boolean => {
 export class TransientFetchError extends S.TaggedErrorClass<TransientFetchError>()(
   "TransientFetchError",
   {
-    message: S.String,
+    message: S.String.pipe(T.ErrorMessage()),
     cause: S.Any,
   },
 ).pipe(Category.withNetworkError) {}
 
 export class InternalError extends S.TaggedErrorClass<InternalError>()(
   "InternalError",
-  {},
+  { message: ErrorMessage },
 ).pipe(Category.withServerError) {}
 
 /** Error when endpoint resolution fails due to a rule error */
 export class EndpointError extends S.TaggedErrorClass<EndpointError>()(
   "EndpointError",
-  { message: S.String },
+  { message: S.String.pipe(T.ErrorMessage()) },
 ).pipe(Category.withServerError) {}
 
 /** Error when no rule matches in the ruleset */
 export class NoMatchingRuleError extends S.TaggedErrorClass<NoMatchingRuleError>()(
   "NoMatchingRuleError",
-  {},
+  { message: ErrorMessage },
 ) {}
 
 export class ParseError extends S.TaggedErrorClass<ParseError>()("ParseError", {
-  message: S.String,
+  message: S.String.pipe(T.ErrorMessage()),
 }) {}
 
 export const COMMON_ERRORS = [

--- a/packages/aws/src/services/accessanalyzer.ts
+++ b/packages/aws/src/services/accessanalyzer.ts
@@ -93,20 +93,24 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.all(T.HttpError(500), T.Retryable()),
@@ -114,26 +118,34 @@ export class InternalServerException
 export class InvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterException>()(
     "InvalidParameterException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.all(T.HttpError(429), T.Retryable({ throttling: true })),
@@ -141,14 +153,14 @@ export class ThrottlingException
 export class UnprocessableEntityException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnprocessableEntityException>()(
     "UnprocessableEntityException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(422), T.Retryable()),
   ).pipe(C.withBadRequestError, C.withRetryableError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.String,
       fieldList: S.optional(
         S.suspend(() => ValidationExceptionFieldList).annotate({

--- a/packages/aws/src/services/account.ts
+++ b/packages/aws/src/services/account.ts
@@ -104,7 +104,7 @@ export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       errorType: S.optional(S.String).pipe(T.HttpHeader("x-amzn-ErrorType")),
     },
     T.HttpError(403),
@@ -113,7 +113,7 @@ export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       errorType: S.optional(S.String).pipe(T.HttpHeader("x-amzn-ErrorType")),
     },
     T.HttpError(409),
@@ -122,7 +122,7 @@ export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       errorType: S.optional(S.String).pipe(T.HttpHeader("x-amzn-ErrorType")),
     },
     T.all(T.HttpError(500), T.Retryable()),
@@ -131,7 +131,7 @@ export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       errorType: S.optional(S.String).pipe(T.HttpHeader("x-amzn-ErrorType")),
     },
     T.HttpError(404),
@@ -140,7 +140,7 @@ export class ResourceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceUnavailableException>()(
     "ResourceUnavailableException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       errorType: S.optional(S.String).pipe(T.HttpHeader("x-amzn-ErrorType")),
     },
     T.HttpError(424),
@@ -149,7 +149,7 @@ export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       errorType: S.optional(S.String).pipe(T.HttpHeader("x-amzn-ErrorType")),
     },
     T.all(T.HttpError(429), T.Retryable({ throttling: true })),
@@ -158,7 +158,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: SensitiveString,
+      message: SensitiveString.pipe(T.ErrorMessage()),
       reason: S.optional(S.String),
       fieldList: S.optional(
         S.suspend(() => ValidationExceptionFieldList).annotate({

--- a/packages/aws/src/services/acm-pca.ts
+++ b/packages/aws/src/services/acm-pca.ts
@@ -91,97 +91,97 @@ const rules = T.EndpointResolver((p, _) => {
 export class CertificateMismatchException
   extends /*@__PURE__*/ S.TaggedErrorClass<CertificateMismatchException>()(
     "CertificateMismatchException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ConcurrentModificationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentModificationException>()(
     "ConcurrentModificationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidArgsException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidArgsException>()(
     "InvalidArgsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidArnException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidArnException>()(
     "InvalidArnException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidNextTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNextTokenException>()(
     "InvalidNextTokenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidPolicyException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPolicyException>()(
     "InvalidPolicyException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidStateException>()(
     "InvalidStateException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTagException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTagException>()(
     "InvalidTagException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LockoutPreventedException
   extends /*@__PURE__*/ S.TaggedErrorClass<LockoutPreventedException>()(
     "LockoutPreventedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MalformedCertificateException
   extends /*@__PURE__*/ S.TaggedErrorClass<MalformedCertificateException>()(
     "MalformedCertificateException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MalformedCSRException
   extends /*@__PURE__*/ S.TaggedErrorClass<MalformedCSRException>()(
     "MalformedCSRException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class PermissionAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<PermissionAlreadyExistsException>()(
     "PermissionAlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class RequestAlreadyProcessedException
   extends /*@__PURE__*/ S.TaggedErrorClass<RequestAlreadyProcessedException>()(
     "RequestAlreadyProcessedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class RequestFailedException
   extends /*@__PURE__*/ S.TaggedErrorClass<RequestFailedException>()(
     "RequestFailedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class RequestInProgressException
   extends /*@__PURE__*/ S.TaggedErrorClass<RequestInProgressException>()(
     "RequestInProgressException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type KeyAlgorithm =
   | "RSA_2048"

--- a/packages/aws/src/services/acm.ts
+++ b/packages/aws/src/services/acm.ts
@@ -93,7 +93,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "AccessDenied", httpResponseCode: 403 }),
       T.HttpError(403),
@@ -102,68 +102,68 @@ export class AccessDeniedException
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidArgsException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidArgsException>()(
     "InvalidArgsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidArnException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidArnException>()(
     "InvalidArnException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidDomainValidationOptionsException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDomainValidationOptionsException>()(
     "InvalidDomainValidationOptionsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterException>()(
     "InvalidParameterException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidStateException>()(
     "InvalidStateException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTagException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTagException>()(
     "InvalidTagException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withQuotaError) {}
 export class RequestInProgressException
   extends /*@__PURE__*/ S.TaggedErrorClass<RequestInProgressException>()(
     "RequestInProgressException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withConflictError, C.withRetryableError) {}
 export class ResourceInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUseException>()(
     "ResourceInUseException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TagPolicyException
   extends /*@__PURE__*/ S.TaggedErrorClass<TagPolicyException>()(
     "TagPolicyException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       throttlingReasons: S.optional(
         S.suspend(() => ThrottlingReasonList).annotate({
           identifier: "ThrottlingReasonList",
@@ -178,12 +178,12 @@ export class ThrottlingException
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ValidationError", httpResponseCode: 400 }),
       T.HttpError(400),

--- a/packages/aws/src/services/aiops.ts
+++ b/packages/aws/src/services/aiops.ts
@@ -87,32 +87,32 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceType: S.optional(S.String),
       serviceCode: S.optional(S.String),
@@ -123,18 +123,18 @@ export class ServiceQuotaExceededException
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class UnauthorizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnauthorizedException>()(
     "UnauthorizedException",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAuthError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type StringWithPatternAndLengthLimits = string;

--- a/packages/aws/src/services/amp.ts
+++ b/packages/aws/src/services/amp.ts
@@ -88,20 +88,24 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.all(T.HttpError(500), T.Retryable()),
@@ -109,14 +113,18 @@ export class InternalServerException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.String,
       resourceType: S.String,
       serviceCode: S.String,
@@ -128,7 +136,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       serviceCode: S.optional(S.String),
       quotaCode: S.optional(S.String),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
@@ -139,7 +147,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.String,
       fieldList: S.optional(
         S.suspend(() => ValidationExceptionFieldList).annotate({

--- a/packages/aws/src/services/amplify.ts
+++ b/packages/aws/src/services/amplify.ts
@@ -88,48 +88,48 @@ const rules = T.EndpointResolver((p, _) => {
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class DependentServiceFailureException
   extends /*@__PURE__*/ S.TaggedErrorClass<DependentServiceFailureException>()(
     "DependentServiceFailureException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class InternalFailureException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalFailureException>()(
     "InternalFailureException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { code: S.String, message: S.String },
+    { code: S.String, message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class TimeoutException
   extends /*@__PURE__*/ S.TaggedErrorClass<TimeoutException>()(
     "TimeoutException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class UnauthorizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnauthorizedException>()(
     "UnauthorizedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export type Name = string;

--- a/packages/aws/src/services/amplifybackend.ts
+++ b/packages/aws/src/services/amplifybackend.ts
@@ -87,25 +87,31 @@ const rules = T.EndpointResolver((p, _) => {
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class GatewayTimeoutException
   extends /*@__PURE__*/ S.TaggedErrorClass<GatewayTimeoutException>()(
     "GatewayTimeoutException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(504),
   ).pipe(C.withTimeoutError) {}
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { Message: S.optional(S.String), ResourceType: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ResourceType: S.optional(S.String),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { LimitType: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      LimitType: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export interface CloneBackendRequest {

--- a/packages/aws/src/services/amplifyuibuilder.ts
+++ b/packages/aws/src/services/amplifyuibuilder.ts
@@ -90,43 +90,43 @@ const rules = T.EndpointResolver((p, _) => {
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterException>()(
     "InvalidParameterException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceConflictException>()(
     "ResourceConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class UnauthorizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnauthorizedException>()(
     "UnauthorizedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export type ComponentName = string;

--- a/packages/aws/src/services/api-gateway.ts
+++ b/packages/aws/src/services/api-gateway.ts
@@ -90,13 +90,13 @@ const rules = T.EndpointResolver((p, _) => {
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class LimitExceededException
@@ -104,14 +104,14 @@ export class LimitExceededException
     "LimitExceededException",
     {
       retryAfterSeconds: S.optional(S.String).pipe(T.HttpHeader("Retry-After")),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceUnavailableException
@@ -119,7 +119,7 @@ export class ServiceUnavailableException
     "ServiceUnavailableException",
     {
       retryAfterSeconds: S.optional(S.String).pipe(T.HttpHeader("Retry-After")),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
@@ -128,14 +128,14 @@ export class TooManyRequestsException
     "TooManyRequestsException",
     {
       retryAfterSeconds: S.optional(S.String).pipe(T.HttpHeader("Retry-After")),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class UnauthorizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnauthorizedException>()(
     "UnauthorizedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export interface StageKey {

--- a/packages/aws/src/services/apigatewaymanagementapi.ts
+++ b/packages/aws/src/services/apigatewaymanagementapi.ts
@@ -87,25 +87,25 @@ const rules = T.EndpointResolver((p, _) => {
 export class ForbiddenException
   extends /*@__PURE__*/ S.TaggedErrorClass<ForbiddenException>()(
     "ForbiddenException",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class GoneException
   extends /*@__PURE__*/ S.TaggedErrorClass<GoneException>()(
     "GoneException",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(410),
   ).pipe(C.withBadRequestError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class PayloadTooLargeException
   extends /*@__PURE__*/ S.TaggedErrorClass<PayloadTooLargeException>()(
     "PayloadTooLargeException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(413),
   ).pipe(C.withBadRequestError) {}
 export interface DeleteConnectionRequest {

--- a/packages/aws/src/services/apigatewayv2.ts
+++ b/packages/aws/src/services/apigatewayv2.ts
@@ -88,31 +88,37 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { Message: S.optional(S.String), ResourceType: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ResourceType: S.optional(S.String),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { LimitType: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      LimitType: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export type SelectionExpression = string;

--- a/packages/aws/src/services/app-mesh.ts
+++ b/packages/aws/src/services/app-mesh.ts
@@ -85,61 +85,61 @@ const rules = T.EndpointResolver((p, _) => {
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ForbiddenException
   extends /*@__PURE__*/ S.TaggedErrorClass<ForbiddenException>()(
     "ForbiddenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class InternalServerErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerErrorException>()(
     "InternalServerErrorException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ResourceInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUseException>()(
     "ResourceInUseException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(503), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(429), T.Retryable({ throttling: true })),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type ResourceName = string;

--- a/packages/aws/src/services/appconfig.ts
+++ b/packages/aws/src/services/appconfig.ts
@@ -97,7 +97,7 @@ export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => BadRequestReason).annotate({
           identifier: "BadRequestReason",
@@ -114,20 +114,20 @@ export class BadRequestException
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class PayloadTooLargeException
   extends /*@__PURE__*/ S.TaggedErrorClass<PayloadTooLargeException>()(
     "PayloadTooLargeException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Measure: S.optional(
         S.suspend(() => BytesMeasure).annotate({ identifier: "BytesMeasure" }),
       ),
@@ -139,13 +139,16 @@ export class PayloadTooLargeException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String), ResourceName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ResourceName: S.optional(S.String),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export type Name = string;

--- a/packages/aws/src/services/appconfigdata.ts
+++ b/packages/aws/src/services/appconfigdata.ts
@@ -91,7 +91,7 @@ export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Reason: S.optional(S.String),
       Details: S.optional(
         S.suspend(() => BadRequestDetails).annotate({
@@ -104,14 +104,14 @@ export class BadRequestException
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       ResourceType: S.optional(S.String),
       ReferencedBy: S.optional(
         S.suspend(() => StringMap).annotate({ identifier: "StringMap" }),
@@ -122,7 +122,7 @@ export class ResourceNotFoundException
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export type Token = string;

--- a/packages/aws/src/services/appfabric.ts
+++ b/packages/aws/src/services/appfabric.ts
@@ -90,20 +90,24 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.all(T.HttpError(500), T.Retryable()),
@@ -111,14 +115,18 @@ export class InternalServerException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.String,
       resourceType: S.String,
       serviceCode: S.String,
@@ -130,7 +138,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       serviceCode: S.optional(S.String),
       quotaCode: S.optional(S.String),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
@@ -141,7 +149,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.suspend(() => ValidationExceptionReason).annotate({
         identifier: "ValidationExceptionReason",
       }),

--- a/packages/aws/src/services/appflow.ts
+++ b/packages/aws/src/services/appflow.ts
@@ -90,61 +90,61 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ConnectorAuthenticationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConnectorAuthenticationException>()(
     "ConnectorAuthenticationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export class ConnectorServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConnectorServerException>()(
     "ConnectorServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class UnsupportedOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedOperationException>()(
     "UnsupportedOperationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type FlowName = string;

--- a/packages/aws/src/services/appintegrations.ts
+++ b/packages/aws/src/services/appintegrations.ts
@@ -88,54 +88,54 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class DuplicateResourceException
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicateResourceException>()(
     "DuplicateResourceException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServiceError
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServiceError>()(
     "InternalServiceError",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ResourceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceQuotaExceededException>()(
     "ResourceQuotaExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class UnsupportedOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedOperationException>()(
     "UnsupportedOperationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type ApplicationName = string;

--- a/packages/aws/src/services/application-auto-scaling.ts
+++ b/packages/aws/src/services/application-auto-scaling.ts
@@ -93,7 +93,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class ConcurrentUpdateException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentUpdateException>()(
     "ConcurrentUpdateException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ConcurrentUpdateException",
@@ -105,7 +105,7 @@ export class ConcurrentUpdateException
 export class FailedResourceAccessException
   extends /*@__PURE__*/ S.TaggedErrorClass<FailedResourceAccessException>()(
     "FailedResourceAccessException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "FailedResourceAccessException",
@@ -117,7 +117,7 @@ export class FailedResourceAccessException
 export class InternalServiceException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServiceException>()(
     "InternalServiceException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InternalServiceException",
@@ -129,7 +129,7 @@ export class InternalServiceException
 export class InvalidNextTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNextTokenException>()(
     "InvalidNextTokenException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidNextTokenException",
@@ -141,7 +141,7 @@ export class InvalidNextTokenException
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "LimitExceededException",
@@ -153,7 +153,7 @@ export class LimitExceededException
 export class ObjectNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ObjectNotFoundException>()(
     "ObjectNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ObjectNotFoundException",
@@ -165,7 +165,7 @@ export class ObjectNotFoundException
 export class PredictiveScalingForecastNotSupported
   extends /*@__PURE__*/ S.TaggedErrorClass<PredictiveScalingForecastNotSupported>()(
     "PredictiveScalingForecastNotSupported",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "AccessDeniedException",
       message: { includes: "GetPredictiveScalingForecast is not supported" },
@@ -174,19 +174,25 @@ export class PredictiveScalingForecastNotSupported
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String), ResourceName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ResourceName: S.optional(S.String),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { Message: S.optional(S.String), ResourceName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ResourceName: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ValidationException", httpResponseCode: 400 }),
       T.HttpError(400),

--- a/packages/aws/src/services/application-discovery-service.ts
+++ b/packages/aws/src/services/application-discovery-service.ts
@@ -89,61 +89,61 @@ const rules = T.EndpointResolver((p, _) => {
 export class AuthorizationErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<AuthorizationErrorException>()(
     "AuthorizationErrorException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictErrorException>()(
     "ConflictErrorException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class HomeRegionNotSetException
   extends /*@__PURE__*/ S.TaggedErrorClass<HomeRegionNotSetException>()(
     "HomeRegionNotSetException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterException>()(
     "InvalidParameterException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidParameterValueException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterValueException>()(
     "InvalidParameterValueException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class OperationNotPermittedException
   extends /*@__PURE__*/ S.TaggedErrorClass<OperationNotPermittedException>()(
     "OperationNotPermittedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ResourceInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUseException>()(
     "ResourceInUseException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ServerInternalErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServerInternalErrorException>()(
     "ServerInternalErrorException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export type ApplicationId = string;

--- a/packages/aws/src/services/application-insights.ts
+++ b/packages/aws/src/services/application-insights.ts
@@ -88,7 +88,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "AccessDeniedException", httpResponseCode: 403 }),
       T.HttpError(403),
@@ -97,7 +97,7 @@ export class AccessDeniedException
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "BadRequestException", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -106,7 +106,7 @@ export class BadRequestException
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InternalServerException",
@@ -118,7 +118,7 @@ export class InternalServerException
 export class ResourceInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUseException>()(
     "ResourceInUseException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ResourceInUseException",
@@ -130,7 +130,7 @@ export class ResourceInUseException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ResourceNotFoundException",
@@ -142,19 +142,22 @@ export class ResourceNotFoundException
 export class TagsAlreadyExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<TagsAlreadyExistException>()(
     "TagsAlreadyExistException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { Message: S.optional(S.String), ResourceName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ResourceName: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ValidationException", httpResponseCode: 400 }),
       T.HttpError(400),

--- a/packages/aws/src/services/application-signals.ts
+++ b/packages/aws/src/services/application-signals.ts
@@ -55,7 +55,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "AccessDenied", httpResponseCode: 403 }),
       T.HttpError(403),
@@ -64,31 +64,35 @@ export class AccessDeniedException
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { ResourceType: S.String, ResourceId: S.String, Message: S.String },
+    {
+      ResourceType: S.String,
+      ResourceId: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ValidationError", httpResponseCode: 400 }),
       T.HttpError(400),

--- a/packages/aws/src/services/applicationcostprofiler.ts
+++ b/packages/aws/src/services/applicationcostprofiler.ts
@@ -88,31 +88,31 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type ReportId = string;

--- a/packages/aws/src/services/apprunner.ts
+++ b/packages/aws/src/services/apprunner.ts
@@ -91,7 +91,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class InternalServiceErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServiceErrorException>()(
     "InternalServiceErrorException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InternalServiceError", httpResponseCode: 500 }),
       T.HttpError(500),
@@ -100,7 +100,7 @@ export class InternalServiceErrorException
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidRequest", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -109,7 +109,7 @@ export class InvalidRequestException
 export class InvalidStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidStateException>()(
     "InvalidStateException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidState", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -118,7 +118,7 @@ export class InvalidStateException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ResourceNotfound", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -127,7 +127,7 @@ export class ResourceNotFoundException
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ServiceQuotaExceeded", httpResponseCode: 402 }),
       T.HttpError(402),

--- a/packages/aws/src/services/appstream.ts
+++ b/packages/aws/src/services/appstream.ts
@@ -96,91 +96,91 @@ const rules = T.EndpointResolver((p, _) => {
 export class ConcurrentModificationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentModificationException>()(
     "ConcurrentModificationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class DryRunOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<DryRunOperationException>()(
     "DryRunOperationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(412),
   ) {}
 export class EntitlementAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<EntitlementAlreadyExistsException>()(
     "EntitlementAlreadyExistsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError, C.withAlreadyExistsError) {}
 export class EntitlementNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<EntitlementNotFoundException>()(
     "EntitlementNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class IncompatibleImageException
   extends /*@__PURE__*/ S.TaggedErrorClass<IncompatibleImageException>()(
     "IncompatibleImageException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidAccountStatusException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidAccountStatusException>()(
     "InvalidAccountStatusException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidParameterCombinationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterCombinationException>()(
     "InvalidParameterCombinationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidRoleException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRoleException>()(
     "InvalidRoleException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class OperationNotPermittedException
   extends /*@__PURE__*/ S.TaggedErrorClass<OperationNotPermittedException>()(
     "OperationNotPermittedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class RequestLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<RequestLimitExceededException>()(
     "RequestLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceAlreadyExistsException>()(
     "ResourceAlreadyExistsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError, C.withAlreadyExistsError) {}
 export class ResourceInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUseException>()(
     "ResourceInUseException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotAvailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotAvailableException>()(
     "ResourceNotAvailableException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export type Arn = string;

--- a/packages/aws/src/services/appsync.ts
+++ b/packages/aws/src/services/appsync.ts
@@ -89,32 +89,32 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ApiKeyLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ApiKeyLimitExceededException>()(
     "ApiKeyLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ApiKeyValidityOutOfBoundsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ApiKeyValidityOutOfBoundsException>()(
     "ApiKeyValidityOutOfBoundsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ApiLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ApiLimitExceededException>()(
     "ApiLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       reason: S.optional(
         S.suspend(() => BadRequestReason).annotate({
           identifier: "BadRequestReason",
@@ -131,49 +131,49 @@ export class BadRequestException
 export class ConcurrentModificationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentModificationException>()(
     "ConcurrentModificationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class GraphQLSchemaException
   extends /*@__PURE__*/ S.TaggedErrorClass<GraphQLSchemaException>()(
     "GraphQLSchemaException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InternalFailureException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalFailureException>()(
     "InternalFailureException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class UnauthorizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnauthorizedException>()(
     "UnauthorizedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export type DomainName = string;

--- a/packages/aws/src/services/arc-region-switch.ts
+++ b/packages/aws/src/services/arc-region-switch.ts
@@ -132,31 +132,31 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class IllegalArgumentException
   extends /*@__PURE__*/ S.TaggedErrorClass<IllegalArgumentException>()(
     "IllegalArgumentException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class IllegalStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<IllegalStateException>()(
     "IllegalStateException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export type PlanArn = string;

--- a/packages/aws/src/services/arc-zonal-shift.ts
+++ b/packages/aws/src/services/arc-zonal-shift.ts
@@ -88,14 +88,14 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.suspend(() => ConflictExceptionReason).annotate({
         identifier: "ConflictExceptionReason",
       }),
@@ -106,26 +106,26 @@ export class ConflictException
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.suspend(() => ValidationExceptionReason).annotate({
         identifier: "ValidationExceptionReason",
       }),

--- a/packages/aws/src/services/artifact.ts
+++ b/packages/aws/src/services/artifact.ts
@@ -104,20 +104,24 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.all(T.HttpError(500), T.Retryable()),
@@ -125,14 +129,18 @@ export class InternalServerException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.String,
       resourceType: S.String,
       serviceCode: S.String,
@@ -144,7 +152,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       serviceCode: S.optional(S.String),
       quotaCode: S.optional(S.String),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
@@ -155,7 +163,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.String,
       fieldList: S.optional(
         S.suspend(() => ValidationExceptionFieldList).annotate({

--- a/packages/aws/src/services/athena.ts
+++ b/packages/aws/src/services/athena.ts
@@ -88,7 +88,10 @@ const rules = T.EndpointResolver((p, _) => {
 export class DataCatalogNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<DataCatalogNotFound>()(
     "DataCatalogNotFound",
-    { AthenaErrorCode: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      AthenaErrorCode: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.SyntheticError({
       from: "InvalidRequestException",
       message: { matches: "DataCatalog.*not found" },
@@ -97,22 +100,28 @@ export class DataCatalogNotFound
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
-    { AthenaErrorCode: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      AthenaErrorCode: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
   ) {}
 export class MetadataException
   extends /*@__PURE__*/ S.TaggedErrorClass<MetadataException>()(
     "MetadataException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NamedQueryNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<NamedQueryNotFound>()(
     "NamedQueryNotFound",
-    { AthenaErrorCode: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      AthenaErrorCode: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.SyntheticError({
       from: "InvalidRequestException",
       message: { matches: "NamedQuery.*does not exist" },
@@ -121,18 +130,21 @@ export class NamedQueryNotFound
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String), ResourceName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ResourceName: S.optional(S.String),
+    },
   ) {}
 export class SessionAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<SessionAlreadyExistsException>()(
     "SessionAlreadyExistsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => ThrottleReason).annotate({
           identifier: "ThrottleReason",
@@ -143,7 +155,10 @@ export class TooManyRequestsException
 export class WorkGroupNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<WorkGroupNotFound>()(
     "WorkGroupNotFound",
-    { AthenaErrorCode: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      AthenaErrorCode: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.SyntheticError({
       from: "InvalidRequestException",
       message: { matches: "WorkGroup.*not found" },

--- a/packages/aws/src/services/auditmanager.ts
+++ b/packages/aws/src/services/auditmanager.ts
@@ -90,14 +90,14 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class AuditManagerMaintenanceMode
   extends /*@__PURE__*/ S.TaggedErrorClass<AuditManagerMaintenanceMode>()(
     "AuditManagerMaintenanceMode",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.optional(
         S.suspend(() => ValidationExceptionReason).annotate({
           identifier: "ValidationExceptionReason",
@@ -117,32 +117,36 @@ export class AuditManagerMaintenanceMode
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.optional(
         S.suspend(() => ValidationExceptionReason).annotate({
           identifier: "ValidationExceptionReason",

--- a/packages/aws/src/services/auto-scaling-plans.ts
+++ b/packages/aws/src/services/auto-scaling-plans.ts
@@ -93,7 +93,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class ConcurrentUpdateException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentUpdateException>()(
     "ConcurrentUpdateException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ConcurrentUpdateException",
@@ -105,7 +105,7 @@ export class ConcurrentUpdateException
 export class InternalServiceException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServiceException>()(
     "InternalServiceException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InternalServiceException",
@@ -117,7 +117,7 @@ export class InternalServiceException
 export class InvalidNextTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNextTokenException>()(
     "InvalidNextTokenException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidNextTokenException",
@@ -129,7 +129,7 @@ export class InvalidNextTokenException
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "LimitExceededException",
@@ -141,7 +141,7 @@ export class LimitExceededException
 export class ObjectNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ObjectNotFoundException>()(
     "ObjectNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ObjectNotFoundException",
@@ -153,7 +153,7 @@ export class ObjectNotFoundException
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ValidationException", httpResponseCode: 400 }),
       T.HttpError(400),

--- a/packages/aws/src/services/auto-scaling.ts
+++ b/packages/aws/src/services/auto-scaling.ts
@@ -92,7 +92,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class ActiveInstanceRefreshNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ActiveInstanceRefreshNotFoundFault>()(
     "ActiveInstanceRefreshNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ActiveInstanceRefreshNotFound",
@@ -104,7 +104,7 @@ export class ActiveInstanceRefreshNotFoundFault
 export class AlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<AlreadyExistsFault>()(
     "AlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "AlreadyExists", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -113,7 +113,7 @@ export class AlreadyExistsFault
 export class AutoScalingGroupNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<AutoScalingGroupNotFound>()(
     "AutoScalingGroupNotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "ValidationError",
       message: { includes: "not found" },
@@ -122,7 +122,7 @@ export class AutoScalingGroupNotFound
 export class IdempotentParameterMismatchError
   extends /*@__PURE__*/ S.TaggedErrorClass<IdempotentParameterMismatchError>()(
     "IdempotentParameterMismatchError",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "IdempotentParameterMismatch",
@@ -134,7 +134,7 @@ export class IdempotentParameterMismatchError
 export class InstanceRefreshInProgressFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InstanceRefreshInProgressFault>()(
     "InstanceRefreshInProgressFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InstanceRefreshInProgress",
@@ -146,7 +146,7 @@ export class InstanceRefreshInProgressFault
 export class InvalidNextToken
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNextToken>()(
     "InvalidNextToken",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidNextToken", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -155,7 +155,7 @@ export class InvalidNextToken
 export class IrreversibleInstanceRefreshFault
   extends /*@__PURE__*/ S.TaggedErrorClass<IrreversibleInstanceRefreshFault>()(
     "IrreversibleInstanceRefreshFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "IrreversibleInstanceRefresh",
@@ -167,7 +167,7 @@ export class IrreversibleInstanceRefreshFault
 export class LimitExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededFault>()(
     "LimitExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "LimitExceeded", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -176,7 +176,7 @@ export class LimitExceededFault
 export class ResourceContentionFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceContentionFault>()(
     "ResourceContentionFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ResourceContention", httpResponseCode: 500 }),
       T.HttpError(500),
@@ -185,7 +185,7 @@ export class ResourceContentionFault
 export class ResourceInUseFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUseFault>()(
     "ResourceInUseFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ResourceInUse", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -194,7 +194,7 @@ export class ResourceInUseFault
 export class ScalingActivityInProgressFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ScalingActivityInProgressFault>()(
     "ScalingActivityInProgressFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ScalingActivityInProgress",
@@ -206,7 +206,7 @@ export class ScalingActivityInProgressFault
 export class ServiceLinkedRoleFailure
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceLinkedRoleFailure>()(
     "ServiceLinkedRoleFailure",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ServiceLinkedRoleFailure",

--- a/packages/aws/src/services/b2bi.ts
+++ b/packages/aws/src/services/b2bi.ts
@@ -87,20 +87,20 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.all(T.HttpError(500), T.Retryable()),
@@ -108,14 +108,14 @@ export class InternalServerException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.String,
       resourceType: S.String,
       serviceCode: S.String,
@@ -127,7 +127,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.all(T.HttpError(429), T.Retryable()),
@@ -135,7 +135,7 @@ export class ThrottlingException
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type CapabilityName = string;

--- a/packages/aws/src/services/backup-gateway.ts
+++ b/packages/aws/src/services/backup-gateway.ts
@@ -90,19 +90,28 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { ErrorCode: S.String, Message: S.optional(S.String) },
+    {
+      ErrorCode: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { ErrorCode: S.String, Message: S.optional(S.String) },
+    {
+      ErrorCode: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { ErrorCode: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      ErrorCode: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export type GatewayArn = string;

--- a/packages/aws/src/services/backup.ts
+++ b/packages/aws/src/services/backup.ts
@@ -92,7 +92,7 @@ export class AlreadyExistsException
     "AlreadyExistsException",
     {
       Code: S.optional(S.String),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       CreatorRequestId: S.optional(S.String),
       Arn: S.optional(S.String),
       Type: S.optional(S.String),
@@ -104,7 +104,7 @@ export class ConflictException
     "ConflictException",
     {
       Code: S.optional(S.String),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Type: S.optional(S.String),
       Context: S.optional(S.String),
     },
@@ -118,7 +118,7 @@ export class DependencyFailureException
     "DependencyFailureException",
     {
       Code: S.optional(S.String),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Type: S.optional(S.String),
       Context: S.optional(S.String),
     },
@@ -128,7 +128,7 @@ export class InvalidParameterValueException
     "InvalidParameterValueException",
     {
       Code: S.optional(S.String),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Type: S.optional(S.String),
       Context: S.optional(S.String),
     },
@@ -138,7 +138,7 @@ export class InvalidRequestException
     "InvalidRequestException",
     {
       Code: S.optional(S.String),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Type: S.optional(S.String),
       Context: S.optional(S.String),
     },
@@ -148,7 +148,7 @@ export class InvalidResourceStateException
     "InvalidResourceStateException",
     {
       Code: S.optional(S.String),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Type: S.optional(S.String),
       Context: S.optional(S.String),
     },
@@ -158,7 +158,7 @@ export class LimitExceededException
     "LimitExceededException",
     {
       Code: S.optional(S.String),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Type: S.optional(S.String),
       Context: S.optional(S.String),
     },
@@ -168,7 +168,7 @@ export class MissingParameterValueException
     "MissingParameterValueException",
     {
       Code: S.optional(S.String),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Type: S.optional(S.String),
       Context: S.optional(S.String),
     },
@@ -178,7 +178,7 @@ export class ResourceNotFoundException
     "ResourceNotFoundException",
     {
       Code: S.optional(S.String),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Type: S.optional(S.String),
       Context: S.optional(S.String),
     },
@@ -188,7 +188,7 @@ export class ServiceUnavailableException
     "ServiceUnavailableException",
     {
       Code: S.optional(S.String),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Type: S.optional(S.String),
       Context: S.optional(S.String),
     },

--- a/packages/aws/src/services/backupsearch.ts
+++ b/packages/aws/src/services/backupsearch.ts
@@ -57,20 +57,28 @@ const rules = T.EndpointResolver((p, _) => {
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.String,
       resourceType: S.String,
       serviceCode: S.String,

--- a/packages/aws/src/services/batch.ts
+++ b/packages/aws/src/services/batch.ts
@@ -95,13 +95,13 @@ const rules = T.EndpointResolver((p, _) => {
 export class ClientException
   extends /*@__PURE__*/ S.TaggedErrorClass<ClientException>()(
     "ClientException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ComputeEnvironmentBeingModified
   extends /*@__PURE__*/ S.TaggedErrorClass<ComputeEnvironmentBeingModified>()(
     "ComputeEnvironmentBeingModified",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "ClientException",
       message: { includes: "is being modified" },
@@ -110,7 +110,7 @@ export class ComputeEnvironmentBeingModified
 export class ComputeEnvironmentInUse
   extends /*@__PURE__*/ S.TaggedErrorClass<ComputeEnvironmentInUse>()(
     "ComputeEnvironmentInUse",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "ClientException",
       message: { includes: "found existing JobQueue relationship" },
@@ -119,7 +119,7 @@ export class ComputeEnvironmentInUse
 export class ComputeEnvironmentNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<ComputeEnvironmentNotFound>()(
     "ComputeEnvironmentNotFound",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "ClientException",
       message: { matches: "compute-environment/.* does not exist" },
@@ -128,7 +128,7 @@ export class ComputeEnvironmentNotFound
 export class ComputeEnvironmentNotValid
   extends /*@__PURE__*/ S.TaggedErrorClass<ComputeEnvironmentNotValid>()(
     "ComputeEnvironmentNotValid",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "ClientException",
       message: { matches: "must be (created and )?valid before attaching" },
@@ -137,7 +137,7 @@ export class ComputeEnvironmentNotValid
 export class JobQueueAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<JobQueueAlreadyExists>()(
     "JobQueueAlreadyExists",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "ClientException",
       message: { includes: "already exists" },
@@ -146,7 +146,7 @@ export class JobQueueAlreadyExists
 export class JobQueueBeingModified
   extends /*@__PURE__*/ S.TaggedErrorClass<JobQueueBeingModified>()(
     "JobQueueBeingModified",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "ClientException",
       message: { includes: "is being modified" },
@@ -155,7 +155,7 @@ export class JobQueueBeingModified
 export class JobQueueNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<JobQueueNotFound>()(
     "JobQueueNotFound",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "ClientException",
       message: { matches: "job-queue/.* does not exist" },
@@ -164,7 +164,7 @@ export class JobQueueNotFound
 export class ServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServerException>()(
     "ServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export interface CancelJobRequest {

--- a/packages/aws/src/services/bcm-dashboards.ts
+++ b/packages/aws/src/services/bcm-dashboards.ts
@@ -67,43 +67,43 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type DashboardName = string;

--- a/packages/aws/src/services/bcm-data-exports.ts
+++ b/packages/aws/src/services/bcm-data-exports.ts
@@ -117,26 +117,30 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.String, ResourceId: S.String, ResourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      ResourceId: S.String,
+      ResourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       ResourceId: S.optional(S.String),
       ResourceType: S.optional(S.String),
       QuotaCode: S.String,
@@ -148,7 +152,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       QuotaCode: S.optional(S.String),
       ServiceCode: S.optional(S.String),
     },
@@ -158,7 +162,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => ValidationExceptionReason).annotate({
           identifier: "ValidationExceptionReason",

--- a/packages/aws/src/services/bcm-pricing-calculator.ts
+++ b/packages/aws/src/services/bcm-pricing-calculator.ts
@@ -67,7 +67,11 @@ const rules = T.EndpointResolver((p, _) => {
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.all(
       T.AwsQueryError({ code: "ConflictCode", httpResponseCode: 409 }),
       T.HttpError(409),
@@ -76,13 +80,17 @@ export class ConflictException
 export class DataUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<DataUnavailableException>()(
     "DataUnavailableException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.all(
       T.AwsQueryError({ code: "ResourceNotFoundCode", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -92,7 +100,7 @@ export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.String,
       resourceType: S.String,
       serviceCode: S.optional(S.String),

--- a/packages/aws/src/services/bcm-recommended-actions.ts
+++ b/packages/aws/src/services/bcm-recommended-actions.ts
@@ -67,7 +67,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "BCMRecommendedActionsAccessDenied",
@@ -79,7 +79,7 @@ export class AccessDeniedException
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "BCMRecommendedActionsInternalServer",
@@ -91,7 +91,7 @@ export class InternalServerException
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "BCMRecommendedActionsThrottling",
@@ -104,7 +104,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.suspend(() => ValidationExceptionReason).annotate({
         identifier: "ValidationExceptionReason",
       }),

--- a/packages/aws/src/services/bedrock-agent-runtime.ts
+++ b/packages/aws/src/services/bedrock-agent-runtime.ts
@@ -90,61 +90,70 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class BadGatewayException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadGatewayException>()(
     "BadGatewayException",
-    { message: S.optional(S.String), resourceName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      resourceName: S.optional(S.String),
+    },
     T.HttpError(502),
   ).pipe(C.withServerError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class DependencyFailedException
   extends /*@__PURE__*/ S.TaggedErrorClass<DependencyFailedException>()(
     "DependencyFailedException",
-    { message: S.optional(S.String), resourceName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      resourceName: S.optional(S.String),
+    },
     T.HttpError(424),
   ) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String), reason: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      reason: S.optional(S.String),
+    },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ModelNotReadyException
   extends /*@__PURE__*/ S.TaggedErrorClass<ModelNotReadyException>()(
     "ModelNotReadyException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(424),
   ) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export interface AgenticRetrieveMessageContent {

--- a/packages/aws/src/services/bedrock-agent.ts
+++ b/packages/aws/src/services/bedrock-agent.ts
@@ -90,44 +90,44 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       fieldList: S.optional(
         S.suspend(() => ValidationExceptionFieldList).annotate({
           identifier: "ValidationExceptionFieldList",

--- a/packages/aws/src/services/bedrock-agentcore-control.ts
+++ b/packages/aws/src/services/bedrock-agentcore-control.ts
@@ -90,86 +90,86 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConcurrentModificationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentModificationException>()(
     "ConcurrentModificationException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class DecryptionFailure
   extends /*@__PURE__*/ S.TaggedErrorClass<DecryptionFailure>()(
     "DecryptionFailure",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class EncryptionFailure
   extends /*@__PURE__*/ S.TaggedErrorClass<EncryptionFailure>()(
     "EncryptionFailure",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceLimitExceededException>()(
     "ResourceLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceException>()(
     "ServiceException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottledException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottledException>()(
     "ThrottledException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(429), T.Retryable()),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class UnauthorizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnauthorizedException>()(
     "UnauthorizedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.suspend(() => ValidationExceptionReason).annotate({
         identifier: "ValidationExceptionReason",
       }),

--- a/packages/aws/src/services/bedrock-agentcore.ts
+++ b/packages/aws/src/services/bedrock-agentcore.ts
@@ -90,86 +90,86 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class DuplicateIdException
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicateIdException>()(
     "DuplicateIdException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidInputException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInputException>()(
     "InvalidInputException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class RetryableConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<RetryableConflictException>()(
     "RetryableConflictException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(409), T.Retryable()),
   ).pipe(C.withConflictError, C.withRetryableError) {}
 export class RuntimeClientError
   extends /*@__PURE__*/ S.TaggedErrorClass<RuntimeClientError>()(
     "RuntimeClientError",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(424),
   ) {}
 export class ServiceException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceException>()(
     "ServiceException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottledException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottledException>()(
     "ThrottledException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class UnauthorizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnauthorizedException>()(
     "UnauthorizedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.suspend(() => ValidationExceptionReason).annotate({
         identifier: "ValidationExceptionReason",
       }),

--- a/packages/aws/src/services/bedrock-data-automation-runtime.ts
+++ b/packages/aws/src/services/bedrock-data-automation-runtime.ts
@@ -87,43 +87,43 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type InvocationArn = string;

--- a/packages/aws/src/services/bedrock-data-automation.ts
+++ b/packages/aws/src/services/bedrock-data-automation.ts
@@ -90,44 +90,44 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       fieldList: S.optional(
         S.suspend(() => ValidationExceptionFieldList).annotate({
           identifier: "ValidationExceptionFieldList",

--- a/packages/aws/src/services/bedrock-runtime.ts
+++ b/packages/aws/src/services/bedrock-runtime.ts
@@ -90,26 +90,26 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ModelErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<ModelErrorException>()(
     "ModelErrorException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       originalStatusCode: S.optional(S.Number),
       resourceName: S.optional(S.String),
     },
@@ -118,14 +118,14 @@ export class ModelErrorException
 export class ModelNotReadyException
   extends /*@__PURE__*/ S.TaggedErrorClass<ModelNotReadyException>()(
     "ModelNotReadyException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(429), T.Retryable()),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class ModelStreamErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<ModelStreamErrorException>()(
     "ModelStreamErrorException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       originalStatusCode: S.optional(S.Number),
       originalMessage: S.optional(S.String),
     },
@@ -134,37 +134,37 @@ export class ModelStreamErrorException
 export class ModelTimeoutException
   extends /*@__PURE__*/ S.TaggedErrorClass<ModelTimeoutException>()(
     "ModelTimeoutException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(408),
   ).pipe(C.withTimeoutError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type GuardrailIdentifier = string;

--- a/packages/aws/src/services/bedrock.ts
+++ b/packages/aws/src/services/bedrock.ts
@@ -90,61 +90,64 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUseException>()(
     "ResourceInUseException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { message: S.optional(S.String), resourceName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      resourceName: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type AdvancedPromptOptimizationJobIdentifier = string;

--- a/packages/aws/src/services/billing.ts
+++ b/packages/aws/src/services/billing.ts
@@ -123,7 +123,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "BillingAccessDenied", httpResponseCode: 403 }),
       T.HttpError(403),
@@ -132,13 +132,17 @@ export class AccessDeniedException
 export class BillingViewHealthStatusException
   extends /*@__PURE__*/ S.TaggedErrorClass<BillingViewHealthStatusException>()(
     "BillingViewHealthStatusException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.all(
       T.AwsQueryError({ code: "BillingConflict", httpResponseCode: 409 }),
       T.HttpError(409),
@@ -147,7 +151,7 @@ export class ConflictException
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "BillingInternalServer", httpResponseCode: 500 }),
       T.HttpError(500),
@@ -156,7 +160,11 @@ export class InternalServerException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.all(
       T.AwsQueryError({
         code: "BillingResourceNotFound",
@@ -169,7 +177,7 @@ export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.String,
       resourceType: S.String,
       serviceCode: S.String,
@@ -186,7 +194,7 @@ export class ServiceQuotaExceededException
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "BillingThrottling", httpResponseCode: 429 }),
       T.HttpError(429),
@@ -196,7 +204,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.suspend(() => ValidationExceptionReason).annotate({
         identifier: "ValidationExceptionReason",
       }),

--- a/packages/aws/src/services/billingconductor.ts
+++ b/packages/aws/src/services/billingconductor.ts
@@ -109,14 +109,14 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       ResourceId: S.String,
       ResourceType: S.String,
       Reason: S.optional(
@@ -131,7 +131,7 @@ export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       RetryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.HttpError(500),
@@ -139,14 +139,18 @@ export class InternalServerException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.String, ResourceId: S.String, ResourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      ResourceId: S.String,
+      ResourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceLimitExceededException>()(
     "ServiceLimitExceededException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       ResourceId: S.optional(S.String),
       ResourceType: S.optional(S.String),
       LimitCode: S.String,
@@ -158,7 +162,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       RetryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.HttpError(429),
@@ -167,7 +171,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => ValidationExceptionReason).annotate({
           identifier: "ValidationExceptionReason",

--- a/packages/aws/src/services/braket.ts
+++ b/packages/aws/src/services/braket.ts
@@ -85,56 +85,56 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class DeviceOfflineException
   extends /*@__PURE__*/ S.TaggedErrorClass<DeviceOfflineException>()(
     "DeviceOfflineException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(424),
   ) {}
 export class DeviceRetiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<DeviceRetiredException>()(
     "DeviceRetiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(410),
   ).pipe(C.withBadRequestError) {}
 export class InternalServiceException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServiceException>()(
     "InternalServiceException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       reason: S.optional(S.String),
       programSetValidationFailures: S.optional(
         S.suspend(() => ProgramSetValidationFailuresList).annotate({

--- a/packages/aws/src/services/budgets.ts
+++ b/packages/aws/src/services/budgets.ts
@@ -183,73 +183,73 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class BillingViewHealthStatusException
   extends /*@__PURE__*/ S.TaggedErrorClass<BillingViewHealthStatusException>()(
     "BillingViewHealthStatusException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class CreationLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<CreationLimitExceededException>()(
     "CreationLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(405),
   ).pipe(C.withBadRequestError) {}
 export class DuplicateRecordException
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicateRecordException>()(
     "DuplicateRecordException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ExpiredNextTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<ExpiredNextTokenException>()(
     "ExpiredNextTokenException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InternalErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalErrorException>()(
     "InternalErrorException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidNextTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNextTokenException>()(
     "InvalidNextTokenException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterException>()(
     "InvalidParameterException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ResourceLockedException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceLockedException>()(
     "ResourceLockedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(423),
   ) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type AccountId = string;

--- a/packages/aws/src/services/chatbot.ts
+++ b/packages/aws/src/services/chatbot.ts
@@ -93,151 +93,151 @@ const rules = T.EndpointResolver((p, _) => {
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class CreateChimeWebhookConfigurationException
   extends /*@__PURE__*/ S.TaggedErrorClass<CreateChimeWebhookConfigurationException>()(
     "CreateChimeWebhookConfigurationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class CreateSlackChannelConfigurationException
   extends /*@__PURE__*/ S.TaggedErrorClass<CreateSlackChannelConfigurationException>()(
     "CreateSlackChannelConfigurationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class CreateTeamsChannelConfigurationException
   extends /*@__PURE__*/ S.TaggedErrorClass<CreateTeamsChannelConfigurationException>()(
     "CreateTeamsChannelConfigurationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class DeleteChimeWebhookConfigurationException
   extends /*@__PURE__*/ S.TaggedErrorClass<DeleteChimeWebhookConfigurationException>()(
     "DeleteChimeWebhookConfigurationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class DeleteMicrosoftTeamsUserIdentityException
   extends /*@__PURE__*/ S.TaggedErrorClass<DeleteMicrosoftTeamsUserIdentityException>()(
     "DeleteMicrosoftTeamsUserIdentityException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class DeleteSlackChannelConfigurationException
   extends /*@__PURE__*/ S.TaggedErrorClass<DeleteSlackChannelConfigurationException>()(
     "DeleteSlackChannelConfigurationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class DeleteSlackUserIdentityException
   extends /*@__PURE__*/ S.TaggedErrorClass<DeleteSlackUserIdentityException>()(
     "DeleteSlackUserIdentityException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class DeleteSlackWorkspaceAuthorizationFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DeleteSlackWorkspaceAuthorizationFault>()(
     "DeleteSlackWorkspaceAuthorizationFault",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class DeleteTeamsChannelConfigurationException
   extends /*@__PURE__*/ S.TaggedErrorClass<DeleteTeamsChannelConfigurationException>()(
     "DeleteTeamsChannelConfigurationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class DeleteTeamsConfiguredTeamException
   extends /*@__PURE__*/ S.TaggedErrorClass<DeleteTeamsConfiguredTeamException>()(
     "DeleteTeamsConfiguredTeamException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class DescribeChimeWebhookConfigurationsException
   extends /*@__PURE__*/ S.TaggedErrorClass<DescribeChimeWebhookConfigurationsException>()(
     "DescribeChimeWebhookConfigurationsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class DescribeSlackChannelConfigurationsException
   extends /*@__PURE__*/ S.TaggedErrorClass<DescribeSlackChannelConfigurationsException>()(
     "DescribeSlackChannelConfigurationsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class DescribeSlackUserIdentitiesException
   extends /*@__PURE__*/ S.TaggedErrorClass<DescribeSlackUserIdentitiesException>()(
     "DescribeSlackUserIdentitiesException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class DescribeSlackWorkspacesException
   extends /*@__PURE__*/ S.TaggedErrorClass<DescribeSlackWorkspacesException>()(
     "DescribeSlackWorkspacesException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class GetAccountPreferencesException
   extends /*@__PURE__*/ S.TaggedErrorClass<GetAccountPreferencesException>()(
     "GetAccountPreferencesException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class GetTeamsChannelConfigurationException
   extends /*@__PURE__*/ S.TaggedErrorClass<GetTeamsChannelConfigurationException>()(
     "GetTeamsChannelConfigurationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InternalServiceError
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServiceError>()(
     "InternalServiceError",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterException>()(
     "InvalidParameterException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ListMicrosoftTeamsConfiguredTeamsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ListMicrosoftTeamsConfiguredTeamsException>()(
     "ListMicrosoftTeamsConfiguredTeamsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ListMicrosoftTeamsUserIdentitiesException
   extends /*@__PURE__*/ S.TaggedErrorClass<ListMicrosoftTeamsUserIdentitiesException>()(
     "ListMicrosoftTeamsUserIdentitiesException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ListTeamsChannelConfigurationsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ListTeamsChannelConfigurationsException>()(
     "ListTeamsChannelConfigurationsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class MicrosoftTeamsTeamNotConfigured
   extends /*@__PURE__*/ S.TaggedErrorClass<MicrosoftTeamsTeamNotConfigured>()(
     "MicrosoftTeamsTeamNotConfigured",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "InvalidRequestException",
       message: { includes: "team id you are using is not configured" },
@@ -246,19 +246,19 @@ export class MicrosoftTeamsTeamNotConfigured
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError, C.withServerError) {}
 export class SlackWorkspaceNotAuthorized
   extends /*@__PURE__*/ S.TaggedErrorClass<SlackWorkspaceNotAuthorized>()(
     "SlackWorkspaceNotAuthorized",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "InvalidRequestException",
       message: { includes: "is not authorized with AWS account" },
@@ -267,37 +267,37 @@ export class SlackWorkspaceNotAuthorized
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class UnauthorizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnauthorizedException>()(
     "UnauthorizedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class UpdateAccountPreferencesException
   extends /*@__PURE__*/ S.TaggedErrorClass<UpdateAccountPreferencesException>()(
     "UpdateAccountPreferencesException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class UpdateChimeWebhookConfigurationException
   extends /*@__PURE__*/ S.TaggedErrorClass<UpdateChimeWebhookConfigurationException>()(
     "UpdateChimeWebhookConfigurationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class UpdateSlackChannelConfigurationException
   extends /*@__PURE__*/ S.TaggedErrorClass<UpdateSlackChannelConfigurationException>()(
     "UpdateSlackChannelConfigurationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class UpdateTeamsChannelConfigurationException
   extends /*@__PURE__*/ S.TaggedErrorClass<UpdateTeamsChannelConfigurationException>()(
     "UpdateTeamsChannelConfigurationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export type ResourceIdentifier = string;

--- a/packages/aws/src/services/chime-sdk-identity.ts
+++ b/packages/aws/src/services/chime-sdk-identity.ts
@@ -94,7 +94,7 @@ export class BadRequestException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
@@ -105,7 +105,7 @@ export class ConflictException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
@@ -116,7 +116,7 @@ export class ForbiddenException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
@@ -127,7 +127,7 @@ export class NotFoundException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
@@ -138,7 +138,7 @@ export class ResourceLimitExceededException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
@@ -149,7 +149,7 @@ export class ServiceFailureException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
@@ -160,7 +160,7 @@ export class ServiceUnavailableException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
@@ -171,7 +171,7 @@ export class ThrottledClientException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
@@ -182,7 +182,7 @@ export class UnauthorizedClientException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}

--- a/packages/aws/src/services/chime-sdk-media-pipelines.ts
+++ b/packages/aws/src/services/chime-sdk-media-pipelines.ts
@@ -94,7 +94,7 @@ export class BadRequestException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       RequestId: S.optional(S.String),
     },
     T.HttpError(400),
@@ -106,7 +106,7 @@ export class ConflictException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       RequestId: S.optional(S.String),
     },
     T.HttpError(409),
@@ -118,7 +118,7 @@ export class ForbiddenException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       RequestId: S.optional(S.String),
     },
     T.HttpError(403),
@@ -130,7 +130,7 @@ export class NotFoundException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       RequestId: S.optional(S.String),
     },
     T.HttpError(404),
@@ -142,7 +142,7 @@ export class ResourceLimitExceededException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       RequestId: S.optional(S.String),
     },
     T.HttpError(400),
@@ -154,7 +154,7 @@ export class ServiceFailureException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       RequestId: S.optional(S.String),
     },
     T.HttpError(500),
@@ -166,7 +166,7 @@ export class ServiceUnavailableException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       RequestId: S.optional(S.String),
     },
     T.HttpError(503),
@@ -178,7 +178,7 @@ export class ThrottledClientException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       RequestId: S.optional(S.String),
     },
     T.HttpError(429),
@@ -190,7 +190,7 @@ export class UnauthorizedClientException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       RequestId: S.optional(S.String),
     },
     T.HttpError(401),

--- a/packages/aws/src/services/chime-sdk-meetings.ts
+++ b/packages/aws/src/services/chime-sdk-meetings.ts
@@ -92,7 +92,7 @@ export class BadRequestException
     "BadRequestException",
     {
       Code: S.optional(S.String),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       RequestId: S.optional(S.String),
     },
     T.HttpError(400),
@@ -102,7 +102,7 @@ export class ConflictException
     "ConflictException",
     {
       Code: S.optional(S.String),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       RequestId: S.optional(S.String),
     },
     T.HttpError(409),
@@ -112,7 +112,7 @@ export class ForbiddenException
     "ForbiddenException",
     {
       Code: S.optional(S.String),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       RequestId: S.optional(S.String),
     },
     T.HttpError(403),
@@ -122,7 +122,7 @@ export class LimitExceededException
     "LimitExceededException",
     {
       Code: S.optional(S.String),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       RequestId: S.optional(S.String),
     },
     T.HttpError(400),
@@ -132,7 +132,7 @@ export class NotFoundException
     "NotFoundException",
     {
       Code: S.optional(S.String),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       RequestId: S.optional(S.String),
     },
     T.HttpError(404),
@@ -142,7 +142,7 @@ export class ResourceNotFoundException
     "ResourceNotFoundException",
     {
       Code: S.optional(S.String),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       RequestId: S.optional(S.String),
       ResourceName: S.optional(S.String),
     },
@@ -153,7 +153,7 @@ export class ServiceFailureException
     "ServiceFailureException",
     {
       Code: S.optional(S.String),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       RequestId: S.optional(S.String),
     },
     T.HttpError(500),
@@ -163,7 +163,7 @@ export class ServiceUnavailableException
     "ServiceUnavailableException",
     {
       Code: S.optional(S.String),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       RequestId: S.optional(S.String),
       RetryAfterSeconds: S.optional(S.String).pipe(T.HttpHeader("Retry-After")),
     },
@@ -174,7 +174,7 @@ export class ThrottlingException
     "ThrottlingException",
     {
       Code: S.optional(S.String),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       RequestId: S.optional(S.String),
     },
     T.HttpError(429),
@@ -184,7 +184,7 @@ export class TooManyTagsException
     "TooManyTagsException",
     {
       Code: S.optional(S.String),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       RequestId: S.optional(S.String),
       ResourceName: S.optional(S.String),
     },
@@ -195,7 +195,7 @@ export class UnauthorizedException
     "UnauthorizedException",
     {
       Code: S.optional(S.String),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       RequestId: S.optional(S.String),
     },
     T.HttpError(401),
@@ -205,7 +205,7 @@ export class UnprocessableEntityException
     "UnprocessableEntityException",
     {
       Code: S.optional(S.String),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       RequestId: S.optional(S.String),
     },
     T.HttpError(422),

--- a/packages/aws/src/services/chime-sdk-messaging.ts
+++ b/packages/aws/src/services/chime-sdk-messaging.ts
@@ -94,7 +94,7 @@ export class BadRequestException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
@@ -105,7 +105,7 @@ export class ConflictException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
@@ -116,7 +116,7 @@ export class ForbiddenException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
@@ -127,7 +127,7 @@ export class NotFoundException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
@@ -138,7 +138,7 @@ export class ResourceLimitExceededException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
@@ -149,7 +149,7 @@ export class ServiceFailureException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
@@ -160,7 +160,7 @@ export class ServiceUnavailableException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
@@ -171,7 +171,7 @@ export class ThrottledClientException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
@@ -182,7 +182,7 @@ export class UnauthorizedClientException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}

--- a/packages/aws/src/services/chime-sdk-voice.ts
+++ b/packages/aws/src/services/chime-sdk-voice.ts
@@ -94,7 +94,7 @@ export class AccessDeniedException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
@@ -105,7 +105,7 @@ export class BadRequestException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
@@ -116,7 +116,7 @@ export class ConflictException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
@@ -127,7 +127,7 @@ export class ForbiddenException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
@@ -138,7 +138,7 @@ export class GoneException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(410),
   ).pipe(C.withBadRequestError) {}
@@ -149,7 +149,7 @@ export class NotFoundException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
@@ -160,7 +160,7 @@ export class ResourceLimitExceededException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
@@ -171,7 +171,7 @@ export class ServiceFailureException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
@@ -182,7 +182,7 @@ export class ServiceUnavailableException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
@@ -193,7 +193,7 @@ export class ThrottledClientException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
@@ -204,7 +204,7 @@ export class UnauthorizedClientException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
@@ -215,7 +215,7 @@ export class UnprocessableEntityException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(422),
   ).pipe(C.withBadRequestError) {}

--- a/packages/aws/src/services/chime.ts
+++ b/packages/aws/src/services/chime.ts
@@ -113,7 +113,7 @@ export class AccessDeniedException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
@@ -124,7 +124,7 @@ export class BadRequestException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
@@ -135,7 +135,7 @@ export class ConflictException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
@@ -146,7 +146,7 @@ export class ForbiddenException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
@@ -157,7 +157,7 @@ export class NotFoundException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
@@ -168,7 +168,7 @@ export class ResourceLimitExceededException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
@@ -179,7 +179,7 @@ export class ServiceFailureException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
@@ -190,7 +190,7 @@ export class ServiceUnavailableException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
@@ -201,7 +201,7 @@ export class ThrottledClientException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
@@ -212,7 +212,7 @@ export class UnauthorizedClientException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
@@ -223,7 +223,7 @@ export class UnprocessableEntityException
       Code: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(422),
   ).pipe(C.withBadRequestError) {}

--- a/packages/aws/src/services/cleanrooms.ts
+++ b/packages/aws/src/services/cleanrooms.ts
@@ -90,14 +90,17 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String), reason: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      reason: S.optional(S.String),
+    },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceType: S.optional(S.String),
       reason: S.optional(S.String),
@@ -107,32 +110,40 @@ export class ConflictException
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.String, quotaName: S.String, quotaValue: S.Number },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      quotaName: S.String,
+      quotaValue: S.Number,
+    },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       reason: S.optional(S.String),
       fieldList: S.optional(
         S.suspend(() => ValidationExceptionFieldList).annotate({

--- a/packages/aws/src/services/cleanroomsml.ts
+++ b/packages/aws/src/services/cleanroomsml.ts
@@ -88,32 +88,32 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServiceException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServiceException>()(
     "InternalServiceException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       quotaName: S.optional(S.String),
       quotaValue: S.optional(S.Number),
     },
@@ -122,13 +122,13 @@ export class ServiceQuotaExceededException
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type UUID = string;

--- a/packages/aws/src/services/cloud9.ts
+++ b/packages/aws/src/services/cloud9.ts
@@ -90,7 +90,7 @@ export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       className: S.optional(S.String),
       code: S.optional(S.Number),
     },
@@ -99,7 +99,7 @@ export class ConcurrentAccessException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentAccessException>()(
     "ConcurrentAccessException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       className: S.optional(S.String),
       code: S.optional(S.Number),
     },
@@ -108,7 +108,7 @@ export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       className: S.optional(S.String),
       code: S.optional(S.Number),
     },
@@ -117,7 +117,7 @@ export class ForbiddenException
   extends /*@__PURE__*/ S.TaggedErrorClass<ForbiddenException>()(
     "ForbiddenException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       className: S.optional(S.String),
       code: S.optional(S.Number),
     },
@@ -126,7 +126,7 @@ export class InternalServerErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerErrorException>()(
     "InternalServerErrorException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       className: S.optional(S.String),
       code: S.optional(S.Number),
     },
@@ -135,7 +135,7 @@ export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       className: S.optional(S.String),
       code: S.optional(S.Number),
     },
@@ -144,7 +144,7 @@ export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       className: S.optional(S.String),
       code: S.optional(S.Number),
     },
@@ -153,7 +153,7 @@ export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       className: S.optional(S.String),
       code: S.optional(S.Number),
     },

--- a/packages/aws/src/services/cloudcontrol.ts
+++ b/packages/aws/src/services/cloudcontrol.ts
@@ -90,7 +90,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class AlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<AlreadyExistsException>()(
     "AlreadyExistsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "AlreadyExistsException",
@@ -102,7 +102,7 @@ export class AlreadyExistsException
 export class ClientTokenConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ClientTokenConflictException>()(
     "ClientTokenConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ClientTokenConflictException",
@@ -114,7 +114,7 @@ export class ClientTokenConflictException
 export class ConcurrentModificationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentModificationException>()(
     "ConcurrentModificationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ConcurrentModificationException",
@@ -126,7 +126,7 @@ export class ConcurrentModificationException
 export class ConcurrentOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentOperationException>()(
     "ConcurrentOperationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ConcurrentOperationException",
@@ -138,7 +138,7 @@ export class ConcurrentOperationException
 export class GeneralServiceException
   extends /*@__PURE__*/ S.TaggedErrorClass<GeneralServiceException>()(
     "GeneralServiceException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "GeneralServiceException",
@@ -150,7 +150,7 @@ export class GeneralServiceException
 export class HandlerFailureException
   extends /*@__PURE__*/ S.TaggedErrorClass<HandlerFailureException>()(
     "HandlerFailureException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "HandlerFailureException",
@@ -162,7 +162,7 @@ export class HandlerFailureException
 export class HandlerInternalFailureException
   extends /*@__PURE__*/ S.TaggedErrorClass<HandlerInternalFailureException>()(
     "HandlerInternalFailureException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "HandlerInternalFailureException",
@@ -174,7 +174,7 @@ export class HandlerInternalFailureException
 export class InvalidCredentialsException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCredentialsException>()(
     "InvalidCredentialsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidCredentialsException",
@@ -186,7 +186,7 @@ export class InvalidCredentialsException
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidRequestException",
@@ -198,7 +198,7 @@ export class InvalidRequestException
 export class NetworkFailureException
   extends /*@__PURE__*/ S.TaggedErrorClass<NetworkFailureException>()(
     "NetworkFailureException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "NetworkFailureException",
@@ -210,7 +210,7 @@ export class NetworkFailureException
 export class NotStabilizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotStabilizedException>()(
     "NotStabilizedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "NotStabilizedException",
@@ -222,7 +222,7 @@ export class NotStabilizedException
 export class NotUpdatableException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotUpdatableException>()(
     "NotUpdatableException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "NotUpdatableException", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -231,7 +231,7 @@ export class NotUpdatableException
 export class PrivateTypeException
   extends /*@__PURE__*/ S.TaggedErrorClass<PrivateTypeException>()(
     "PrivateTypeException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "PrivateTypeException", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -240,7 +240,7 @@ export class PrivateTypeException
 export class RequestTokenNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<RequestTokenNotFoundException>()(
     "RequestTokenNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "RequestTokenNotFoundException",
@@ -252,7 +252,7 @@ export class RequestTokenNotFoundException
 export class ResourceConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceConflictException>()(
     "ResourceConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ResourceConflictException",
@@ -264,7 +264,7 @@ export class ResourceConflictException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ResourceNotFoundException",
@@ -276,7 +276,7 @@ export class ResourceNotFoundException
 export class ServiceInternalErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceInternalErrorException>()(
     "ServiceInternalErrorException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ServiceInternalErrorException",
@@ -288,7 +288,7 @@ export class ServiceInternalErrorException
 export class ServiceLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceLimitExceededException>()(
     "ServiceLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ServiceLimitExceededException",
@@ -300,7 +300,7 @@ export class ServiceLimitExceededException
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ThrottlingException", httpResponseCode: 429 }),
       T.HttpError(429),
@@ -309,7 +309,7 @@ export class ThrottlingException
 export class TypeNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<TypeNotFoundException>()(
     "TypeNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "TypeNotFoundException", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -318,7 +318,7 @@ export class TypeNotFoundException
 export class UnsupportedActionException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedActionException>()(
     "UnsupportedActionException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "UnsupportedActionException",

--- a/packages/aws/src/services/clouddirectory.ts
+++ b/packages/aws/src/services/clouddirectory.ts
@@ -91,7 +91,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class BatchWriteException
@@ -104,205 +104,205 @@ export class BatchWriteException
           identifier: "BatchWriteExceptionType",
         }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
   ) {}
 export class CannotListParentOfRootException
   extends /*@__PURE__*/ S.TaggedErrorClass<CannotListParentOfRootException>()(
     "CannotListParentOfRootException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class DirectoryAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<DirectoryAlreadyExistsException>()(
     "DirectoryAlreadyExistsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError, C.withAlreadyExistsError) {}
 export class DirectoryDeletedException
   extends /*@__PURE__*/ S.TaggedErrorClass<DirectoryDeletedException>()(
     "DirectoryDeletedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class DirectoryNotDisabledException
   extends /*@__PURE__*/ S.TaggedErrorClass<DirectoryNotDisabledException>()(
     "DirectoryNotDisabledException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class DirectoryNotEnabledException
   extends /*@__PURE__*/ S.TaggedErrorClass<DirectoryNotEnabledException>()(
     "DirectoryNotEnabledException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class FacetAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<FacetAlreadyExistsException>()(
     "FacetAlreadyExistsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError, C.withAlreadyExistsError) {}
 export class FacetInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<FacetInUseException>()(
     "FacetInUseException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class FacetNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<FacetNotFoundException>()(
     "FacetNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class FacetValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<FacetValidationException>()(
     "FacetValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class IncompatibleSchemaException
   extends /*@__PURE__*/ S.TaggedErrorClass<IncompatibleSchemaException>()(
     "IncompatibleSchemaException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class IndexedAttributeMissingException
   extends /*@__PURE__*/ S.TaggedErrorClass<IndexedAttributeMissingException>()(
     "IndexedAttributeMissingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InternalServiceException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServiceException>()(
     "InternalServiceException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidArnException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidArnException>()(
     "InvalidArnException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidAttachmentException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidAttachmentException>()(
     "InvalidAttachmentException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidFacetUpdateException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidFacetUpdateException>()(
     "InvalidFacetUpdateException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidNextTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNextTokenException>()(
     "InvalidNextTokenException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidRuleException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRuleException>()(
     "InvalidRuleException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidSchemaDocException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSchemaDocException>()(
     "InvalidSchemaDocException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidTaggingRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTaggingRequestException>()(
     "InvalidTaggingRequestException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class LinkNameAlreadyInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<LinkNameAlreadyInUseException>()(
     "LinkNameAlreadyInUseException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class NotIndexException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotIndexException>()(
     "NotIndexException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class NotNodeException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotNodeException>()(
     "NotNodeException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class NotPolicyException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotPolicyException>()(
     "NotPolicyException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ObjectAlreadyDetachedException
   extends /*@__PURE__*/ S.TaggedErrorClass<ObjectAlreadyDetachedException>()(
     "ObjectAlreadyDetachedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ObjectNotDetachedException
   extends /*@__PURE__*/ S.TaggedErrorClass<ObjectNotDetachedException>()(
     "ObjectNotDetachedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class RetryableConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<RetryableConflictException>()(
     "RetryableConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class SchemaAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<SchemaAlreadyExistsException>()(
     "SchemaAlreadyExistsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError, C.withAlreadyExistsError) {}
 export class SchemaAlreadyPublishedException
   extends /*@__PURE__*/ S.TaggedErrorClass<SchemaAlreadyPublishedException>()(
     "SchemaAlreadyPublishedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class StillContainsLinksException
   extends /*@__PURE__*/ S.TaggedErrorClass<StillContainsLinksException>()(
     "StillContainsLinksException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class UnsupportedIndexTypeException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedIndexTypeException>()(
     "UnsupportedIndexTypeException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type Arn = string;

--- a/packages/aws/src/services/cloudformation.ts
+++ b/packages/aws/src/services/cloudformation.ts
@@ -94,7 +94,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class AlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<AlreadyExistsException>()(
     "AlreadyExistsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "AlreadyExistsException",
@@ -106,7 +106,7 @@ export class AlreadyExistsException
 export class CFNRegistryException
   extends /*@__PURE__*/ S.TaggedErrorClass<CFNRegistryException>()(
     "CFNRegistryException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "CFNRegistryException", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -115,7 +115,7 @@ export class CFNRegistryException
 export class ChangeSetNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ChangeSetNotFoundException>()(
     "ChangeSetNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ChangeSetNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -124,7 +124,7 @@ export class ChangeSetNotFoundException
 export class ConcurrentResourcesLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentResourcesLimitExceededException>()(
     "ConcurrentResourcesLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ConcurrentResourcesLimitExceeded",
@@ -136,7 +136,7 @@ export class ConcurrentResourcesLimitExceededException
 export class CreatedButModifiedException
   extends /*@__PURE__*/ S.TaggedErrorClass<CreatedButModifiedException>()(
     "CreatedButModifiedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CreatedButModifiedException",
@@ -148,7 +148,7 @@ export class CreatedButModifiedException
 export class GeneratedTemplateNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<GeneratedTemplateNotFoundException>()(
     "GeneratedTemplateNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "GeneratedTemplateNotFound",
@@ -160,7 +160,7 @@ export class GeneratedTemplateNotFoundException
 export class HookResultNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<HookResultNotFoundException>()(
     "HookResultNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "HookResultNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -169,7 +169,7 @@ export class HookResultNotFoundException
 export class InsufficientCapabilitiesException
   extends /*@__PURE__*/ S.TaggedErrorClass<InsufficientCapabilitiesException>()(
     "InsufficientCapabilitiesException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InsufficientCapabilitiesException",
@@ -181,7 +181,7 @@ export class InsufficientCapabilitiesException
 export class InvalidChangeSetStatusException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidChangeSetStatusException>()(
     "InvalidChangeSetStatusException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidChangeSetStatus",
@@ -193,7 +193,7 @@ export class InvalidChangeSetStatusException
 export class InvalidOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidOperationException>()(
     "InvalidOperationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidOperationException",
@@ -205,7 +205,7 @@ export class InvalidOperationException
 export class InvalidStateTransitionException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidStateTransitionException>()(
     "InvalidStateTransitionException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidStateTransition",
@@ -217,7 +217,7 @@ export class InvalidStateTransitionException
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "LimitExceededException",
@@ -229,7 +229,7 @@ export class LimitExceededException
 export class NameAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<NameAlreadyExistsException>()(
     "NameAlreadyExistsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "NameAlreadyExistsException",
@@ -241,7 +241,7 @@ export class NameAlreadyExistsException
 export class NoUpdateToPerform
   extends /*@__PURE__*/ S.TaggedErrorClass<NoUpdateToPerform>()(
     "NoUpdateToPerform",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "ValidationError",
       message: { includes: "No updates are to be performed" },
@@ -250,7 +250,7 @@ export class NoUpdateToPerform
 export class OperationIdAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<OperationIdAlreadyExistsException>()(
     "OperationIdAlreadyExistsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "OperationIdAlreadyExistsException",
@@ -262,7 +262,7 @@ export class OperationIdAlreadyExistsException
 export class OperationInProgressException
   extends /*@__PURE__*/ S.TaggedErrorClass<OperationInProgressException>()(
     "OperationInProgressException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "OperationInProgressException",
@@ -274,7 +274,7 @@ export class OperationInProgressException
 export class OperationNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<OperationNotFoundException>()(
     "OperationNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "OperationNotFoundException",
@@ -286,7 +286,7 @@ export class OperationNotFoundException
 export class OperationStatusCheckFailedException
   extends /*@__PURE__*/ S.TaggedErrorClass<OperationStatusCheckFailedException>()(
     "OperationStatusCheckFailedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ConditionalCheckFailed",
@@ -298,7 +298,7 @@ export class OperationStatusCheckFailedException
 export class ResourceScanInProgressException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceScanInProgressException>()(
     "ResourceScanInProgressException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ResourceScanInProgress",
@@ -310,7 +310,7 @@ export class ResourceScanInProgressException
 export class ResourceScanLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceScanLimitExceededException>()(
     "ResourceScanLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ResourceScanLimitExceeded",
@@ -322,7 +322,7 @@ export class ResourceScanLimitExceededException
 export class ResourceScanNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceScanNotFoundException>()(
     "ResourceScanNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ResourceScanNotFound", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -331,7 +331,7 @@ export class ResourceScanNotFoundException
 export class StackInstanceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<StackInstanceNotFoundException>()(
     "StackInstanceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "StackInstanceNotFoundException",
@@ -343,7 +343,7 @@ export class StackInstanceNotFoundException
 export class StackNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<StackNotFound>()(
     "StackNotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "ValidationError",
       message: { includes: "does not exist" },
@@ -352,7 +352,7 @@ export class StackNotFound
 export class StackNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<StackNotFoundException>()(
     "StackNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "StackNotFoundException",
@@ -364,7 +364,7 @@ export class StackNotFoundException
 export class StackRefactorNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<StackRefactorNotFoundException>()(
     "StackRefactorNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "StackRefactorNotFoundException",
@@ -376,7 +376,7 @@ export class StackRefactorNotFoundException
 export class StackSetNotEmptyException
   extends /*@__PURE__*/ S.TaggedErrorClass<StackSetNotEmptyException>()(
     "StackSetNotEmptyException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "StackSetNotEmptyException",
@@ -388,7 +388,7 @@ export class StackSetNotEmptyException
 export class StackSetNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<StackSetNotFoundException>()(
     "StackSetNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "StackSetNotFoundException",
@@ -400,7 +400,7 @@ export class StackSetNotFoundException
 export class StaleRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<StaleRequestException>()(
     "StaleRequestException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "StaleRequestException", httpResponseCode: 409 }),
       T.HttpError(409),
@@ -409,7 +409,7 @@ export class StaleRequestException
 export class TokenAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TokenAlreadyExistsException>()(
     "TokenAlreadyExistsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "TokenAlreadyExistsException",
@@ -421,7 +421,7 @@ export class TokenAlreadyExistsException
 export class TypeConfigurationNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<TypeConfigurationNotFoundException>()(
     "TypeConfigurationNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "TypeConfigurationNotFoundException",
@@ -433,7 +433,7 @@ export class TypeConfigurationNotFoundException
 export class TypeNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<TypeNotFoundException>()(
     "TypeNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "TypeNotFoundException", httpResponseCode: 404 }),
       T.HttpError(404),

--- a/packages/aws/src/services/cloudfront-keyvaluestore.ts
+++ b/packages/aws/src/services/cloudfront-keyvaluestore.ts
@@ -145,37 +145,37 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type KvsARN = string;

--- a/packages/aws/src/services/cloudfront.ts
+++ b/packages/aws/src/services/cloudfront.ts
@@ -149,913 +149,913 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDenied
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDenied>()(
     "AccessDenied",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class BatchTooLarge
   extends /*@__PURE__*/ S.TaggedErrorClass<BatchTooLarge>()(
     "BatchTooLarge",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(413),
   ).pipe(C.withBadRequestError) {}
 export class CachePolicyAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<CachePolicyAlreadyExists>()(
     "CachePolicyAlreadyExists",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class CachePolicyInUse
   extends /*@__PURE__*/ S.TaggedErrorClass<CachePolicyInUse>()(
     "CachePolicyInUse",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withDependencyViolationError) {}
 export class CannotChangeImmutablePublicKeyFields
   extends /*@__PURE__*/ S.TaggedErrorClass<CannotChangeImmutablePublicKeyFields>()(
     "CannotChangeImmutablePublicKeyFields",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class CannotDeleteEntityWhileInUse
   extends /*@__PURE__*/ S.TaggedErrorClass<CannotDeleteEntityWhileInUse>()(
     "CannotDeleteEntityWhileInUse",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withDependencyViolationError) {}
 export class CannotUpdateEntityWhileInUse
   extends /*@__PURE__*/ S.TaggedErrorClass<CannotUpdateEntityWhileInUse>()(
     "CannotUpdateEntityWhileInUse",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withDependencyViolationError) {}
 export class CloudFrontOriginAccessIdentityAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<CloudFrontOriginAccessIdentityAlreadyExists>()(
     "CloudFrontOriginAccessIdentityAlreadyExists",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class CloudFrontOriginAccessIdentityInUse
   extends /*@__PURE__*/ S.TaggedErrorClass<CloudFrontOriginAccessIdentityInUse>()(
     "CloudFrontOriginAccessIdentityInUse",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withDependencyViolationError) {}
 export class CNAMEAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<CNAMEAlreadyExists>()(
     "CNAMEAlreadyExists",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class ContinuousDeploymentPolicyAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<ContinuousDeploymentPolicyAlreadyExists>()(
     "ContinuousDeploymentPolicyAlreadyExists",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class ContinuousDeploymentPolicyInUse
   extends /*@__PURE__*/ S.TaggedErrorClass<ContinuousDeploymentPolicyInUse>()(
     "ContinuousDeploymentPolicyInUse",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withDependencyViolationError) {}
 export class DistributionAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<DistributionAlreadyExists>()(
     "DistributionAlreadyExists",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class DistributionNotDisabled
   extends /*@__PURE__*/ S.TaggedErrorClass<DistributionNotDisabled>()(
     "DistributionNotDisabled",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class EntityAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<EntityAlreadyExists>()(
     "EntityAlreadyExists",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class EntityLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<EntityLimitExceeded>()(
     "EntityLimitExceeded",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError, C.withThrottlingError) {}
 export class EntityNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<EntityNotFound>()(
     "EntityNotFound",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class EntitySizeLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<EntitySizeLimitExceeded>()(
     "EntitySizeLimitExceeded",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(413),
   ).pipe(C.withBadRequestError, C.withThrottlingError) {}
 export class FieldLevelEncryptionConfigAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<FieldLevelEncryptionConfigAlreadyExists>()(
     "FieldLevelEncryptionConfigAlreadyExists",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class FieldLevelEncryptionConfigInUse
   extends /*@__PURE__*/ S.TaggedErrorClass<FieldLevelEncryptionConfigInUse>()(
     "FieldLevelEncryptionConfigInUse",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withDependencyViolationError) {}
 export class FieldLevelEncryptionProfileAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<FieldLevelEncryptionProfileAlreadyExists>()(
     "FieldLevelEncryptionProfileAlreadyExists",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class FieldLevelEncryptionProfileInUse
   extends /*@__PURE__*/ S.TaggedErrorClass<FieldLevelEncryptionProfileInUse>()(
     "FieldLevelEncryptionProfileInUse",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withDependencyViolationError) {}
 export class FieldLevelEncryptionProfileSizeExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<FieldLevelEncryptionProfileSizeExceeded>()(
     "FieldLevelEncryptionProfileSizeExceeded",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class FunctionAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<FunctionAlreadyExists>()(
     "FunctionAlreadyExists",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class FunctionInUse
   extends /*@__PURE__*/ S.TaggedErrorClass<FunctionInUse>()(
     "FunctionInUse",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withDependencyViolationError) {}
 export class FunctionSizeLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<FunctionSizeLimitExceeded>()(
     "FunctionSizeLimitExceeded",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(413),
   ).pipe(C.withBadRequestError, C.withThrottlingError) {}
 export class IllegalDelete
   extends /*@__PURE__*/ S.TaggedErrorClass<IllegalDelete>()(
     "IllegalDelete",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class IllegalFieldLevelEncryptionConfigAssociationWithCacheBehavior
   extends /*@__PURE__*/ S.TaggedErrorClass<IllegalFieldLevelEncryptionConfigAssociationWithCacheBehavior>()(
     "IllegalFieldLevelEncryptionConfigAssociationWithCacheBehavior",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class IllegalOriginAccessConfiguration
   extends /*@__PURE__*/ S.TaggedErrorClass<IllegalOriginAccessConfiguration>()(
     "IllegalOriginAccessConfiguration",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class IllegalUpdate
   extends /*@__PURE__*/ S.TaggedErrorClass<IllegalUpdate>()(
     "IllegalUpdate",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InconsistentQuantities
   extends /*@__PURE__*/ S.TaggedErrorClass<InconsistentQuantities>()(
     "InconsistentQuantities",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidArgument
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidArgument>()(
     "InvalidArgument",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidAssociation
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidAssociation>()(
     "InvalidAssociation",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InvalidDefaultRootObject
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDefaultRootObject>()(
     "InvalidDefaultRootObject",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidDomainNameForOriginAccessControl
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDomainNameForOriginAccessControl>()(
     "InvalidDomainNameForOriginAccessControl",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidErrorCode
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidErrorCode>()(
     "InvalidErrorCode",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidForwardCookies
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidForwardCookies>()(
     "InvalidForwardCookies",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidFunctionAssociation
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidFunctionAssociation>()(
     "InvalidFunctionAssociation",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidGeoRestrictionParameter
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidGeoRestrictionParameter>()(
     "InvalidGeoRestrictionParameter",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidHeadersForS3Origin
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidHeadersForS3Origin>()(
     "InvalidHeadersForS3Origin",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidIfMatchVersion
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidIfMatchVersion>()(
     "InvalidIfMatchVersion",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidLambdaFunctionAssociation
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidLambdaFunctionAssociation>()(
     "InvalidLambdaFunctionAssociation",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidLocationCode
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidLocationCode>()(
     "InvalidLocationCode",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidMinimumProtocolVersion
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidMinimumProtocolVersion>()(
     "InvalidMinimumProtocolVersion",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidOrigin
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidOrigin>()(
     "InvalidOrigin",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidOriginAccessControl
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidOriginAccessControl>()(
     "InvalidOriginAccessControl",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidOriginAccessIdentity
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidOriginAccessIdentity>()(
     "InvalidOriginAccessIdentity",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidOriginKeepaliveTimeout
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidOriginKeepaliveTimeout>()(
     "InvalidOriginKeepaliveTimeout",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidOriginReadTimeout
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidOriginReadTimeout>()(
     "InvalidOriginReadTimeout",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidProtocolSettings
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidProtocolSettings>()(
     "InvalidProtocolSettings",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidQueryStringParameters
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidQueryStringParameters>()(
     "InvalidQueryStringParameters",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidRelativePath
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRelativePath>()(
     "InvalidRelativePath",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidRequiredProtocol
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequiredProtocol>()(
     "InvalidRequiredProtocol",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidResponseCode
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidResponseCode>()(
     "InvalidResponseCode",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidTagging
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTagging>()(
     "InvalidTagging",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidTTLOrder
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTTLOrder>()(
     "InvalidTTLOrder",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidViewerCertificate
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidViewerCertificate>()(
     "InvalidViewerCertificate",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidWebACLId
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidWebACLId>()(
     "InvalidWebACLId",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class KeyGroupAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<KeyGroupAlreadyExists>()(
     "KeyGroupAlreadyExists",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class MissingBody
   extends /*@__PURE__*/ S.TaggedErrorClass<MissingBody>()(
     "MissingBody",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class MonitoringSubscriptionAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<MonitoringSubscriptionAlreadyExists>()(
     "MonitoringSubscriptionAlreadyExists",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class NoSuchCachePolicy
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchCachePolicy>()(
     "NoSuchCachePolicy",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class NoSuchCloudFrontOriginAccessIdentity
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchCloudFrontOriginAccessIdentity>()(
     "NoSuchCloudFrontOriginAccessIdentity",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class NoSuchContinuousDeploymentPolicy
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchContinuousDeploymentPolicy>()(
     "NoSuchContinuousDeploymentPolicy",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class NoSuchDistribution
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchDistribution>()(
     "NoSuchDistribution",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class NoSuchFieldLevelEncryptionConfig
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchFieldLevelEncryptionConfig>()(
     "NoSuchFieldLevelEncryptionConfig",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class NoSuchFieldLevelEncryptionProfile
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchFieldLevelEncryptionProfile>()(
     "NoSuchFieldLevelEncryptionProfile",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class NoSuchFunctionExists
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchFunctionExists>()(
     "NoSuchFunctionExists",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class NoSuchInvalidation
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchInvalidation>()(
     "NoSuchInvalidation",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class NoSuchMonitoringSubscription
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchMonitoringSubscription>()(
     "NoSuchMonitoringSubscription",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class NoSuchOrigin
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchOrigin>()(
     "NoSuchOrigin",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class NoSuchOriginAccessControl
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchOriginAccessControl>()(
     "NoSuchOriginAccessControl",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class NoSuchOriginRequestPolicy
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchOriginRequestPolicy>()(
     "NoSuchOriginRequestPolicy",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class NoSuchPublicKey
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchPublicKey>()(
     "NoSuchPublicKey",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class NoSuchRealtimeLogConfig
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchRealtimeLogConfig>()(
     "NoSuchRealtimeLogConfig",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class NoSuchResource
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchResource>()(
     "NoSuchResource",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class NoSuchResponseHeadersPolicy
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchResponseHeadersPolicy>()(
     "NoSuchResponseHeadersPolicy",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class NoSuchStreamingDistribution
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchStreamingDistribution>()(
     "NoSuchStreamingDistribution",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class OriginAccessControlAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<OriginAccessControlAlreadyExists>()(
     "OriginAccessControlAlreadyExists",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class OriginAccessControlInUse
   extends /*@__PURE__*/ S.TaggedErrorClass<OriginAccessControlInUse>()(
     "OriginAccessControlInUse",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withDependencyViolationError) {}
 export class OriginRequestPolicyAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<OriginRequestPolicyAlreadyExists>()(
     "OriginRequestPolicyAlreadyExists",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class OriginRequestPolicyInUse
   extends /*@__PURE__*/ S.TaggedErrorClass<OriginRequestPolicyInUse>()(
     "OriginRequestPolicyInUse",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withDependencyViolationError) {}
 export class PreconditionFailed
   extends /*@__PURE__*/ S.TaggedErrorClass<PreconditionFailed>()(
     "PreconditionFailed",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(412),
   ) {}
 export class PublicKeyAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<PublicKeyAlreadyExists>()(
     "PublicKeyAlreadyExists",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class PublicKeyInUse
   extends /*@__PURE__*/ S.TaggedErrorClass<PublicKeyInUse>()(
     "PublicKeyInUse",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withDependencyViolationError) {}
 export class QueryArgProfileEmpty
   extends /*@__PURE__*/ S.TaggedErrorClass<QueryArgProfileEmpty>()(
     "QueryArgProfileEmpty",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class RealtimeLogConfigAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<RealtimeLogConfigAlreadyExists>()(
     "RealtimeLogConfigAlreadyExists",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class RealtimeLogConfigInUse
   extends /*@__PURE__*/ S.TaggedErrorClass<RealtimeLogConfigInUse>()(
     "RealtimeLogConfigInUse",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError, C.withDependencyViolationError) {}
 export class RealtimeLogConfigOwnerMismatch
   extends /*@__PURE__*/ S.TaggedErrorClass<RealtimeLogConfigOwnerMismatch>()(
     "RealtimeLogConfigOwnerMismatch",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export class ResourceInUse
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUse>()(
     "ResourceInUse",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withDependencyViolationError) {}
 export class ResourceNotDisabled
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotDisabled>()(
     "ResourceNotDisabled",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ResponseHeadersPolicyAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<ResponseHeadersPolicyAlreadyExists>()(
     "ResponseHeadersPolicyAlreadyExists",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class ResponseHeadersPolicyInUse
   extends /*@__PURE__*/ S.TaggedErrorClass<ResponseHeadersPolicyInUse>()(
     "ResponseHeadersPolicyInUse",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withDependencyViolationError) {}
 export class StagingDistributionInUse
   extends /*@__PURE__*/ S.TaggedErrorClass<StagingDistributionInUse>()(
     "StagingDistributionInUse",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withDependencyViolationError) {}
 export class StreamingDistributionAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<StreamingDistributionAlreadyExists>()(
     "StreamingDistributionAlreadyExists",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class StreamingDistributionNotDisabled
   extends /*@__PURE__*/ S.TaggedErrorClass<StreamingDistributionNotDisabled>()(
     "StreamingDistributionNotDisabled",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class TestFunctionFailed
   extends /*@__PURE__*/ S.TaggedErrorClass<TestFunctionFailed>()(
     "TestFunctionFailed",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class TooLongCSPInResponseHeadersPolicy
   extends /*@__PURE__*/ S.TaggedErrorClass<TooLongCSPInResponseHeadersPolicy>()(
     "TooLongCSPInResponseHeadersPolicy",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyCacheBehaviors
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyCacheBehaviors>()(
     "TooManyCacheBehaviors",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyCachePolicies
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyCachePolicies>()(
     "TooManyCachePolicies",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyCertificates
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyCertificates>()(
     "TooManyCertificates",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyCloudFrontOriginAccessIdentities
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyCloudFrontOriginAccessIdentities>()(
     "TooManyCloudFrontOriginAccessIdentities",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyContinuousDeploymentPolicies
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyContinuousDeploymentPolicies>()(
     "TooManyContinuousDeploymentPolicies",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyCookieNamesInWhiteList
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyCookieNamesInWhiteList>()(
     "TooManyCookieNamesInWhiteList",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyCookiesInCachePolicy
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyCookiesInCachePolicy>()(
     "TooManyCookiesInCachePolicy",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyCookiesInOriginRequestPolicy
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyCookiesInOriginRequestPolicy>()(
     "TooManyCookiesInOriginRequestPolicy",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyCustomHeadersInResponseHeadersPolicy
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyCustomHeadersInResponseHeadersPolicy>()(
     "TooManyCustomHeadersInResponseHeadersPolicy",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyDistributionCNAMEs
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyDistributionCNAMEs>()(
     "TooManyDistributionCNAMEs",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyDistributions
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyDistributions>()(
     "TooManyDistributions",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyDistributionsAssociatedToCachePolicy
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyDistributionsAssociatedToCachePolicy>()(
     "TooManyDistributionsAssociatedToCachePolicy",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyDistributionsAssociatedToFieldLevelEncryptionConfig
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyDistributionsAssociatedToFieldLevelEncryptionConfig>()(
     "TooManyDistributionsAssociatedToFieldLevelEncryptionConfig",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyDistributionsAssociatedToKeyGroup
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyDistributionsAssociatedToKeyGroup>()(
     "TooManyDistributionsAssociatedToKeyGroup",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyDistributionsAssociatedToOriginAccessControl
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyDistributionsAssociatedToOriginAccessControl>()(
     "TooManyDistributionsAssociatedToOriginAccessControl",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyDistributionsAssociatedToOriginRequestPolicy
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyDistributionsAssociatedToOriginRequestPolicy>()(
     "TooManyDistributionsAssociatedToOriginRequestPolicy",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyDistributionsAssociatedToResponseHeadersPolicy
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyDistributionsAssociatedToResponseHeadersPolicy>()(
     "TooManyDistributionsAssociatedToResponseHeadersPolicy",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyDistributionsWithFunctionAssociations
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyDistributionsWithFunctionAssociations>()(
     "TooManyDistributionsWithFunctionAssociations",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyDistributionsWithLambdaAssociations
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyDistributionsWithLambdaAssociations>()(
     "TooManyDistributionsWithLambdaAssociations",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyDistributionsWithSingleFunctionARN
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyDistributionsWithSingleFunctionARN>()(
     "TooManyDistributionsWithSingleFunctionARN",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyFieldLevelEncryptionConfigs
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyFieldLevelEncryptionConfigs>()(
     "TooManyFieldLevelEncryptionConfigs",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyFieldLevelEncryptionContentTypeProfiles
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyFieldLevelEncryptionContentTypeProfiles>()(
     "TooManyFieldLevelEncryptionContentTypeProfiles",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyFieldLevelEncryptionEncryptionEntities
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyFieldLevelEncryptionEncryptionEntities>()(
     "TooManyFieldLevelEncryptionEncryptionEntities",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyFieldLevelEncryptionFieldPatterns
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyFieldLevelEncryptionFieldPatterns>()(
     "TooManyFieldLevelEncryptionFieldPatterns",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyFieldLevelEncryptionProfiles
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyFieldLevelEncryptionProfiles>()(
     "TooManyFieldLevelEncryptionProfiles",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyFieldLevelEncryptionQueryArgProfiles
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyFieldLevelEncryptionQueryArgProfiles>()(
     "TooManyFieldLevelEncryptionQueryArgProfiles",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyFunctionAssociations
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyFunctionAssociations>()(
     "TooManyFunctionAssociations",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyFunctions
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyFunctions>()(
     "TooManyFunctions",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyHeadersInCachePolicy
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyHeadersInCachePolicy>()(
     "TooManyHeadersInCachePolicy",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyHeadersInForwardedValues
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyHeadersInForwardedValues>()(
     "TooManyHeadersInForwardedValues",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyHeadersInOriginRequestPolicy
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyHeadersInOriginRequestPolicy>()(
     "TooManyHeadersInOriginRequestPolicy",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyInvalidationsInProgress
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyInvalidationsInProgress>()(
     "TooManyInvalidationsInProgress",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyKeyGroups
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyKeyGroups>()(
     "TooManyKeyGroups",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyKeyGroupsAssociatedToDistribution
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyKeyGroupsAssociatedToDistribution>()(
     "TooManyKeyGroupsAssociatedToDistribution",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyLambdaFunctionAssociations
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyLambdaFunctionAssociations>()(
     "TooManyLambdaFunctionAssociations",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyOriginAccessControls
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyOriginAccessControls>()(
     "TooManyOriginAccessControls",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyOriginCustomHeaders
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyOriginCustomHeaders>()(
     "TooManyOriginCustomHeaders",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyOriginGroupsPerDistribution
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyOriginGroupsPerDistribution>()(
     "TooManyOriginGroupsPerDistribution",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyOriginRequestPolicies
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyOriginRequestPolicies>()(
     "TooManyOriginRequestPolicies",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyOrigins
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyOrigins>()(
     "TooManyOrigins",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyPublicKeys
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyPublicKeys>()(
     "TooManyPublicKeys",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyPublicKeysInKeyGroup
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyPublicKeysInKeyGroup>()(
     "TooManyPublicKeysInKeyGroup",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyQueryStringParameters
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyQueryStringParameters>()(
     "TooManyQueryStringParameters",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyQueryStringsInCachePolicy
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyQueryStringsInCachePolicy>()(
     "TooManyQueryStringsInCachePolicy",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyQueryStringsInOriginRequestPolicy
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyQueryStringsInOriginRequestPolicy>()(
     "TooManyQueryStringsInOriginRequestPolicy",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyRealtimeLogConfigs
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRealtimeLogConfigs>()(
     "TooManyRealtimeLogConfigs",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyRemoveHeadersInResponseHeadersPolicy
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRemoveHeadersInResponseHeadersPolicy>()(
     "TooManyRemoveHeadersInResponseHeadersPolicy",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyResponseHeadersPolicies
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyResponseHeadersPolicies>()(
     "TooManyResponseHeadersPolicies",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyStreamingDistributionCNAMEs
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyStreamingDistributionCNAMEs>()(
     "TooManyStreamingDistributionCNAMEs",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyStreamingDistributions
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyStreamingDistributions>()(
     "TooManyStreamingDistributions",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyTrustedSigners
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTrustedSigners>()(
     "TooManyTrustedSigners",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TrustedKeyGroupDoesNotExist
   extends /*@__PURE__*/ S.TaggedErrorClass<TrustedKeyGroupDoesNotExist>()(
     "TrustedKeyGroupDoesNotExist",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TrustedSignerDoesNotExist
   extends /*@__PURE__*/ S.TaggedErrorClass<TrustedSignerDoesNotExist>()(
     "TrustedSignerDoesNotExist",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class UnsupportedOperation
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedOperation>()(
     "UnsupportedOperation",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export interface AssociateAliasRequest {

--- a/packages/aws/src/services/cloudhsm-v2.ts
+++ b/packages/aws/src/services/cloudhsm-v2.ts
@@ -94,37 +94,37 @@ const rules = T.EndpointResolver((p, _) => {
 export class CloudHsmAccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<CloudHsmAccessDeniedException>()(
     "CloudHsmAccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAuthError) {}
 export class CloudHsmInternalFailureException
   extends /*@__PURE__*/ S.TaggedErrorClass<CloudHsmInternalFailureException>()(
     "CloudHsmInternalFailureException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class CloudHsmInvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<CloudHsmInvalidRequestException>()(
     "CloudHsmInvalidRequestException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class CloudHsmResourceLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<CloudHsmResourceLimitExceededException>()(
     "CloudHsmResourceLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class CloudHsmResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<CloudHsmResourceNotFoundException>()(
     "CloudHsmResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class CloudHsmServiceException
   extends /*@__PURE__*/ S.TaggedErrorClass<CloudHsmServiceException>()(
     "CloudHsmServiceException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class CloudHsmTagException
   extends /*@__PURE__*/ S.TaggedErrorClass<CloudHsmTagException>()(
     "CloudHsmTagException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type Region = string;
 export type BackupId = string;

--- a/packages/aws/src/services/cloudhsm.ts
+++ b/packages/aws/src/services/cloudhsm.ts
@@ -86,17 +86,26 @@ const rules = T.EndpointResolver((p, _) => {
 export class CloudHsmInternalException
   extends /*@__PURE__*/ S.TaggedErrorClass<CloudHsmInternalException>()(
     "CloudHsmInternalException",
-    { message: S.optional(S.String), retryable: S.optional(S.Boolean) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      retryable: S.optional(S.Boolean),
+    },
   ) {}
 export class CloudHsmServiceException
   extends /*@__PURE__*/ S.TaggedErrorClass<CloudHsmServiceException>()(
     "CloudHsmServiceException",
-    { message: S.optional(S.String), retryable: S.optional(S.Boolean) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      retryable: S.optional(S.Boolean),
+    },
   ) {}
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
-    { message: S.optional(S.String), retryable: S.optional(S.Boolean) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      retryable: S.optional(S.Boolean),
+    },
   ) {}
 export type TagKey = string;
 export type TagValue = string;

--- a/packages/aws/src/services/cloudsearch-domain.ts
+++ b/packages/aws/src/services/cloudsearch-domain.ts
@@ -87,12 +87,15 @@ const rules = T.EndpointResolver((p, _) => {
 export class DocumentServiceException
   extends /*@__PURE__*/ S.TaggedErrorClass<DocumentServiceException>()(
     "DocumentServiceException",
-    { status: S.optional(S.String), message: S.optional(S.String) },
+    {
+      status: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
   ) {}
 export class SearchException
   extends /*@__PURE__*/ S.TaggedErrorClass<SearchException>()(
     "SearchException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type Cursor = string;
 export type Expr = string;

--- a/packages/aws/src/services/cloudsearch.ts
+++ b/packages/aws/src/services/cloudsearch.ts
@@ -88,12 +88,15 @@ const rules = T.EndpointResolver((p, _) => {
 export class BaseException
   extends /*@__PURE__*/ S.TaggedErrorClass<BaseException>()("BaseException", {
     Code: S.optional(S.String),
-    Message: S.optional(S.String),
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
   }) {}
 export class DisabledOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<DisabledOperationException>()(
     "DisabledOperationException",
-    { Code: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Code: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.all(
       T.AwsQueryError({ code: "DisabledAction", httpResponseCode: 409 }),
       T.HttpError(409),
@@ -102,7 +105,10 @@ export class DisabledOperationException
 export class InternalException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalException>()(
     "InternalException",
-    { Code: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Code: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.all(
       T.AwsQueryError({ code: "InternalException", httpResponseCode: 500 }),
       T.HttpError(500),
@@ -111,7 +117,10 @@ export class InternalException
 export class InvalidTypeException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTypeException>()(
     "InvalidTypeException",
-    { Code: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Code: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.all(
       T.AwsQueryError({ code: "InvalidType", httpResponseCode: 409 }),
       T.HttpError(409),
@@ -120,7 +129,10 @@ export class InvalidTypeException
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { Code: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Code: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.all(
       T.AwsQueryError({ code: "LimitExceeded", httpResponseCode: 409 }),
       T.HttpError(409),
@@ -129,7 +141,10 @@ export class LimitExceededException
 export class ResourceAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceAlreadyExistsException>()(
     "ResourceAlreadyExistsException",
-    { Code: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Code: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.all(
       T.AwsQueryError({ code: "ResourceAlreadyExists", httpResponseCode: 409 }),
       T.HttpError(409),
@@ -138,7 +153,10 @@ export class ResourceAlreadyExistsException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Code: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Code: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.all(
       T.AwsQueryError({ code: "ResourceNotFound", httpResponseCode: 409 }),
       T.HttpError(409),
@@ -147,7 +165,10 @@ export class ResourceNotFoundException
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Code: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Code: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type DomainName = string;

--- a/packages/aws/src/services/cloudtrail-data.ts
+++ b/packages/aws/src/services/cloudtrail-data.ts
@@ -86,32 +86,32 @@ const rules = T.EndpointResolver((p, _) => {
 export class ChannelInsufficientPermission
   extends /*@__PURE__*/ S.TaggedErrorClass<ChannelInsufficientPermission>()(
     "ChannelInsufficientPermission",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ChannelNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<ChannelNotFound>()(
     "ChannelNotFound",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ChannelUnsupportedSchema
   extends /*@__PURE__*/ S.TaggedErrorClass<ChannelUnsupportedSchema>()(
     "ChannelUnsupportedSchema",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class DuplicatedAuditEventId
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicatedAuditEventId>()(
     "DuplicatedAuditEventId",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidChannelARN
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidChannelARN>()(
     "InvalidChannelARN",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class UnsupportedOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedOperationException>()(
     "UnsupportedOperationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type Uuid = string;
 export interface AuditEvent {

--- a/packages/aws/src/services/cloudtrail.ts
+++ b/packages/aws/src/services/cloudtrail.ts
@@ -95,7 +95,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ResourceAccessDenied", httpResponseCode: 403 }),
       T.HttpError(403),
@@ -104,7 +104,7 @@ export class AccessDeniedException
 export class AccountHasOngoingImportException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccountHasOngoingImportException>()(
     "AccountHasOngoingImportException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "AccountHasOngoingImport",
@@ -116,7 +116,7 @@ export class AccountHasOngoingImportException
 export class AccountNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccountNotFoundException>()(
     "AccountNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "AccountNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -125,7 +125,7 @@ export class AccountNotFoundException
 export class AccountNotRegisteredException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccountNotRegisteredException>()(
     "AccountNotRegisteredException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "AccountNotRegistered", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -134,7 +134,7 @@ export class AccountNotRegisteredException
 export class AccountRegisteredException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccountRegisteredException>()(
     "AccountRegisteredException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "AccountRegistered", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -143,7 +143,7 @@ export class AccountRegisteredException
 export class CannotDelegateManagementAccountException
   extends /*@__PURE__*/ S.TaggedErrorClass<CannotDelegateManagementAccountException>()(
     "CannotDelegateManagementAccountException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CannotDelegateManagementAccount",
@@ -155,7 +155,7 @@ export class CannotDelegateManagementAccountException
 export class ChannelAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ChannelAlreadyExistsException>()(
     "ChannelAlreadyExistsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ChannelAlreadyExists", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -164,7 +164,7 @@ export class ChannelAlreadyExistsException
 export class ChannelARNInvalidException
   extends /*@__PURE__*/ S.TaggedErrorClass<ChannelARNInvalidException>()(
     "ChannelARNInvalidException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ChannelARNInvalid", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -173,7 +173,7 @@ export class ChannelARNInvalidException
 export class ChannelExistsForEDSException
   extends /*@__PURE__*/ S.TaggedErrorClass<ChannelExistsForEDSException>()(
     "ChannelExistsForEDSException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ChannelExistsForEDS", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -182,7 +182,7 @@ export class ChannelExistsForEDSException
 export class ChannelMaxLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ChannelMaxLimitExceededException>()(
     "ChannelMaxLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ChannelMaxLimitExceeded",
@@ -194,7 +194,7 @@ export class ChannelMaxLimitExceededException
 export class ChannelNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ChannelNotFoundException>()(
     "ChannelNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ChannelNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -203,7 +203,7 @@ export class ChannelNotFoundException
 export class CloudTrailAccessNotEnabledException
   extends /*@__PURE__*/ S.TaggedErrorClass<CloudTrailAccessNotEnabledException>()(
     "CloudTrailAccessNotEnabledException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CloudTrailAccessNotEnabled",
@@ -215,7 +215,7 @@ export class CloudTrailAccessNotEnabledException
 export class CloudTrailARNInvalidException
   extends /*@__PURE__*/ S.TaggedErrorClass<CloudTrailARNInvalidException>()(
     "CloudTrailARNInvalidException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "CloudTrailARNInvalid", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -224,7 +224,7 @@ export class CloudTrailARNInvalidException
 export class CloudTrailInvalidClientTokenIdException
   extends /*@__PURE__*/ S.TaggedErrorClass<CloudTrailInvalidClientTokenIdException>()(
     "CloudTrailInvalidClientTokenIdException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CloudTrailInvalidClientTokenId",
@@ -236,7 +236,7 @@ export class CloudTrailInvalidClientTokenIdException
 export class CloudTrailLakeOnboardingClosed
   extends /*@__PURE__*/ S.TaggedErrorClass<CloudTrailLakeOnboardingClosed>()(
     "CloudTrailLakeOnboardingClosed",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "InvalidParameterException",
       message: { includes: "no longer accepting new customers" },
@@ -245,7 +245,7 @@ export class CloudTrailLakeOnboardingClosed
 export class CloudWatchLogsDeliveryUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<CloudWatchLogsDeliveryUnavailableException>()(
     "CloudWatchLogsDeliveryUnavailableException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CloudWatchLogsDeliveryUnavailable",
@@ -257,7 +257,7 @@ export class CloudWatchLogsDeliveryUnavailableException
 export class ConcurrentModificationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentModificationException>()(
     "ConcurrentModificationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ConcurrentModification",
@@ -269,7 +269,7 @@ export class ConcurrentModificationException
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ConflictException", httpResponseCode: 409 }),
       T.HttpError(409),
@@ -278,7 +278,7 @@ export class ConflictException
 export class DelegatedAdminAccountLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<DelegatedAdminAccountLimitExceededException>()(
     "DelegatedAdminAccountLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DelegatedAdminAccountLimitExceeded",
@@ -290,7 +290,7 @@ export class DelegatedAdminAccountLimitExceededException
 export class EventDataStoreAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<EventDataStoreAlreadyExistsException>()(
     "EventDataStoreAlreadyExistsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "EventDataStoreAlreadyExists",
@@ -302,7 +302,7 @@ export class EventDataStoreAlreadyExistsException
 export class EventDataStoreARNInvalidException
   extends /*@__PURE__*/ S.TaggedErrorClass<EventDataStoreARNInvalidException>()(
     "EventDataStoreARNInvalidException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "EventDataStoreARNInvalid",
@@ -314,7 +314,7 @@ export class EventDataStoreARNInvalidException
 export class EventDataStoreFederationEnabledException
   extends /*@__PURE__*/ S.TaggedErrorClass<EventDataStoreFederationEnabledException>()(
     "EventDataStoreFederationEnabledException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "EventDataStoreFederationEnabled",
@@ -326,7 +326,7 @@ export class EventDataStoreFederationEnabledException
 export class EventDataStoreHasOngoingImportException
   extends /*@__PURE__*/ S.TaggedErrorClass<EventDataStoreHasOngoingImportException>()(
     "EventDataStoreHasOngoingImportException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "EventDataStoreHasOngoingImport",
@@ -338,7 +338,7 @@ export class EventDataStoreHasOngoingImportException
 export class EventDataStoreMaxLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<EventDataStoreMaxLimitExceededException>()(
     "EventDataStoreMaxLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "EventDataStoreMaxLimitExceeded",
@@ -350,7 +350,7 @@ export class EventDataStoreMaxLimitExceededException
 export class EventDataStoreNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<EventDataStoreNotFoundException>()(
     "EventDataStoreNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "EventDataStoreNotFound",
@@ -362,7 +362,7 @@ export class EventDataStoreNotFoundException
 export class EventDataStoreTerminationProtectedException
   extends /*@__PURE__*/ S.TaggedErrorClass<EventDataStoreTerminationProtectedException>()(
     "EventDataStoreTerminationProtectedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "EventDataStoreTerminationProtectedException",
@@ -374,7 +374,7 @@ export class EventDataStoreTerminationProtectedException
 export class GenerateResponseException
   extends /*@__PURE__*/ S.TaggedErrorClass<GenerateResponseException>()(
     "GenerateResponseException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "GenerateResponse", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -383,7 +383,7 @@ export class GenerateResponseException
 export class ImportNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ImportNotFoundException>()(
     "ImportNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ImportNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -392,7 +392,7 @@ export class ImportNotFoundException
 export class InactiveEventDataStoreException
   extends /*@__PURE__*/ S.TaggedErrorClass<InactiveEventDataStoreException>()(
     "InactiveEventDataStoreException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InactiveEventDataStore",
@@ -404,7 +404,7 @@ export class InactiveEventDataStoreException
 export class InactiveQueryException
   extends /*@__PURE__*/ S.TaggedErrorClass<InactiveQueryException>()(
     "InactiveQueryException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InactiveQuery", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -413,7 +413,7 @@ export class InactiveQueryException
 export class InsightNotEnabledException
   extends /*@__PURE__*/ S.TaggedErrorClass<InsightNotEnabledException>()(
     "InsightNotEnabledException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InsightNotEnabled", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -422,7 +422,7 @@ export class InsightNotEnabledException
 export class InsufficientDependencyServiceAccessPermissionException
   extends /*@__PURE__*/ S.TaggedErrorClass<InsufficientDependencyServiceAccessPermissionException>()(
     "InsufficientDependencyServiceAccessPermissionException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InsufficientDependencyServiceAccessPermission",
@@ -434,7 +434,7 @@ export class InsufficientDependencyServiceAccessPermissionException
 export class InsufficientEncryptionPolicyException
   extends /*@__PURE__*/ S.TaggedErrorClass<InsufficientEncryptionPolicyException>()(
     "InsufficientEncryptionPolicyException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InsufficientEncryptionPolicy",
@@ -446,7 +446,7 @@ export class InsufficientEncryptionPolicyException
 export class InsufficientIAMAccessPermissionException
   extends /*@__PURE__*/ S.TaggedErrorClass<InsufficientIAMAccessPermissionException>()(
     "InsufficientIAMAccessPermissionException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InsufficientIAMAccessPermission",
@@ -458,7 +458,7 @@ export class InsufficientIAMAccessPermissionException
 export class InsufficientS3BucketPolicyException
   extends /*@__PURE__*/ S.TaggedErrorClass<InsufficientS3BucketPolicyException>()(
     "InsufficientS3BucketPolicyException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InsufficientS3BucketPolicy",
@@ -470,7 +470,7 @@ export class InsufficientS3BucketPolicyException
 export class InsufficientSnsTopicPolicyException
   extends /*@__PURE__*/ S.TaggedErrorClass<InsufficientSnsTopicPolicyException>()(
     "InsufficientSnsTopicPolicyException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InsufficientSnsTopicPolicy",
@@ -482,7 +482,7 @@ export class InsufficientSnsTopicPolicyException
 export class InvalidCloudWatchLogsLogGroupArnException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCloudWatchLogsLogGroupArnException>()(
     "InvalidCloudWatchLogsLogGroupArnException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidCloudWatchLogsLogGroupArn",
@@ -494,7 +494,7 @@ export class InvalidCloudWatchLogsLogGroupArnException
 export class InvalidCloudWatchLogsRoleArnException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCloudWatchLogsRoleArnException>()(
     "InvalidCloudWatchLogsRoleArnException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidCloudWatchLogsRoleArn",
@@ -506,7 +506,7 @@ export class InvalidCloudWatchLogsRoleArnException
 export class InvalidDateRangeException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDateRangeException>()(
     "InvalidDateRangeException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidDateRange", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -515,7 +515,7 @@ export class InvalidDateRangeException
 export class InvalidEventCategoryException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidEventCategoryException>()(
     "InvalidEventCategoryException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidEventCategory", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -524,7 +524,7 @@ export class InvalidEventCategoryException
 export class InvalidEventDataStoreCategoryException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidEventDataStoreCategoryException>()(
     "InvalidEventDataStoreCategoryException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidEventDataStoreCategory",
@@ -536,7 +536,7 @@ export class InvalidEventDataStoreCategoryException
 export class InvalidEventDataStoreStatusException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidEventDataStoreStatusException>()(
     "InvalidEventDataStoreStatusException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidEventDataStoreStatus",
@@ -548,7 +548,7 @@ export class InvalidEventDataStoreStatusException
 export class InvalidEventSelectorsException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidEventSelectorsException>()(
     "InvalidEventSelectorsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidEventSelectors", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -557,7 +557,7 @@ export class InvalidEventSelectorsException
 export class InvalidHomeRegionException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidHomeRegionException>()(
     "InvalidHomeRegionException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidHomeRegion", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -566,7 +566,7 @@ export class InvalidHomeRegionException
 export class InvalidImportSourceException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidImportSourceException>()(
     "InvalidImportSourceException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidImportSource", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -575,7 +575,7 @@ export class InvalidImportSourceException
 export class InvalidInsightSelectorsException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInsightSelectorsException>()(
     "InvalidInsightSelectorsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidInsightSelectors",
@@ -587,7 +587,7 @@ export class InvalidInsightSelectorsException
 export class InvalidKmsKeyIdException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidKmsKeyIdException>()(
     "InvalidKmsKeyIdException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidKmsKeyId", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -596,7 +596,7 @@ export class InvalidKmsKeyIdException
 export class InvalidLookupAttributesException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidLookupAttributesException>()(
     "InvalidLookupAttributesException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidLookupAttributes",
@@ -608,7 +608,7 @@ export class InvalidLookupAttributesException
 export class InvalidMaxResultsException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidMaxResultsException>()(
     "InvalidMaxResultsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidMaxResults", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -617,7 +617,7 @@ export class InvalidMaxResultsException
 export class InvalidNextTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNextTokenException>()(
     "InvalidNextTokenException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidNextToken", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -626,7 +626,7 @@ export class InvalidNextTokenException
 export class InvalidParameterCombinationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterCombinationException>()(
     "InvalidParameterCombinationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidParameterCombinationError",
@@ -638,7 +638,7 @@ export class InvalidParameterCombinationException
 export class InvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterException>()(
     "InvalidParameterException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidParameter", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -647,7 +647,7 @@ export class InvalidParameterException
 export class InvalidQueryStatementException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidQueryStatementException>()(
     "InvalidQueryStatementException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidQueryStatement", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -656,7 +656,7 @@ export class InvalidQueryStatementException
 export class InvalidQueryStatusException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidQueryStatusException>()(
     "InvalidQueryStatusException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidQueryStatus", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -665,7 +665,7 @@ export class InvalidQueryStatusException
 export class InvalidS3BucketNameException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidS3BucketNameException>()(
     "InvalidS3BucketNameException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidS3BucketName", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -674,7 +674,7 @@ export class InvalidS3BucketNameException
 export class InvalidS3PrefixException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidS3PrefixException>()(
     "InvalidS3PrefixException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidS3Prefix", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -683,7 +683,7 @@ export class InvalidS3PrefixException
 export class InvalidSnsTopicNameException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSnsTopicNameException>()(
     "InvalidSnsTopicNameException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidSnsTopicName", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -692,7 +692,7 @@ export class InvalidSnsTopicNameException
 export class InvalidSourceException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSourceException>()(
     "InvalidSourceException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidSource", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -701,7 +701,7 @@ export class InvalidSourceException
 export class InvalidTagParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTagParameterException>()(
     "InvalidTagParameterException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidTagParameter", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -710,7 +710,7 @@ export class InvalidTagParameterException
 export class InvalidTimeRangeException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTimeRangeException>()(
     "InvalidTimeRangeException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidTimeRange", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -719,7 +719,7 @@ export class InvalidTimeRangeException
 export class InvalidTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTokenException>()(
     "InvalidTokenException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidToken", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -728,7 +728,7 @@ export class InvalidTokenException
 export class InvalidTrailNameException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTrailNameException>()(
     "InvalidTrailNameException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidTrailName", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -737,7 +737,7 @@ export class InvalidTrailNameException
 export class KmsException
   extends /*@__PURE__*/ S.TaggedErrorClass<KmsException>()(
     "KmsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "KmsException", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -746,7 +746,7 @@ export class KmsException
 export class KmsKeyDisabledException
   extends /*@__PURE__*/ S.TaggedErrorClass<KmsKeyDisabledException>()(
     "KmsKeyDisabledException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "KmsKeyDisabled", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -755,7 +755,7 @@ export class KmsKeyDisabledException
 export class KmsKeyNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<KmsKeyNotFoundException>()(
     "KmsKeyNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "KmsKeyNotFound", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -764,7 +764,7 @@ export class KmsKeyNotFoundException
 export class MaxConcurrentQueriesException
   extends /*@__PURE__*/ S.TaggedErrorClass<MaxConcurrentQueriesException>()(
     "MaxConcurrentQueriesException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "MaxConcurrentQueries", httpResponseCode: 429 }),
       T.HttpError(429),
@@ -773,7 +773,7 @@ export class MaxConcurrentQueriesException
 export class MaximumNumberOfTrailsExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<MaximumNumberOfTrailsExceededException>()(
     "MaximumNumberOfTrailsExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "MaximumNumberOfTrailsExceeded",
@@ -785,7 +785,7 @@ export class MaximumNumberOfTrailsExceededException
 export class NoManagementAccountSLRExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<NoManagementAccountSLRExistsException>()(
     "NoManagementAccountSLRExistsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "NoManagementAccountSLRExists",
@@ -797,7 +797,7 @@ export class NoManagementAccountSLRExistsException
 export class NotOrganizationManagementAccountException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotOrganizationManagementAccountException>()(
     "NotOrganizationManagementAccountException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "NotOrganizationManagementAccount",
@@ -809,7 +809,7 @@ export class NotOrganizationManagementAccountException
 export class NotOrganizationMasterAccountException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotOrganizationMasterAccountException>()(
     "NotOrganizationMasterAccountException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "NotOrganizationMasterAccount",
@@ -821,7 +821,7 @@ export class NotOrganizationMasterAccountException
 export class OperationNotPermittedException
   extends /*@__PURE__*/ S.TaggedErrorClass<OperationNotPermittedException>()(
     "OperationNotPermittedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "OperationNotPermitted", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -830,7 +830,7 @@ export class OperationNotPermittedException
 export class OrganizationNotInAllFeaturesModeException
   extends /*@__PURE__*/ S.TaggedErrorClass<OrganizationNotInAllFeaturesModeException>()(
     "OrganizationNotInAllFeaturesModeException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "OrganizationNotInAllFeaturesMode",
@@ -842,7 +842,7 @@ export class OrganizationNotInAllFeaturesModeException
 export class OrganizationsNotInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<OrganizationsNotInUseException>()(
     "OrganizationsNotInUseException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "OrganizationsNotInUse", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -851,7 +851,7 @@ export class OrganizationsNotInUseException
 export class QueryIdNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<QueryIdNotFoundException>()(
     "QueryIdNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "QueryIdNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -860,7 +860,7 @@ export class QueryIdNotFoundException
 export class ResourceARNNotValidException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceARNNotValidException>()(
     "ResourceARNNotValidException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ResourceARNNotValid", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -869,7 +869,7 @@ export class ResourceARNNotValidException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ResourceNotFound", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -878,7 +878,7 @@ export class ResourceNotFoundException
 export class ResourcePolicyNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourcePolicyNotFoundException>()(
     "ResourcePolicyNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ResourcePolicyNotFound",
@@ -890,7 +890,7 @@ export class ResourcePolicyNotFoundException
 export class ResourcePolicyNotValidException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourcePolicyNotValidException>()(
     "ResourcePolicyNotValidException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ResourcePolicyNotValid",
@@ -902,7 +902,7 @@ export class ResourcePolicyNotValidException
 export class ResourceTypeNotSupportedException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceTypeNotSupportedException>()(
     "ResourceTypeNotSupportedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ResourceTypeNotSupported",
@@ -914,7 +914,7 @@ export class ResourceTypeNotSupportedException
 export class S3BucketDoesNotExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<S3BucketDoesNotExistException>()(
     "S3BucketDoesNotExistException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "S3BucketDoesNotExist", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -923,7 +923,7 @@ export class S3BucketDoesNotExistException
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ServiceQuotaExceeded", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -932,7 +932,7 @@ export class ServiceQuotaExceededException
 export class TagsLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<TagsLimitExceededException>()(
     "TagsLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "TagsLimitExceeded", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -941,7 +941,7 @@ export class TagsLimitExceededException
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ThrottlingException", httpResponseCode: 429 }),
       T.HttpError(429),
@@ -950,7 +950,7 @@ export class ThrottlingException
 export class TrailAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TrailAlreadyExistsException>()(
     "TrailAlreadyExistsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "TrailAlreadyExists", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -959,7 +959,7 @@ export class TrailAlreadyExistsException
 export class TrailNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<TrailNotFoundException>()(
     "TrailNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "TrailNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -968,7 +968,7 @@ export class TrailNotFoundException
 export class TrailNotProvidedException
   extends /*@__PURE__*/ S.TaggedErrorClass<TrailNotProvidedException>()(
     "TrailNotProvidedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "TrailNotProvided", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -977,7 +977,7 @@ export class TrailNotProvidedException
 export class UnsupportedOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedOperationException>()(
     "UnsupportedOperationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "UnsupportedOperation", httpResponseCode: 400 }),
       T.HttpError(400),

--- a/packages/aws/src/services/cloudwatch-events.ts
+++ b/packages/aws/src/services/cloudwatch-events.ts
@@ -96,57 +96,57 @@ const rules = T.EndpointResolver((p, _) => {
 export class ConcurrentModificationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentModificationException>()(
     "ConcurrentModificationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class IllegalStatusException
   extends /*@__PURE__*/ S.TaggedErrorClass<IllegalStatusException>()(
     "IllegalStatusException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InternalException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalException>()(
     "InternalException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidEventPatternException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidEventPatternException>()(
     "InvalidEventPatternException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidStateException>()(
     "InvalidStateException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ManagedRuleException
   extends /*@__PURE__*/ S.TaggedErrorClass<ManagedRuleException>()(
     "ManagedRuleException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class OperationDisabledException
   extends /*@__PURE__*/ S.TaggedErrorClass<OperationDisabledException>()(
     "OperationDisabledException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class PolicyLengthExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<PolicyLengthExceededException>()(
     "PolicyLengthExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceAlreadyExistsException>()(
     "ResourceAlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type EventSourceName = string;
 export interface ActivateEventSourceRequest {

--- a/packages/aws/src/services/cloudwatch-logs.ts
+++ b/packages/aws/src/services/cloudwatch-logs.ts
@@ -95,49 +95,49 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withConflictError) {}
 export class DataAlreadyAcceptedException
   extends /*@__PURE__*/ S.TaggedErrorClass<DataAlreadyAcceptedException>()(
     "DataAlreadyAcceptedException",
     {
       expectedSequenceToken: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidOperationException>()(
     "InvalidOperationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class InvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterException>()(
     "InvalidParameterException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class InvalidSequenceTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSequenceTokenException>()(
     "InvalidSequenceTokenException",
     {
       expectedSequenceToken: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
   ).pipe(C.withBadRequestError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withQuotaError) {}
 export class MalformedQueryException
   extends /*@__PURE__*/ S.TaggedErrorClass<MalformedQueryException>()(
@@ -148,54 +148,57 @@ export class MalformedQueryException
           identifier: "QueryCompileError",
         }),
       ),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
   ).pipe(C.withBadRequestError) {}
 export class OperationAbortedException
   extends /*@__PURE__*/ S.TaggedErrorClass<OperationAbortedException>()(
     "OperationAbortedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withConflictError, C.withRetryableError) {}
 export class ResourceAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceAlreadyExistsException>()(
     "ResourceAlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withNotFoundError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withQuotaError) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withServerError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { message: S.optional(S.String), resourceName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      resourceName: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class UnrecognizedClientException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnrecognizedClientException>()(
     "UnrecognizedClientException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAuthError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export type LogGroupName = string;
 export type KmsKeyId = string;

--- a/packages/aws/src/services/cloudwatch.ts
+++ b/packages/aws/src/services/cloudwatch.ts
@@ -107,7 +107,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class ConcurrentModificationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentModificationException>()(
     "ConcurrentModificationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ConcurrentModificationException",
@@ -119,14 +119,14 @@ export class ConcurrentModificationException
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class DashboardInvalidInputError
   extends /*@__PURE__*/ S.TaggedErrorClass<DashboardInvalidInputError>()(
     "DashboardInvalidInputError",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       dashboardValidationMessages: S.optional(
         S.suspend(() => DashboardValidationMessages).annotate({
           identifier: "DashboardValidationMessages",
@@ -141,7 +141,7 @@ export class DashboardInvalidInputError
 export class DashboardNotFoundError
   extends /*@__PURE__*/ S.TaggedErrorClass<DashboardNotFoundError>()(
     "DashboardNotFoundError",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ResourceNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -150,7 +150,7 @@ export class DashboardNotFoundError
 export class InternalServiceFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServiceFault>()(
     "InternalServiceFault",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InternalServiceError", httpResponseCode: 500 }),
       T.HttpError(500),
@@ -159,7 +159,7 @@ export class InternalServiceFault
 export class InvalidFormatFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidFormatFault>()(
     "InvalidFormatFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidFormat", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -168,7 +168,7 @@ export class InvalidFormatFault
 export class InvalidNextToken
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNextToken>()(
     "InvalidNextToken",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidNextToken", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -177,7 +177,7 @@ export class InvalidNextToken
 export class InvalidParameterCombinationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterCombinationException>()(
     "InvalidParameterCombinationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidParameterCombination",
@@ -189,7 +189,7 @@ export class InvalidParameterCombinationException
 export class InvalidParameterValueException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterValueException>()(
     "InvalidParameterValueException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidParameterValue", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -198,22 +198,22 @@ export class InvalidParameterValueException
 export class KmsAccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<KmsAccessDeniedException>()(
     "KmsAccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAuthError) {}
 export class KmsKeyDisabledException
   extends /*@__PURE__*/ S.TaggedErrorClass<KmsKeyDisabledException>()(
     "KmsKeyDisabledException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class KmsKeyNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<KmsKeyNotFoundException>()(
     "KmsKeyNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "LimitExceededException",
@@ -225,7 +225,7 @@ export class LimitExceededException
 export class LimitExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededFault>()(
     "LimitExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "LimitExceeded", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -234,7 +234,7 @@ export class LimitExceededFault
 export class MissingRequiredParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<MissingRequiredParameterException>()(
     "MissingRequiredParameterException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "MissingParameter", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -243,7 +243,7 @@ export class MissingRequiredParameterException
 export class ResourceConflict
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceConflict>()(
     "ResourceConflict",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ResourceConflict", httpResponseCode: 409 }),
       T.HttpError(409),
@@ -252,7 +252,7 @@ export class ResourceConflict
 export class ResourceNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFound>()(
     "ResourceNotFound",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ResourceNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -264,7 +264,7 @@ export class ResourceNotFoundException
     {
       ResourceType: S.optional(S.String),
       ResourceId: S.optional(S.String),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.all(
       T.AwsQueryError({
@@ -277,7 +277,7 @@ export class ResourceNotFoundException
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export type DatasetIdentifier = string;
 export type KmsKeyArn = string;

--- a/packages/aws/src/services/codeartifact.ts
+++ b/packages/aws/src/services/codeartifact.ts
@@ -90,14 +90,14 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceType: S.optional(
         S.suspend(() => ResourceType).annotate({ identifier: "ResourceType" }),
@@ -108,14 +108,14 @@ export class ConflictException
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceType: S.optional(
         S.suspend(() => ResourceType).annotate({ identifier: "ResourceType" }),
@@ -127,7 +127,7 @@ export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceType: S.optional(
         S.suspend(() => ResourceType).annotate({ identifier: "ResourceType" }),
@@ -139,7 +139,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.HttpError(429),
@@ -148,7 +148,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.optional(
         S.suspend(() => ValidationExceptionReason).annotate({
           identifier: "ValidationExceptionReason",

--- a/packages/aws/src/services/codebuild.ts
+++ b/packages/aws/src/services/codebuild.ts
@@ -90,32 +90,32 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccountLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccountLimitExceededException>()(
     "AccountLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class AccountSuspendedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccountSuspendedException>()(
     "AccountSuspendedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidInputException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInputException>()(
     "InvalidInputException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class OAuthProviderException
   extends /*@__PURE__*/ S.TaggedErrorClass<OAuthProviderException>()(
     "OAuthProviderException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceAlreadyExistsException>()(
     "ResourceAlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type NonEmptyString = string;
 export type BuildIds = string[];

--- a/packages/aws/src/services/codecommit.ts
+++ b/packages/aws/src/services/codecommit.ts
@@ -89,947 +89,947 @@ const rules = T.EndpointResolver((p, _) => {
 export class ActorDoesNotExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<ActorDoesNotExistException>()(
     "ActorDoesNotExistException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ApprovalRuleContentRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<ApprovalRuleContentRequiredException>()(
     "ApprovalRuleContentRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ApprovalRuleDoesNotExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<ApprovalRuleDoesNotExistException>()(
     "ApprovalRuleDoesNotExistException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ApprovalRuleNameAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ApprovalRuleNameAlreadyExistsException>()(
     "ApprovalRuleNameAlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class ApprovalRuleNameRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<ApprovalRuleNameRequiredException>()(
     "ApprovalRuleNameRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ApprovalRuleTemplateContentRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<ApprovalRuleTemplateContentRequiredException>()(
     "ApprovalRuleTemplateContentRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ApprovalRuleTemplateDoesNotExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<ApprovalRuleTemplateDoesNotExistException>()(
     "ApprovalRuleTemplateDoesNotExistException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ApprovalRuleTemplateInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ApprovalRuleTemplateInUseException>()(
     "ApprovalRuleTemplateInUseException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ApprovalRuleTemplateNameAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ApprovalRuleTemplateNameAlreadyExistsException>()(
     "ApprovalRuleTemplateNameAlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class ApprovalRuleTemplateNameRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<ApprovalRuleTemplateNameRequiredException>()(
     "ApprovalRuleTemplateNameRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ApprovalStateRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<ApprovalStateRequiredException>()(
     "ApprovalStateRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class AuthorDoesNotExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<AuthorDoesNotExistException>()(
     "AuthorDoesNotExistException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class BeforeCommitIdAndAfterCommitIdAreSameException
   extends /*@__PURE__*/ S.TaggedErrorClass<BeforeCommitIdAndAfterCommitIdAreSameException>()(
     "BeforeCommitIdAndAfterCommitIdAreSameException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class BlobIdDoesNotExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<BlobIdDoesNotExistException>()(
     "BlobIdDoesNotExistException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class BlobIdRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<BlobIdRequiredException>()(
     "BlobIdRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class BranchDoesNotExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<BranchDoesNotExistException>()(
     "BranchDoesNotExistException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class BranchNameExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<BranchNameExistsException>()(
     "BranchNameExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class BranchNameIsTagNameException
   extends /*@__PURE__*/ S.TaggedErrorClass<BranchNameIsTagNameException>()(
     "BranchNameIsTagNameException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class BranchNameRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<BranchNameRequiredException>()(
     "BranchNameRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class CannotDeleteApprovalRuleFromTemplateException
   extends /*@__PURE__*/ S.TaggedErrorClass<CannotDeleteApprovalRuleFromTemplateException>()(
     "CannotDeleteApprovalRuleFromTemplateException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class CannotModifyApprovalRuleFromTemplateException
   extends /*@__PURE__*/ S.TaggedErrorClass<CannotModifyApprovalRuleFromTemplateException>()(
     "CannotModifyApprovalRuleFromTemplateException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ClientRequestTokenRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<ClientRequestTokenRequiredException>()(
     "ClientRequestTokenRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class CommentContentRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<CommentContentRequiredException>()(
     "CommentContentRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class CommentContentSizeLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<CommentContentSizeLimitExceededException>()(
     "CommentContentSizeLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class CommentDeletedException
   extends /*@__PURE__*/ S.TaggedErrorClass<CommentDeletedException>()(
     "CommentDeletedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class CommentDoesNotExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<CommentDoesNotExistException>()(
     "CommentDoesNotExistException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class CommentIdRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<CommentIdRequiredException>()(
     "CommentIdRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class CommentNotCreatedByCallerException
   extends /*@__PURE__*/ S.TaggedErrorClass<CommentNotCreatedByCallerException>()(
     "CommentNotCreatedByCallerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class CommitDoesNotExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<CommitDoesNotExistException>()(
     "CommitDoesNotExistException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class CommitIdDoesNotExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<CommitIdDoesNotExistException>()(
     "CommitIdDoesNotExistException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class CommitIdRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<CommitIdRequiredException>()(
     "CommitIdRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class CommitIdsLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<CommitIdsLimitExceededException>()(
     "CommitIdsLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class CommitIdsListRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<CommitIdsListRequiredException>()(
     "CommitIdsListRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class CommitMessageLengthExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<CommitMessageLengthExceededException>()(
     "CommitMessageLengthExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class CommitRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<CommitRequiredException>()(
     "CommitRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ConcurrentReferenceUpdateException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentReferenceUpdateException>()(
     "ConcurrentReferenceUpdateException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class DefaultBranchCannotBeDeletedException
   extends /*@__PURE__*/ S.TaggedErrorClass<DefaultBranchCannotBeDeletedException>()(
     "DefaultBranchCannotBeDeletedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class DirectoryNameConflictsWithFileNameException
   extends /*@__PURE__*/ S.TaggedErrorClass<DirectoryNameConflictsWithFileNameException>()(
     "DirectoryNameConflictsWithFileNameException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class EncryptionIntegrityChecksFailedException
   extends /*@__PURE__*/ S.TaggedErrorClass<EncryptionIntegrityChecksFailedException>()(
     "EncryptionIntegrityChecksFailedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class EncryptionKeyAccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<EncryptionKeyAccessDeniedException>()(
     "EncryptionKeyAccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAuthError) {}
 export class EncryptionKeyDisabledException
   extends /*@__PURE__*/ S.TaggedErrorClass<EncryptionKeyDisabledException>()(
     "EncryptionKeyDisabledException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class EncryptionKeyInvalidIdException
   extends /*@__PURE__*/ S.TaggedErrorClass<EncryptionKeyInvalidIdException>()(
     "EncryptionKeyInvalidIdException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class EncryptionKeyInvalidUsageException
   extends /*@__PURE__*/ S.TaggedErrorClass<EncryptionKeyInvalidUsageException>()(
     "EncryptionKeyInvalidUsageException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class EncryptionKeyNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<EncryptionKeyNotFoundException>()(
     "EncryptionKeyNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class EncryptionKeyRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<EncryptionKeyRequiredException>()(
     "EncryptionKeyRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class EncryptionKeyUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<EncryptionKeyUnavailableException>()(
     "EncryptionKeyUnavailableException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class FileContentAndSourceFileSpecifiedException
   extends /*@__PURE__*/ S.TaggedErrorClass<FileContentAndSourceFileSpecifiedException>()(
     "FileContentAndSourceFileSpecifiedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class FileContentRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<FileContentRequiredException>()(
     "FileContentRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class FileContentSizeLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<FileContentSizeLimitExceededException>()(
     "FileContentSizeLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class FileDoesNotExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<FileDoesNotExistException>()(
     "FileDoesNotExistException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class FileEntryRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<FileEntryRequiredException>()(
     "FileEntryRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class FileModeRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<FileModeRequiredException>()(
     "FileModeRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class FileNameConflictsWithDirectoryNameException
   extends /*@__PURE__*/ S.TaggedErrorClass<FileNameConflictsWithDirectoryNameException>()(
     "FileNameConflictsWithDirectoryNameException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class FilePathConflictsWithSubmodulePathException
   extends /*@__PURE__*/ S.TaggedErrorClass<FilePathConflictsWithSubmodulePathException>()(
     "FilePathConflictsWithSubmodulePathException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class FileTooLargeException
   extends /*@__PURE__*/ S.TaggedErrorClass<FileTooLargeException>()(
     "FileTooLargeException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class FolderContentSizeLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<FolderContentSizeLimitExceededException>()(
     "FolderContentSizeLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class FolderDoesNotExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<FolderDoesNotExistException>()(
     "FolderDoesNotExistException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class IdempotencyParameterMismatchException
   extends /*@__PURE__*/ S.TaggedErrorClass<IdempotencyParameterMismatchException>()(
     "IdempotencyParameterMismatchException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidActorArnException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidActorArnException>()(
     "InvalidActorArnException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidApprovalRuleContentException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidApprovalRuleContentException>()(
     "InvalidApprovalRuleContentException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidApprovalRuleNameException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidApprovalRuleNameException>()(
     "InvalidApprovalRuleNameException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidApprovalRuleTemplateContentException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidApprovalRuleTemplateContentException>()(
     "InvalidApprovalRuleTemplateContentException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidApprovalRuleTemplateDescriptionException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidApprovalRuleTemplateDescriptionException>()(
     "InvalidApprovalRuleTemplateDescriptionException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidApprovalRuleTemplateNameException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidApprovalRuleTemplateNameException>()(
     "InvalidApprovalRuleTemplateNameException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidApprovalStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidApprovalStateException>()(
     "InvalidApprovalStateException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidAuthorArnException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidAuthorArnException>()(
     "InvalidAuthorArnException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidBlobIdException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidBlobIdException>()(
     "InvalidBlobIdException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidBranchNameException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidBranchNameException>()(
     "InvalidBranchNameException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidClientRequestTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidClientRequestTokenException>()(
     "InvalidClientRequestTokenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidCommentIdException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCommentIdException>()(
     "InvalidCommentIdException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidCommitException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCommitException>()(
     "InvalidCommitException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidCommitIdException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCommitIdException>()(
     "InvalidCommitIdException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidConflictDetailLevelException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidConflictDetailLevelException>()(
     "InvalidConflictDetailLevelException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidConflictResolutionException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidConflictResolutionException>()(
     "InvalidConflictResolutionException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidConflictResolutionStrategyException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidConflictResolutionStrategyException>()(
     "InvalidConflictResolutionStrategyException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidContinuationTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidContinuationTokenException>()(
     "InvalidContinuationTokenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidDeletionParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDeletionParameterException>()(
     "InvalidDeletionParameterException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidDescriptionException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDescriptionException>()(
     "InvalidDescriptionException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidDestinationCommitSpecifierException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDestinationCommitSpecifierException>()(
     "InvalidDestinationCommitSpecifierException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidEmailException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidEmailException>()(
     "InvalidEmailException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidFileLocationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidFileLocationException>()(
     "InvalidFileLocationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidFileModeException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidFileModeException>()(
     "InvalidFileModeException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidFilePositionException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidFilePositionException>()(
     "InvalidFilePositionException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidMaxConflictFilesException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidMaxConflictFilesException>()(
     "InvalidMaxConflictFilesException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidMaxMergeHunksException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidMaxMergeHunksException>()(
     "InvalidMaxMergeHunksException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidMaxResultsException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidMaxResultsException>()(
     "InvalidMaxResultsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidMergeOptionException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidMergeOptionException>()(
     "InvalidMergeOptionException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidOrderException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidOrderException>()(
     "InvalidOrderException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidOverrideStatusException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidOverrideStatusException>()(
     "InvalidOverrideStatusException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidParentCommitIdException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParentCommitIdException>()(
     "InvalidParentCommitIdException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidPathException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPathException>()(
     "InvalidPathException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidPullRequestEventTypeException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPullRequestEventTypeException>()(
     "InvalidPullRequestEventTypeException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidPullRequestIdException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPullRequestIdException>()(
     "InvalidPullRequestIdException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidPullRequestStatusException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPullRequestStatusException>()(
     "InvalidPullRequestStatusException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidPullRequestStatusUpdateException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPullRequestStatusUpdateException>()(
     "InvalidPullRequestStatusUpdateException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidReactionUserArnException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidReactionUserArnException>()(
     "InvalidReactionUserArnException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidReactionValueException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidReactionValueException>()(
     "InvalidReactionValueException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidReferenceNameException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidReferenceNameException>()(
     "InvalidReferenceNameException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRelativeFileVersionEnumException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRelativeFileVersionEnumException>()(
     "InvalidRelativeFileVersionEnumException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidReplacementContentException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidReplacementContentException>()(
     "InvalidReplacementContentException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidReplacementTypeException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidReplacementTypeException>()(
     "InvalidReplacementTypeException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRepositoryDescriptionException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRepositoryDescriptionException>()(
     "InvalidRepositoryDescriptionException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRepositoryNameException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRepositoryNameException>()(
     "InvalidRepositoryNameException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRepositoryTriggerBranchNameException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRepositoryTriggerBranchNameException>()(
     "InvalidRepositoryTriggerBranchNameException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRepositoryTriggerCustomDataException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRepositoryTriggerCustomDataException>()(
     "InvalidRepositoryTriggerCustomDataException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRepositoryTriggerDestinationArnException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRepositoryTriggerDestinationArnException>()(
     "InvalidRepositoryTriggerDestinationArnException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRepositoryTriggerEventsException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRepositoryTriggerEventsException>()(
     "InvalidRepositoryTriggerEventsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRepositoryTriggerNameException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRepositoryTriggerNameException>()(
     "InvalidRepositoryTriggerNameException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRepositoryTriggerRegionException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRepositoryTriggerRegionException>()(
     "InvalidRepositoryTriggerRegionException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidResourceArnException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidResourceArnException>()(
     "InvalidResourceArnException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRevisionIdException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRevisionIdException>()(
     "InvalidRevisionIdException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRuleContentSha256Exception
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRuleContentSha256Exception>()(
     "InvalidRuleContentSha256Exception",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidSortByException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSortByException>()(
     "InvalidSortByException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidSourceCommitSpecifierException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSourceCommitSpecifierException>()(
     "InvalidSourceCommitSpecifierException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidSystemTagUsageException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSystemTagUsageException>()(
     "InvalidSystemTagUsageException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTagKeysListException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTagKeysListException>()(
     "InvalidTagKeysListException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTagsMapException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTagsMapException>()(
     "InvalidTagsMapException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTargetBranchException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTargetBranchException>()(
     "InvalidTargetBranchException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTargetException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTargetException>()(
     "InvalidTargetException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTargetsException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTargetsException>()(
     "InvalidTargetsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTitleException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTitleException>()(
     "InvalidTitleException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ManualMergeRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<ManualMergeRequiredException>()(
     "ManualMergeRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MaximumBranchesExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<MaximumBranchesExceededException>()(
     "MaximumBranchesExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MaximumConflictResolutionEntriesExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<MaximumConflictResolutionEntriesExceededException>()(
     "MaximumConflictResolutionEntriesExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MaximumFileContentToLoadExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<MaximumFileContentToLoadExceededException>()(
     "MaximumFileContentToLoadExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MaximumFileEntriesExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<MaximumFileEntriesExceededException>()(
     "MaximumFileEntriesExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MaximumItemsToCompareExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<MaximumItemsToCompareExceededException>()(
     "MaximumItemsToCompareExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MaximumNumberOfApprovalsExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<MaximumNumberOfApprovalsExceededException>()(
     "MaximumNumberOfApprovalsExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MaximumOpenPullRequestsExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<MaximumOpenPullRequestsExceededException>()(
     "MaximumOpenPullRequestsExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MaximumRepositoryNamesExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<MaximumRepositoryNamesExceededException>()(
     "MaximumRepositoryNamesExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MaximumRepositoryTriggersExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<MaximumRepositoryTriggersExceededException>()(
     "MaximumRepositoryTriggersExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MaximumRuleTemplatesAssociatedWithRepositoryException
   extends /*@__PURE__*/ S.TaggedErrorClass<MaximumRuleTemplatesAssociatedWithRepositoryException>()(
     "MaximumRuleTemplatesAssociatedWithRepositoryException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MergeOptionRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<MergeOptionRequiredException>()(
     "MergeOptionRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MultipleConflictResolutionEntriesException
   extends /*@__PURE__*/ S.TaggedErrorClass<MultipleConflictResolutionEntriesException>()(
     "MultipleConflictResolutionEntriesException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MultipleRepositoriesInPullRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<MultipleRepositoriesInPullRequestException>()(
     "MultipleRepositoriesInPullRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NameLengthExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<NameLengthExceededException>()(
     "NameLengthExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NoChangeException
   extends /*@__PURE__*/ S.TaggedErrorClass<NoChangeException>()(
     "NoChangeException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NumberOfRulesExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<NumberOfRulesExceededException>()(
     "NumberOfRulesExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NumberOfRuleTemplatesExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<NumberOfRuleTemplatesExceededException>()(
     "NumberOfRuleTemplatesExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class OperationNotAllowedException
   extends /*@__PURE__*/ S.TaggedErrorClass<OperationNotAllowedException>()(
     "OperationNotAllowedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class OverrideAlreadySetException
   extends /*@__PURE__*/ S.TaggedErrorClass<OverrideAlreadySetException>()(
     "OverrideAlreadySetException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class OverrideStatusRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<OverrideStatusRequiredException>()(
     "OverrideStatusRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ParentCommitDoesNotExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<ParentCommitDoesNotExistException>()(
     "ParentCommitDoesNotExistException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ParentCommitIdOutdatedException
   extends /*@__PURE__*/ S.TaggedErrorClass<ParentCommitIdOutdatedException>()(
     "ParentCommitIdOutdatedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ParentCommitIdRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<ParentCommitIdRequiredException>()(
     "ParentCommitIdRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class PathDoesNotExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<PathDoesNotExistException>()(
     "PathDoesNotExistException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class PathRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<PathRequiredException>()(
     "PathRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class PullRequestAlreadyClosedException
   extends /*@__PURE__*/ S.TaggedErrorClass<PullRequestAlreadyClosedException>()(
     "PullRequestAlreadyClosedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class PullRequestApprovalRulesNotSatisfiedException
   extends /*@__PURE__*/ S.TaggedErrorClass<PullRequestApprovalRulesNotSatisfiedException>()(
     "PullRequestApprovalRulesNotSatisfiedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class PullRequestCannotBeApprovedByAuthorException
   extends /*@__PURE__*/ S.TaggedErrorClass<PullRequestCannotBeApprovedByAuthorException>()(
     "PullRequestCannotBeApprovedByAuthorException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class PullRequestDoesNotExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<PullRequestDoesNotExistException>()(
     "PullRequestDoesNotExistException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class PullRequestIdRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<PullRequestIdRequiredException>()(
     "PullRequestIdRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class PullRequestStatusRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<PullRequestStatusRequiredException>()(
     "PullRequestStatusRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class PutFileEntryConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<PutFileEntryConflictException>()(
     "PutFileEntryConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ReactionLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ReactionLimitExceededException>()(
     "ReactionLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ReactionValueRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<ReactionValueRequiredException>()(
     "ReactionValueRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ReferenceDoesNotExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<ReferenceDoesNotExistException>()(
     "ReferenceDoesNotExistException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ReferenceNameRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<ReferenceNameRequiredException>()(
     "ReferenceNameRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ReferenceTypeNotSupportedException
   extends /*@__PURE__*/ S.TaggedErrorClass<ReferenceTypeNotSupportedException>()(
     "ReferenceTypeNotSupportedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ReplacementContentRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<ReplacementContentRequiredException>()(
     "ReplacementContentRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ReplacementTypeRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<ReplacementTypeRequiredException>()(
     "ReplacementTypeRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class RepositoryDoesNotExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<RepositoryDoesNotExistException>()(
     "RepositoryDoesNotExistException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class RepositoryLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<RepositoryLimitExceededException>()(
     "RepositoryLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class RepositoryNameExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<RepositoryNameExistsException>()(
     "RepositoryNameExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class RepositoryNameRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<RepositoryNameRequiredException>()(
     "RepositoryNameRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class RepositoryNamesRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<RepositoryNamesRequiredException>()(
     "RepositoryNamesRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class RepositoryNotAssociatedWithPullRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<RepositoryNotAssociatedWithPullRequestException>()(
     "RepositoryNotAssociatedWithPullRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class RepositoryTriggerBranchNameListRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<RepositoryTriggerBranchNameListRequiredException>()(
     "RepositoryTriggerBranchNameListRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class RepositoryTriggerDestinationArnRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<RepositoryTriggerDestinationArnRequiredException>()(
     "RepositoryTriggerDestinationArnRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class RepositoryTriggerEventsListRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<RepositoryTriggerEventsListRequiredException>()(
     "RepositoryTriggerEventsListRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class RepositoryTriggerNameRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<RepositoryTriggerNameRequiredException>()(
     "RepositoryTriggerNameRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class RepositoryTriggersListRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<RepositoryTriggersListRequiredException>()(
     "RepositoryTriggersListRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceArnRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceArnRequiredException>()(
     "ResourceArnRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class RestrictedSourceFileException
   extends /*@__PURE__*/ S.TaggedErrorClass<RestrictedSourceFileException>()(
     "RestrictedSourceFileException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class RevisionIdRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<RevisionIdRequiredException>()(
     "RevisionIdRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class RevisionNotCurrentException
   extends /*@__PURE__*/ S.TaggedErrorClass<RevisionNotCurrentException>()(
     "RevisionNotCurrentException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class SameFileContentException
   extends /*@__PURE__*/ S.TaggedErrorClass<SameFileContentException>()(
     "SameFileContentException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class SamePathRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<SamePathRequestException>()(
     "SamePathRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class SourceAndDestinationAreSameException
   extends /*@__PURE__*/ S.TaggedErrorClass<SourceAndDestinationAreSameException>()(
     "SourceAndDestinationAreSameException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class SourceFileOrContentRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<SourceFileOrContentRequiredException>()(
     "SourceFileOrContentRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TagKeysListRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<TagKeysListRequiredException>()(
     "TagKeysListRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TagPolicyException
   extends /*@__PURE__*/ S.TaggedErrorClass<TagPolicyException>()(
     "TagPolicyException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TagsMapRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<TagsMapRequiredException>()(
     "TagsMapRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TargetRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<TargetRequiredException>()(
     "TargetRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TargetsRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<TargetsRequiredException>()(
     "TargetsRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TipOfSourceReferenceIsDifferentException
   extends /*@__PURE__*/ S.TaggedErrorClass<TipOfSourceReferenceIsDifferentException>()(
     "TipOfSourceReferenceIsDifferentException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TipsDivergenceExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<TipsDivergenceExceededException>()(
     "TipsDivergenceExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TitleRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<TitleRequiredException>()(
     "TitleRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type ApprovalRuleTemplateName = string;
 export type RepositoryName = string;

--- a/packages/aws/src/services/codeconnections.ts
+++ b/packages/aws/src/services/codeconnections.ts
@@ -88,103 +88,103 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConcurrentModificationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentModificationException>()(
     "ConcurrentModificationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ConditionalCheckFailedException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConditionalCheckFailedException>()(
     "ConditionalCheckFailedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class InvalidInputException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInputException>()(
     "InvalidInputException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ResourceAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceAlreadyExistsException>()(
     "ResourceAlreadyExistsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ResourceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceUnavailableException>()(
     "ResourceUnavailableException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class RetryLatestCommitFailedException
   extends /*@__PURE__*/ S.TaggedErrorClass<RetryLatestCommitFailedException>()(
     "RetryLatestCommitFailedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class SyncBlockerDoesNotExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<SyncBlockerDoesNotExistException>()(
     "SyncBlockerDoesNotExistException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class SyncConfigurationStillExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<SyncConfigurationStillExistsException>()(
     "SyncConfigurationStillExistsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class UnsupportedOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedOperationException>()(
     "UnsupportedOperationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class UnsupportedProviderTypeException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedProviderTypeException>()(
     "UnsupportedProviderTypeException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class UpdateOutOfSyncException
   extends /*@__PURE__*/ S.TaggedErrorClass<UpdateOutOfSyncException>()(
     "UpdateOutOfSyncException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export type ProviderType =

--- a/packages/aws/src/services/codedeploy.ts
+++ b/packages/aws/src/services/codedeploy.ts
@@ -89,552 +89,552 @@ const rules = T.EndpointResolver((p, _) => {
 export class AlarmsLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<AlarmsLimitExceededException>()(
     "AlarmsLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ApplicationAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ApplicationAlreadyExistsException>()(
     "ApplicationAlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class ApplicationDoesNotExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<ApplicationDoesNotExistException>()(
     "ApplicationDoesNotExistException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ApplicationLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ApplicationLimitExceededException>()(
     "ApplicationLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ApplicationNameRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<ApplicationNameRequiredException>()(
     "ApplicationNameRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ArnNotSupportedException
   extends /*@__PURE__*/ S.TaggedErrorClass<ArnNotSupportedException>()(
     "ArnNotSupportedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class BatchLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<BatchLimitExceededException>()(
     "BatchLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class BucketNameFilterRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<BucketNameFilterRequiredException>()(
     "BucketNameFilterRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class DeploymentAlreadyCompletedException
   extends /*@__PURE__*/ S.TaggedErrorClass<DeploymentAlreadyCompletedException>()(
     "DeploymentAlreadyCompletedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class DeploymentConfigAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<DeploymentConfigAlreadyExistsException>()(
     "DeploymentConfigAlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class DeploymentConfigDoesNotExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<DeploymentConfigDoesNotExistException>()(
     "DeploymentConfigDoesNotExistException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class DeploymentConfigInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<DeploymentConfigInUseException>()(
     "DeploymentConfigInUseException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class DeploymentConfigLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<DeploymentConfigLimitExceededException>()(
     "DeploymentConfigLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class DeploymentConfigNameRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<DeploymentConfigNameRequiredException>()(
     "DeploymentConfigNameRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class DeploymentDoesNotExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<DeploymentDoesNotExistException>()(
     "DeploymentDoesNotExistException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class DeploymentGroupAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<DeploymentGroupAlreadyExistsException>()(
     "DeploymentGroupAlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class DeploymentGroupDoesNotExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<DeploymentGroupDoesNotExistException>()(
     "DeploymentGroupDoesNotExistException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class DeploymentGroupLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<DeploymentGroupLimitExceededException>()(
     "DeploymentGroupLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class DeploymentGroupNameRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<DeploymentGroupNameRequiredException>()(
     "DeploymentGroupNameRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class DeploymentIdRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<DeploymentIdRequiredException>()(
     "DeploymentIdRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class DeploymentIsNotInReadyStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<DeploymentIsNotInReadyStateException>()(
     "DeploymentIsNotInReadyStateException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class DeploymentLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<DeploymentLimitExceededException>()(
     "DeploymentLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class DeploymentNotStartedException
   extends /*@__PURE__*/ S.TaggedErrorClass<DeploymentNotStartedException>()(
     "DeploymentNotStartedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class DeploymentTargetDoesNotExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<DeploymentTargetDoesNotExistException>()(
     "DeploymentTargetDoesNotExistException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class DeploymentTargetIdRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<DeploymentTargetIdRequiredException>()(
     "DeploymentTargetIdRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class DeploymentTargetListSizeExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<DeploymentTargetListSizeExceededException>()(
     "DeploymentTargetListSizeExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class DescriptionTooLongException
   extends /*@__PURE__*/ S.TaggedErrorClass<DescriptionTooLongException>()(
     "DescriptionTooLongException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ECSServiceMappingLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ECSServiceMappingLimitExceededException>()(
     "ECSServiceMappingLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class GitHubAccountTokenDoesNotExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<GitHubAccountTokenDoesNotExistException>()(
     "GitHubAccountTokenDoesNotExistException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class GitHubAccountTokenNameRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<GitHubAccountTokenNameRequiredException>()(
     "GitHubAccountTokenNameRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class IamArnRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<IamArnRequiredException>()(
     "IamArnRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class IamSessionArnAlreadyRegisteredException
   extends /*@__PURE__*/ S.TaggedErrorClass<IamSessionArnAlreadyRegisteredException>()(
     "IamSessionArnAlreadyRegisteredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class IamUserArnAlreadyRegisteredException
   extends /*@__PURE__*/ S.TaggedErrorClass<IamUserArnAlreadyRegisteredException>()(
     "IamUserArnAlreadyRegisteredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class IamUserArnRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<IamUserArnRequiredException>()(
     "IamUserArnRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InstanceDoesNotExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<InstanceDoesNotExistException>()(
     "InstanceDoesNotExistException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InstanceIdRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<InstanceIdRequiredException>()(
     "InstanceIdRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InstanceLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<InstanceLimitExceededException>()(
     "InstanceLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InstanceNameAlreadyRegisteredException
   extends /*@__PURE__*/ S.TaggedErrorClass<InstanceNameAlreadyRegisteredException>()(
     "InstanceNameAlreadyRegisteredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InstanceNameRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<InstanceNameRequiredException>()(
     "InstanceNameRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InstanceNotRegisteredException
   extends /*@__PURE__*/ S.TaggedErrorClass<InstanceNotRegisteredException>()(
     "InstanceNotRegisteredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidAlarmConfigException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidAlarmConfigException>()(
     "InvalidAlarmConfigException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidApplicationNameException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidApplicationNameException>()(
     "InvalidApplicationNameException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidArnException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidArnException>()(
     "InvalidArnException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidAutoRollbackConfigException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidAutoRollbackConfigException>()(
     "InvalidAutoRollbackConfigException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidAutoScalingGroupException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidAutoScalingGroupException>()(
     "InvalidAutoScalingGroupException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidBlueGreenDeploymentConfigurationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidBlueGreenDeploymentConfigurationException>()(
     "InvalidBlueGreenDeploymentConfigurationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidBucketNameFilterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidBucketNameFilterException>()(
     "InvalidBucketNameFilterException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidComputePlatformException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidComputePlatformException>()(
     "InvalidComputePlatformException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidDeployedStateFilterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDeployedStateFilterException>()(
     "InvalidDeployedStateFilterException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidDeploymentConfigNameException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDeploymentConfigNameException>()(
     "InvalidDeploymentConfigNameException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidDeploymentGroupNameException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDeploymentGroupNameException>()(
     "InvalidDeploymentGroupNameException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidDeploymentIdException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDeploymentIdException>()(
     "InvalidDeploymentIdException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidDeploymentInstanceTypeException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDeploymentInstanceTypeException>()(
     "InvalidDeploymentInstanceTypeException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidDeploymentStatusException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDeploymentStatusException>()(
     "InvalidDeploymentStatusException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidDeploymentStyleException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDeploymentStyleException>()(
     "InvalidDeploymentStyleException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidDeploymentTargetIdException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDeploymentTargetIdException>()(
     "InvalidDeploymentTargetIdException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidDeploymentWaitTypeException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDeploymentWaitTypeException>()(
     "InvalidDeploymentWaitTypeException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidEC2TagCombinationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidEC2TagCombinationException>()(
     "InvalidEC2TagCombinationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidEC2TagException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidEC2TagException>()(
     "InvalidEC2TagException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidECSServiceException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidECSServiceException>()(
     "InvalidECSServiceException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidExternalIdException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidExternalIdException>()(
     "InvalidExternalIdException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidFileExistsBehaviorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidFileExistsBehaviorException>()(
     "InvalidFileExistsBehaviorException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidGitHubAccountTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidGitHubAccountTokenException>()(
     "InvalidGitHubAccountTokenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidGitHubAccountTokenNameException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidGitHubAccountTokenNameException>()(
     "InvalidGitHubAccountTokenNameException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidIamSessionArnException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidIamSessionArnException>()(
     "InvalidIamSessionArnException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidIamUserArnException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidIamUserArnException>()(
     "InvalidIamUserArnException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidIgnoreApplicationStopFailuresValueException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidIgnoreApplicationStopFailuresValueException>()(
     "InvalidIgnoreApplicationStopFailuresValueException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidInputException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInputException>()(
     "InvalidInputException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidInstanceNameException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInstanceNameException>()(
     "InvalidInstanceNameException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidInstanceStatusException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInstanceStatusException>()(
     "InvalidInstanceStatusException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidInstanceTypeException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInstanceTypeException>()(
     "InvalidInstanceTypeException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidKeyPrefixFilterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidKeyPrefixFilterException>()(
     "InvalidKeyPrefixFilterException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidLifecycleEventHookExecutionIdException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidLifecycleEventHookExecutionIdException>()(
     "InvalidLifecycleEventHookExecutionIdException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidLifecycleEventHookExecutionStatusException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidLifecycleEventHookExecutionStatusException>()(
     "InvalidLifecycleEventHookExecutionStatusException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidLoadBalancerInfoException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidLoadBalancerInfoException>()(
     "InvalidLoadBalancerInfoException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidMinimumHealthyHostValueException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidMinimumHealthyHostValueException>()(
     "InvalidMinimumHealthyHostValueException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidNextTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNextTokenException>()(
     "InvalidNextTokenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidOnPremisesTagCombinationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidOnPremisesTagCombinationException>()(
     "InvalidOnPremisesTagCombinationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidOperationException>()(
     "InvalidOperationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRegistrationStatusException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRegistrationStatusException>()(
     "InvalidRegistrationStatusException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRevisionException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRevisionException>()(
     "InvalidRevisionException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRoleException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRoleException>()(
     "InvalidRoleException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidSortByException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSortByException>()(
     "InvalidSortByException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidSortOrderException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSortOrderException>()(
     "InvalidSortOrderException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTagException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTagException>()(
     "InvalidTagException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTagFilterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTagFilterException>()(
     "InvalidTagFilterException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTagsToAddException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTagsToAddException>()(
     "InvalidTagsToAddException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTargetFilterNameException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTargetFilterNameException>()(
     "InvalidTargetFilterNameException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTargetGroupPairException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTargetGroupPairException>()(
     "InvalidTargetGroupPairException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTargetInstancesException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTargetInstancesException>()(
     "InvalidTargetInstancesException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTimeRangeException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTimeRangeException>()(
     "InvalidTimeRangeException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTrafficRoutingConfigurationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTrafficRoutingConfigurationException>()(
     "InvalidTrafficRoutingConfigurationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTriggerConfigException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTriggerConfigException>()(
     "InvalidTriggerConfigException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidUpdateOutdatedInstancesOnlyValueException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidUpdateOutdatedInstancesOnlyValueException>()(
     "InvalidUpdateOutdatedInstancesOnlyValueException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidZonalDeploymentConfigurationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidZonalDeploymentConfigurationException>()(
     "InvalidZonalDeploymentConfigurationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LifecycleEventAlreadyCompletedException
   extends /*@__PURE__*/ S.TaggedErrorClass<LifecycleEventAlreadyCompletedException>()(
     "LifecycleEventAlreadyCompletedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LifecycleHookLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LifecycleHookLimitExceededException>()(
     "LifecycleHookLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MultipleIamArnsProvidedException
   extends /*@__PURE__*/ S.TaggedErrorClass<MultipleIamArnsProvidedException>()(
     "MultipleIamArnsProvidedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class OperationNotSupportedException
   extends /*@__PURE__*/ S.TaggedErrorClass<OperationNotSupportedException>()(
     "OperationNotSupportedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceArnRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceArnRequiredException>()(
     "ResourceArnRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceValidationException>()(
     "ResourceValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class RevisionDoesNotExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<RevisionDoesNotExistException>()(
     "RevisionDoesNotExistException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class RevisionRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<RevisionRequiredException>()(
     "RevisionRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class RoleRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<RoleRequiredException>()(
     "RoleRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TagLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<TagLimitExceededException>()(
     "TagLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TagRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<TagRequiredException>()(
     "TagRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TagSetListLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<TagSetListLimitExceededException>()(
     "TagSetListLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TriggerTargetsLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<TriggerTargetsLimitExceededException>()(
     "TriggerTargetsLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class UnsupportedActionForDeploymentTypeException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedActionForDeploymentTypeException>()(
     "UnsupportedActionForDeploymentTypeException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type Key = string;
 export type Value = string;

--- a/packages/aws/src/services/codeguru-reviewer.ts
+++ b/packages/aws/src/services/codeguru-reviewer.ts
@@ -88,43 +88,43 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type Name = string;

--- a/packages/aws/src/services/codeguru-security.ts
+++ b/packages/aws/src/services/codeguru-security.ts
@@ -92,7 +92,7 @@ export class AccessDeniedException
     "AccessDeniedException",
     {
       errorCode: S.String,
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceType: S.optional(S.String),
     },
@@ -103,7 +103,7 @@ export class ConflictException
     "ConflictException",
     {
       errorCode: S.String,
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.String,
       resourceType: S.String,
     },
@@ -112,7 +112,10 @@ export class ConflictException
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { error: S.optional(S.String), message: S.optional(S.String) },
+    {
+      error: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ResourceNotFoundException
@@ -120,7 +123,7 @@ export class ResourceNotFoundException
     "ResourceNotFoundException",
     {
       errorCode: S.String,
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.String,
       resourceType: S.String,
     },
@@ -131,7 +134,7 @@ export class ThrottlingException
     "ThrottlingException",
     {
       errorCode: S.String,
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       serviceCode: S.optional(S.String),
       quotaCode: S.optional(S.String),
     },
@@ -142,7 +145,7 @@ export class ValidationException
     "ValidationException",
     {
       errorCode: S.String,
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.suspend(() => ValidationExceptionReason).annotate({
         identifier: "ValidationExceptionReason",
       }),

--- a/packages/aws/src/services/codeguruprofiler.ts
+++ b/packages/aws/src/services/codeguruprofiler.ts
@@ -88,37 +88,37 @@ const rules = T.EndpointResolver((p, _) => {
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(402), T.Retryable()),
   ).pipe(C.withQuotaError, C.withRetryableError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(429), T.Retryable()),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type ProfilingGroupName = string;

--- a/packages/aws/src/services/codepipeline.ts
+++ b/packages/aws/src/services/codepipeline.ts
@@ -91,208 +91,208 @@ const rules = T.EndpointResolver((p, _) => {
 export class ActionExecutionNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ActionExecutionNotFoundException>()(
     "ActionExecutionNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ActionNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ActionNotFoundException>()(
     "ActionNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ActionTypeNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ActionTypeNotFoundException>()(
     "ActionTypeNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ApprovalAlreadyCompletedException
   extends /*@__PURE__*/ S.TaggedErrorClass<ApprovalAlreadyCompletedException>()(
     "ApprovalAlreadyCompletedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ConcurrentModificationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentModificationException>()(
     "ConcurrentModificationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ConcurrentPipelineExecutionsLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentPipelineExecutionsLimitExceededException>()(
     "ConcurrentPipelineExecutionsLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ConditionNotOverridableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConditionNotOverridableException>()(
     "ConditionNotOverridableException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class DuplicatedStopRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicatedStopRequestException>()(
     "DuplicatedStopRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidActionDeclarationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidActionDeclarationException>()(
     "InvalidActionDeclarationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidApprovalTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidApprovalTokenException>()(
     "InvalidApprovalTokenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidArnException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidArnException>()(
     "InvalidArnException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidBlockerDeclarationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidBlockerDeclarationException>()(
     "InvalidBlockerDeclarationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidClientTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidClientTokenException>()(
     "InvalidClientTokenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidJobException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidJobException>()(
     "InvalidJobException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidJobStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidJobStateException>()(
     "InvalidJobStateException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidNextTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNextTokenException>()(
     "InvalidNextTokenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidNonceException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNonceException>()(
     "InvalidNonceException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidStageDeclarationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidStageDeclarationException>()(
     "InvalidStageDeclarationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidStructureException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidStructureException>()(
     "InvalidStructureException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTagsException>()(
     "InvalidTagsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidWebhookAuthenticationParametersException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidWebhookAuthenticationParametersException>()(
     "InvalidWebhookAuthenticationParametersException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidWebhookFilterPatternException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidWebhookFilterPatternException>()(
     "InvalidWebhookFilterPatternException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class JobNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<JobNotFoundException>()(
     "JobNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NotLatestPipelineExecutionException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotLatestPipelineExecutionException>()(
     "NotLatestPipelineExecutionException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class OutputVariablesSizeExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<OutputVariablesSizeExceededException>()(
     "OutputVariablesSizeExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class PipelineExecutionNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<PipelineExecutionNotFoundException>()(
     "PipelineExecutionNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class PipelineExecutionNotStoppableException
   extends /*@__PURE__*/ S.TaggedErrorClass<PipelineExecutionNotStoppableException>()(
     "PipelineExecutionNotStoppableException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class PipelineExecutionOutdatedException
   extends /*@__PURE__*/ S.TaggedErrorClass<PipelineExecutionOutdatedException>()(
     "PipelineExecutionOutdatedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class PipelineNameInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<PipelineNameInUseException>()(
     "PipelineNameInUseException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class PipelineNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<PipelineNotFoundException>()(
     "PipelineNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class PipelineVersionNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<PipelineVersionNotFoundException>()(
     "PipelineVersionNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class RequestFailedException
   extends /*@__PURE__*/ S.TaggedErrorClass<RequestFailedException>()(
     "RequestFailedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class StageNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<StageNotFoundException>()(
     "StageNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class StageNotRetryableException
   extends /*@__PURE__*/ S.TaggedErrorClass<StageNotRetryableException>()(
     "StageNotRetryableException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class UnableToRollbackStageException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnableToRollbackStageException>()(
     "UnableToRollbackStageException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WebhookNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<WebhookNotFoundException>()(
     "WebhookNotFoundException",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type JobId = string;
 export type Nonce = string;

--- a/packages/aws/src/services/codestar-connections.ts
+++ b/packages/aws/src/services/codestar-connections.ts
@@ -88,103 +88,103 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConcurrentModificationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentModificationException>()(
     "ConcurrentModificationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ConditionalCheckFailedException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConditionalCheckFailedException>()(
     "ConditionalCheckFailedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class InvalidInputException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInputException>()(
     "InvalidInputException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ResourceAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceAlreadyExistsException>()(
     "ResourceAlreadyExistsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ResourceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceUnavailableException>()(
     "ResourceUnavailableException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class RetryLatestCommitFailedException
   extends /*@__PURE__*/ S.TaggedErrorClass<RetryLatestCommitFailedException>()(
     "RetryLatestCommitFailedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class SyncBlockerDoesNotExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<SyncBlockerDoesNotExistException>()(
     "SyncBlockerDoesNotExistException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class SyncConfigurationStillExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<SyncConfigurationStillExistsException>()(
     "SyncConfigurationStillExistsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class UnsupportedOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedOperationException>()(
     "UnsupportedOperationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class UnsupportedProviderTypeException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedProviderTypeException>()(
     "UnsupportedProviderTypeException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class UpdateOutOfSyncException
   extends /*@__PURE__*/ S.TaggedErrorClass<UpdateOutOfSyncException>()(
     "UpdateOutOfSyncException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export type ProviderType =

--- a/packages/aws/src/services/codestar-notifications.ts
+++ b/packages/aws/src/services/codestar-notifications.ts
@@ -90,49 +90,49 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConcurrentModificationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentModificationException>()(
     "ConcurrentModificationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ConfigurationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConfigurationException>()(
     "ConfigurationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidNextTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNextTokenException>()(
     "InvalidNextTokenException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceAlreadyExistsException>()(
     "ResourceAlreadyExistsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type NotificationRuleName = string | redacted.Redacted<string>;

--- a/packages/aws/src/services/cognito-identity-provider.ts
+++ b/packages/aws/src/services/cognito-identity-provider.ts
@@ -106,347 +106,350 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class AliasExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<AliasExistsException>()(
     "AliasExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class CodeDeliveryFailureException
   extends /*@__PURE__*/ S.TaggedErrorClass<CodeDeliveryFailureException>()(
     "CodeDeliveryFailureException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class CodeMismatchException
   extends /*@__PURE__*/ S.TaggedErrorClass<CodeMismatchException>()(
     "CodeMismatchException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ConcurrentModificationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentModificationException>()(
     "ConcurrentModificationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class DeviceKeyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<DeviceKeyExistsException>()(
     "DeviceKeyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class DuplicateProviderException
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicateProviderException>()(
     "DuplicateProviderException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class EnableSoftwareTokenMFAException
   extends /*@__PURE__*/ S.TaggedErrorClass<EnableSoftwareTokenMFAException>()(
     "EnableSoftwareTokenMFAException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ExpiredCodeException
   extends /*@__PURE__*/ S.TaggedErrorClass<ExpiredCodeException>()(
     "ExpiredCodeException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class FeatureUnavailableInTierException
   extends /*@__PURE__*/ S.TaggedErrorClass<FeatureUnavailableInTierException>()(
     "FeatureUnavailableInTierException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ForbiddenException
   extends /*@__PURE__*/ S.TaggedErrorClass<ForbiddenException>()(
     "ForbiddenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class GroupExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<GroupExistsException>()(
     "GroupExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InternalErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalErrorException>()(
     "InternalErrorException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withServerError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidEmailRoleAccessPolicyException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidEmailRoleAccessPolicyException>()(
     "InvalidEmailRoleAccessPolicyException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidLambdaResponseException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidLambdaResponseException>()(
     "InvalidLambdaResponseException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidOAuthFlowException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidOAuthFlowException>()(
     "InvalidOAuthFlowException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterException>()(
     "InvalidParameterException",
-    { message: S.optional(S.String), reasonCode: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      reasonCode: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidPasswordException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPasswordException>()(
     "InvalidPasswordException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidSmsRoleAccessPolicyException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSmsRoleAccessPolicyException>()(
     "InvalidSmsRoleAccessPolicyException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidSmsRoleTrustRelationshipException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSmsRoleTrustRelationshipException>()(
     "InvalidSmsRoleTrustRelationshipException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidUserPoolConfigurationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidUserPoolConfigurationException>()(
     "InvalidUserPoolConfigurationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ManagedLoginBrandingExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ManagedLoginBrandingExistsException>()(
     "ManagedLoginBrandingExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class MFAMethodNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<MFAMethodNotFoundException>()(
     "MFAMethodNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class NotAuthorizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotAuthorizedException>()(
     "NotAuthorizedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class OperationNotEnabledException
   extends /*@__PURE__*/ S.TaggedErrorClass<OperationNotEnabledException>()(
     "OperationNotEnabledException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class PasswordHistoryPolicyViolationException
   extends /*@__PURE__*/ S.TaggedErrorClass<PasswordHistoryPolicyViolationException>()(
     "PasswordHistoryPolicyViolationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class PasswordResetRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<PasswordResetRequiredException>()(
     "PasswordResetRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class PreconditionNotMetException
   extends /*@__PURE__*/ S.TaggedErrorClass<PreconditionNotMetException>()(
     "PreconditionNotMetException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class RefreshTokenReuseException
   extends /*@__PURE__*/ S.TaggedErrorClass<RefreshTokenReuseException>()(
     "RefreshTokenReuseException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ScopeDoesNotExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<ScopeDoesNotExistException>()(
     "ScopeDoesNotExistException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class SoftwareTokenMFANotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<SoftwareTokenMFANotFoundException>()(
     "SoftwareTokenMFANotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TermsExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TermsExistsException>()(
     "TermsExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TierChangeNotAllowedException
   extends /*@__PURE__*/ S.TaggedErrorClass<TierChangeNotAllowedException>()(
     "TierChangeNotAllowedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class TooManyFailedAttemptsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyFailedAttemptsException>()(
     "TooManyFailedAttemptsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class UnauthorizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnauthorizedException>()(
     "UnauthorizedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export class UnexpectedLambdaException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnexpectedLambdaException>()(
     "UnexpectedLambdaException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class UnsupportedIdentityProviderException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedIdentityProviderException>()(
     "UnsupportedIdentityProviderException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class UnsupportedOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedOperationException>()(
     "UnsupportedOperationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class UnsupportedTokenTypeException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedTokenTypeException>()(
     "UnsupportedTokenTypeException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class UnsupportedUserStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedUserStateException>()(
     "UnsupportedUserStateException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class UserImportInProgressException
   extends /*@__PURE__*/ S.TaggedErrorClass<UserImportInProgressException>()(
     "UserImportInProgressException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class UserLambdaValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<UserLambdaValidationException>()(
     "UserLambdaValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class UsernameExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<UsernameExistsException>()(
     "UsernameExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class UserNotConfirmedException
   extends /*@__PURE__*/ S.TaggedErrorClass<UserNotConfirmedException>()(
     "UserNotConfirmedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class UserNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<UserNotFoundException>()(
     "UserNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class UserPoolAddOnNotEnabledException
   extends /*@__PURE__*/ S.TaggedErrorClass<UserPoolAddOnNotEnabledException>()(
     "UserPoolAddOnNotEnabledException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class UserPoolTaggingException
   extends /*@__PURE__*/ S.TaggedErrorClass<UserPoolTaggingException>()(
     "UserPoolTaggingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class WebAuthnChallengeNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<WebAuthnChallengeNotFoundException>()(
     "WebAuthnChallengeNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class WebAuthnClientMismatchException
   extends /*@__PURE__*/ S.TaggedErrorClass<WebAuthnClientMismatchException>()(
     "WebAuthnClientMismatchException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class WebAuthnConfigurationMissingException
   extends /*@__PURE__*/ S.TaggedErrorClass<WebAuthnConfigurationMissingException>()(
     "WebAuthnConfigurationMissingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class WebAuthnCredentialNotSupportedException
   extends /*@__PURE__*/ S.TaggedErrorClass<WebAuthnCredentialNotSupportedException>()(
     "WebAuthnCredentialNotSupportedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class WebAuthnNotEnabledException
   extends /*@__PURE__*/ S.TaggedErrorClass<WebAuthnNotEnabledException>()(
     "WebAuthnNotEnabledException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class WebAuthnOriginNotAllowedException
   extends /*@__PURE__*/ S.TaggedErrorClass<WebAuthnOriginNotAllowedException>()(
     "WebAuthnOriginNotAllowedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class WebAuthnRelyingPartyMismatchException
   extends /*@__PURE__*/ S.TaggedErrorClass<WebAuthnRelyingPartyMismatchException>()(
     "WebAuthnRelyingPartyMismatchException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type UserPoolIdType = string;

--- a/packages/aws/src/services/cognito-identity.ts
+++ b/packages/aws/src/services/cognito-identity.ts
@@ -108,66 +108,66 @@ const rules = T.EndpointResolver((p, _) => {
 export class ConcurrentModificationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentModificationException>()(
     "ConcurrentModificationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class DeveloperUserAlreadyRegisteredException
   extends /*@__PURE__*/ S.TaggedErrorClass<DeveloperUserAlreadyRegisteredException>()(
     "DeveloperUserAlreadyRegisteredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ExternalServiceException
   extends /*@__PURE__*/ S.TaggedErrorClass<ExternalServiceException>()(
     "ExternalServiceException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InternalErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalErrorException>()(
     "InternalErrorException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withServerError) {}
 export class InvalidIdentityPoolConfigurationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidIdentityPoolConfigurationException>()(
     "InvalidIdentityPoolConfigurationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterException>()(
     "InvalidParameterException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class NotAuthorizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotAuthorizedException>()(
     "NotAuthorizedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ResourceConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceConflictException>()(
     "ResourceConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export type IdentityPoolName = string;

--- a/packages/aws/src/services/cognito-sync.ts
+++ b/packages/aws/src/services/cognito-sync.ts
@@ -88,7 +88,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class AlreadyStreamedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AlreadyStreamedException>()(
     "AlreadyStreamedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "AlreadyStreamed", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -97,7 +97,7 @@ export class AlreadyStreamedException
 export class ConcurrentModificationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentModificationException>()(
     "ConcurrentModificationException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ConcurrentModification",
@@ -109,7 +109,7 @@ export class ConcurrentModificationException
 export class DuplicateRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicateRequestException>()(
     "DuplicateRequestException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "DuplicateRequest", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -118,7 +118,7 @@ export class DuplicateRequestException
 export class InternalErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalErrorException>()(
     "InternalErrorException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InternalError", httpResponseCode: 500 }),
       T.HttpError(500),
@@ -127,7 +127,7 @@ export class InternalErrorException
 export class InvalidConfigurationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidConfigurationException>()(
     "InvalidConfigurationException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidConfiguration", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -136,7 +136,7 @@ export class InvalidConfigurationException
 export class InvalidLambdaFunctionOutputException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidLambdaFunctionOutputException>()(
     "InvalidLambdaFunctionOutputException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidLambdaFunctionOutput",
@@ -148,7 +148,7 @@ export class InvalidLambdaFunctionOutputException
 export class InvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterException>()(
     "InvalidParameterException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidParameter", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -157,7 +157,7 @@ export class InvalidParameterException
 export class LambdaThrottledException
   extends /*@__PURE__*/ S.TaggedErrorClass<LambdaThrottledException>()(
     "LambdaThrottledException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "LambdaThrottled", httpResponseCode: 429 }),
       T.HttpError(429),
@@ -166,7 +166,7 @@ export class LambdaThrottledException
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "LimitExceeded", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -175,7 +175,7 @@ export class LimitExceededException
 export class NotAuthorizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotAuthorizedException>()(
     "NotAuthorizedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "NotAuthorizedError", httpResponseCode: 403 }),
       T.HttpError(403),
@@ -184,7 +184,7 @@ export class NotAuthorizedException
 export class ResourceConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceConflictException>()(
     "ResourceConflictException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ResourceConflict", httpResponseCode: 409 }),
       T.HttpError(409),
@@ -193,7 +193,7 @@ export class ResourceConflictException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ResourceNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -202,7 +202,7 @@ export class ResourceNotFoundException
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "TooManyRequests", httpResponseCode: 429 }),
       T.HttpError(429),

--- a/packages/aws/src/services/comprehend.ts
+++ b/packages/aws/src/services/comprehend.ts
@@ -90,32 +90,32 @@ const rules = T.EndpointResolver((p, _) => {
 export class BatchSizeLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<BatchSizeLimitExceededException>()(
     "BatchSizeLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ConcurrentModificationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentModificationException>()(
     "ConcurrentModificationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidFilterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidFilterException>()(
     "InvalidFilterException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => InvalidRequestReason).annotate({
           identifier: "InvalidRequestReason",
@@ -132,72 +132,72 @@ export class InvalidRequestException
 export class JobNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<JobNotFoundException>()(
     "JobNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class KmsKeyValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<KmsKeyValidationException>()(
     "KmsKeyValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class NotAuthorizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotAuthorizedException>()(
     "NotAuthorizedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAuthError) {}
 export class ResourceInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUseException>()(
     "ResourceInUseException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceLimitExceededException>()(
     "ResourceLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ResourceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceUnavailableException>()(
     "ResourceUnavailableException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class TextSizeLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<TextSizeLimitExceededException>()(
     "TextSizeLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class TooManyTagKeysException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagKeysException>()(
     "TooManyTagKeysException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class UnsupportedLanguageException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedLanguageException>()(
     "UnsupportedLanguageException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type CustomerInputString = string | redacted.Redacted<string>;

--- a/packages/aws/src/services/comprehendmedical.ts
+++ b/packages/aws/src/services/comprehendmedical.ts
@@ -87,49 +87,49 @@ const rules = T.EndpointResolver((p, _) => {
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidEncodingException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidEncodingException>()(
     "InvalidEncodingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class TextSizeLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<TextSizeLimitExceededException>()(
     "TextSizeLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type JobId = string;

--- a/packages/aws/src/services/compute-optimizer-automation.ts
+++ b/packages/aws/src/services/compute-optimizer-automation.ts
@@ -88,73 +88,73 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ForbiddenException
   extends /*@__PURE__*/ S.TaggedErrorClass<ForbiddenException>()(
     "ForbiddenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class IdempotencyTokenInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<IdempotencyTokenInUseException>()(
     "IdempotencyTokenInUseException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class IdempotentParameterMismatchException
   extends /*@__PURE__*/ S.TaggedErrorClass<IdempotentParameterMismatchException>()(
     "IdempotentParameterMismatchException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidParameterValueException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterValueException>()(
     "InvalidParameterValueException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class NotManagementAccountException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotManagementAccountException>()(
     "NotManagementAccountException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class OptInRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<OptInRequiredException>()(
     "OptInRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export type AccountId = string;

--- a/packages/aws/src/services/compute-optimizer.ts
+++ b/packages/aws/src/services/compute-optimizer.ts
@@ -88,55 +88,55 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidParameterValueException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterValueException>()(
     "InvalidParameterValueException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class MissingAuthenticationToken
   extends /*@__PURE__*/ S.TaggedErrorClass<MissingAuthenticationToken>()(
     "MissingAuthenticationToken",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class OptInRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<OptInRequiredException>()(
     "OptInRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export type ResourceType =

--- a/packages/aws/src/services/config-service.ts
+++ b/packages/aws/src/services/config-service.ts
@@ -92,283 +92,283 @@ const rules = T.EndpointResolver((p, _) => {
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ConformancePackTemplateValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConformancePackTemplateValidationException>()(
     "ConformancePackTemplateValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class IdempotentParameterMismatch
   extends /*@__PURE__*/ S.TaggedErrorClass<IdempotentParameterMismatch>()(
     "IdempotentParameterMismatch",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError, C.withConflictError) {}
 export class InsufficientDeliveryPolicyException
   extends /*@__PURE__*/ S.TaggedErrorClass<InsufficientDeliveryPolicyException>()(
     "InsufficientDeliveryPolicyException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InsufficientPermissionsException
   extends /*@__PURE__*/ S.TaggedErrorClass<InsufficientPermissionsException>()(
     "InsufficientPermissionsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidConfigurationRecorderNameException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidConfigurationRecorderNameException>()(
     "InvalidConfigurationRecorderNameException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidDeliveryChannelNameException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDeliveryChannelNameException>()(
     "InvalidDeliveryChannelNameException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidExpressionException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidExpressionException>()(
     "InvalidExpressionException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidLimitException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidLimitException>()(
     "InvalidLimitException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidNextTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNextTokenException>()(
     "InvalidNextTokenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidParameterValueException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterValueException>()(
     "InvalidParameterValueException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRecordingGroupException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRecordingGroupException>()(
     "InvalidRecordingGroupException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidResultTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidResultTokenException>()(
     "InvalidResultTokenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRoleException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRoleException>()(
     "InvalidRoleException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidS3KeyPrefixException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidS3KeyPrefixException>()(
     "InvalidS3KeyPrefixException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidS3KmsKeyArnException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidS3KmsKeyArnException>()(
     "InvalidS3KmsKeyArnException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidSNSTopicARNException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSNSTopicARNException>()(
     "InvalidSNSTopicARNException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTimeRangeException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTimeRangeException>()(
     "InvalidTimeRangeException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LastDeliveryChannelDeleteFailedException
   extends /*@__PURE__*/ S.TaggedErrorClass<LastDeliveryChannelDeleteFailedException>()(
     "LastDeliveryChannelDeleteFailedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MaxActiveResourcesExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<MaxActiveResourcesExceededException>()(
     "MaxActiveResourcesExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MaxNumberOfConfigRulesExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<MaxNumberOfConfigRulesExceededException>()(
     "MaxNumberOfConfigRulesExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MaxNumberOfConfigurationRecordersExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<MaxNumberOfConfigurationRecordersExceededException>()(
     "MaxNumberOfConfigurationRecordersExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MaxNumberOfConformancePacksExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<MaxNumberOfConformancePacksExceededException>()(
     "MaxNumberOfConformancePacksExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MaxNumberOfDeliveryChannelsExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<MaxNumberOfDeliveryChannelsExceededException>()(
     "MaxNumberOfDeliveryChannelsExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MaxNumberOfOrganizationConfigRulesExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<MaxNumberOfOrganizationConfigRulesExceededException>()(
     "MaxNumberOfOrganizationConfigRulesExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MaxNumberOfOrganizationConformancePacksExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<MaxNumberOfOrganizationConformancePacksExceededException>()(
     "MaxNumberOfOrganizationConformancePacksExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MaxNumberOfRetentionConfigurationsExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<MaxNumberOfRetentionConfigurationsExceededException>()(
     "MaxNumberOfRetentionConfigurationsExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NoAvailableConfigurationRecorderException
   extends /*@__PURE__*/ S.TaggedErrorClass<NoAvailableConfigurationRecorderException>()(
     "NoAvailableConfigurationRecorderException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NoAvailableDeliveryChannelException
   extends /*@__PURE__*/ S.TaggedErrorClass<NoAvailableDeliveryChannelException>()(
     "NoAvailableDeliveryChannelException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NoAvailableOrganizationException
   extends /*@__PURE__*/ S.TaggedErrorClass<NoAvailableOrganizationException>()(
     "NoAvailableOrganizationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NoRunningConfigurationRecorderException
   extends /*@__PURE__*/ S.TaggedErrorClass<NoRunningConfigurationRecorderException>()(
     "NoRunningConfigurationRecorderException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NoSuchBucketException
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchBucketException>()(
     "NoSuchBucketException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NoSuchConfigRuleException
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchConfigRuleException>()(
     "NoSuchConfigRuleException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NoSuchConfigRuleInConformancePackException
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchConfigRuleInConformancePackException>()(
     "NoSuchConfigRuleInConformancePackException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NoSuchConfigurationAggregatorException
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchConfigurationAggregatorException>()(
     "NoSuchConfigurationAggregatorException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NoSuchConfigurationRecorderException
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchConfigurationRecorderException>()(
     "NoSuchConfigurationRecorderException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NoSuchConformancePackException
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchConformancePackException>()(
     "NoSuchConformancePackException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NoSuchDeliveryChannelException
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchDeliveryChannelException>()(
     "NoSuchDeliveryChannelException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NoSuchOrganizationConfigRuleException
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchOrganizationConfigRuleException>()(
     "NoSuchOrganizationConfigRuleException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NoSuchOrganizationConformancePackException
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchOrganizationConformancePackException>()(
     "NoSuchOrganizationConformancePackException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NoSuchRemediationConfigurationException
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchRemediationConfigurationException>()(
     "NoSuchRemediationConfigurationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NoSuchRemediationExceptionException
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchRemediationExceptionException>()(
     "NoSuchRemediationExceptionException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NoSuchRetentionConfigurationException
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchRetentionConfigurationException>()(
     "NoSuchRetentionConfigurationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class OrganizationAccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<OrganizationAccessDeniedException>()(
     "OrganizationAccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAuthError) {}
 export class OrganizationAllFeaturesNotEnabledException
   extends /*@__PURE__*/ S.TaggedErrorClass<OrganizationAllFeaturesNotEnabledException>()(
     "OrganizationAllFeaturesNotEnabledException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class OrganizationConformancePackTemplateValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<OrganizationConformancePackTemplateValidationException>()(
     "OrganizationConformancePackTemplateValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class OversizedConfigurationItemException
   extends /*@__PURE__*/ S.TaggedErrorClass<OversizedConfigurationItemException>()(
     "OversizedConfigurationItemException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class RemediationInProgressException
   extends /*@__PURE__*/ S.TaggedErrorClass<RemediationInProgressException>()(
     "RemediationInProgressException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceConcurrentModificationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceConcurrentModificationException>()(
     "ResourceConcurrentModificationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUseException>()(
     "ResourceInUseException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceNotDiscoveredException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotDiscoveredException>()(
     "ResourceNotDiscoveredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class UnmodifiableEntityException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnmodifiableEntityException>()(
     "UnmodifiableEntityException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type AmazonResourceName = string;
 export type ResourceType =

--- a/packages/aws/src/services/connect-contact-lens.ts
+++ b/packages/aws/src/services/connect-contact-lens.ts
@@ -88,31 +88,31 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class InternalServiceException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServiceException>()(
     "InternalServiceException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export type InstanceId = string;

--- a/packages/aws/src/services/connect.ts
+++ b/packages/aws/src/services/connect.ts
@@ -93,7 +93,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "AccessDeniedException", httpResponseCode: 403 }),
       T.HttpError(403),
@@ -102,25 +102,25 @@ export class AccessDeniedException
 export class ConditionalOperationFailedException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConditionalOperationFailedException>()(
     "ConditionalOperationFailedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ContactFlowNotPublishedException
   extends /*@__PURE__*/ S.TaggedErrorClass<ContactFlowNotPublishedException>()(
     "ContactFlowNotPublishedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ContactNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ContactNotFoundException>()(
     "ContactNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ContactNotFoundException",
@@ -132,7 +132,7 @@ export class ContactNotFoundException
 export class DestinationNotAllowedException
   extends /*@__PURE__*/ S.TaggedErrorClass<DestinationNotAllowedException>()(
     "DestinationNotAllowedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DestinationNotAllowedException",
@@ -144,25 +144,25 @@ export class DestinationNotAllowedException
 export class DuplicateResourceException
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicateResourceException>()(
     "DuplicateResourceException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class IdempotencyException
   extends /*@__PURE__*/ S.TaggedErrorClass<IdempotencyException>()(
     "IdempotencyException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServiceException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServiceException>()(
     "InternalServiceException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidActiveRegionException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidActiveRegionException>()(
     "InvalidActiveRegionException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidContactFlowException
@@ -172,6 +172,7 @@ export class InvalidContactFlowException
       problems: S.optional(
         S.suspend(() => Problems).annotate({ identifier: "Problems" }),
       ),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
@@ -182,20 +183,21 @@ export class InvalidContactFlowModuleException
       Problems: S.optional(
         S.suspend(() => Problems).annotate({ identifier: "Problems" }),
       ),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterException>()(
     "InvalidParameterException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => InvalidRequestExceptionReason).annotate({
           identifier: "InvalidRequestExceptionReason",
@@ -211,13 +213,14 @@ export class InvalidTestCaseException
       Problems: S.optional(
         S.suspend(() => Problems).annotate({ identifier: "Problems" }),
       ),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "LimitExceededException",
@@ -229,13 +232,13 @@ export class LimitExceededException
 export class MaximumResultReturnedException
   extends /*@__PURE__*/ S.TaggedErrorClass<MaximumResultReturnedException>()(
     "MaximumResultReturnedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class OutboundContactNotPermittedException
   extends /*@__PURE__*/ S.TaggedErrorClass<OutboundContactNotPermittedException>()(
     "OutboundContactNotPermittedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "OutboundContactNotPermittedException",
@@ -247,14 +250,14 @@ export class OutboundContactNotPermittedException
 export class OutputTypeNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<OutputTypeNotFoundException>()(
     "OutputTypeNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class PropertyValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<PropertyValidationException>()(
     "PropertyValidationException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       PropertyList: S.optional(
         S.suspend(() => PropertyValidationExceptionPropertyList).annotate({
           identifier: "PropertyValidationExceptionPropertyList",
@@ -266,14 +269,14 @@ export class PropertyValidationException
 export class ResourceConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceConflictException>()(
     "ResourceConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ResourceInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUseException>()(
     "ResourceInUseException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       ResourceType: S.optional(
         S.suspend(() => ResourceType).annotate({ identifier: "ResourceType" }),
       ),
@@ -284,20 +287,20 @@ export class ResourceInUseException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotReadyException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotReadyException>()(
     "ResourceNotReadyException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => ServiceQuotaExceededExceptionReason).annotate({
           identifier: "ServiceQuotaExceededExceptionReason",
@@ -309,7 +312,7 @@ export class ServiceQuotaExceededException
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ThrottlingException", httpResponseCode: 429 }),
       T.HttpError(429),
@@ -318,13 +321,13 @@ export class ThrottlingException
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class UserNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<UserNotFoundException>()(
     "UserNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export type InstanceId = string;

--- a/packages/aws/src/services/connectcampaigns.ts
+++ b/packages/aws/src/services/connectcampaigns.ts
@@ -91,7 +91,7 @@ export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       xAmzErrorType: S.optional(S.String).pipe(
         T.HttpHeader("x-amzn-ErrorType"),
       ),
@@ -102,7 +102,7 @@ export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       xAmzErrorType: S.optional(S.String).pipe(
         T.HttpHeader("x-amzn-ErrorType"),
       ),
@@ -113,7 +113,7 @@ export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       xAmzErrorType: S.optional(S.String).pipe(
         T.HttpHeader("x-amzn-ErrorType"),
       ),
@@ -125,7 +125,7 @@ export class InvalidCampaignStateException
     "InvalidCampaignStateException",
     {
       state: S.String,
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       xAmzErrorType: S.optional(S.String).pipe(
         T.HttpHeader("x-amzn-ErrorType"),
       ),
@@ -136,7 +136,7 @@ export class InvalidStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidStateException>()(
     "InvalidStateException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       xAmzErrorType: S.optional(S.String).pipe(
         T.HttpHeader("x-amzn-ErrorType"),
       ),
@@ -147,7 +147,7 @@ export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       xAmzErrorType: S.optional(S.String).pipe(
         T.HttpHeader("x-amzn-ErrorType"),
       ),
@@ -158,7 +158,7 @@ export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       xAmzErrorType: S.optional(S.String).pipe(
         T.HttpHeader("x-amzn-ErrorType"),
       ),
@@ -169,7 +169,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       xAmzErrorType: S.optional(S.String).pipe(
         T.HttpHeader("x-amzn-ErrorType"),
       ),
@@ -180,7 +180,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       xAmzErrorType: S.optional(S.String).pipe(
         T.HttpHeader("x-amzn-ErrorType"),
       ),

--- a/packages/aws/src/services/connectcampaignsv2.ts
+++ b/packages/aws/src/services/connectcampaignsv2.ts
@@ -91,7 +91,7 @@ export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       xAmzErrorType: S.optional(S.String).pipe(
         T.HttpHeader("x-amzn-ErrorType"),
       ),
@@ -102,7 +102,7 @@ export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       xAmzErrorType: S.optional(S.String).pipe(
         T.HttpHeader("x-amzn-ErrorType"),
       ),
@@ -113,7 +113,7 @@ export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       xAmzErrorType: S.optional(S.String).pipe(
         T.HttpHeader("x-amzn-ErrorType"),
       ),
@@ -125,7 +125,7 @@ export class InvalidCampaignStateException
     "InvalidCampaignStateException",
     {
       state: S.String,
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       xAmzErrorType: S.optional(S.String).pipe(
         T.HttpHeader("x-amzn-ErrorType"),
       ),
@@ -136,7 +136,7 @@ export class InvalidStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidStateException>()(
     "InvalidStateException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       xAmzErrorType: S.optional(S.String).pipe(
         T.HttpHeader("x-amzn-ErrorType"),
       ),
@@ -147,7 +147,7 @@ export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       xAmzErrorType: S.optional(S.String).pipe(
         T.HttpHeader("x-amzn-ErrorType"),
       ),
@@ -158,7 +158,7 @@ export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       xAmzErrorType: S.optional(S.String).pipe(
         T.HttpHeader("x-amzn-ErrorType"),
       ),
@@ -169,7 +169,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       xAmzErrorType: S.optional(S.String).pipe(
         T.HttpHeader("x-amzn-ErrorType"),
       ),
@@ -180,7 +180,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       xAmzErrorType: S.optional(S.String).pipe(
         T.HttpHeader("x-amzn-ErrorType"),
       ),

--- a/packages/aws/src/services/connectcases.ts
+++ b/packages/aws/src/services/connectcases.ts
@@ -90,20 +90,20 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.all(T.HttpError(500), T.Retryable()),
@@ -111,25 +111,29 @@ export class InternalServerException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(429), T.Retryable()),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type DomainId = string;

--- a/packages/aws/src/services/connecthealth.ts
+++ b/packages/aws/src/services/connecthealth.ts
@@ -57,43 +57,43 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(429), T.Retryable({ throttling: true })),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type DomainId = string;

--- a/packages/aws/src/services/connectparticipant.ts
+++ b/packages/aws/src/services/connectparticipant.ts
@@ -93,26 +93,26 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       ResourceId: S.optional(S.String),
       ResourceType: S.optional(
         S.suspend(() => ResourceType).annotate({ identifier: "ResourceType" }),
@@ -123,19 +123,19 @@ export class ResourceNotFoundException
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type SessionId = string;

--- a/packages/aws/src/services/controlcatalog.ts
+++ b/packages/aws/src/services/controlcatalog.ts
@@ -88,31 +88,31 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(429), T.Retryable({ throttling: true })),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type ControlArn = string;

--- a/packages/aws/src/services/controltower.ts
+++ b/packages/aws/src/services/controltower.ts
@@ -88,43 +88,43 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       serviceCode: S.optional(S.String),
       quotaCode: S.optional(S.String),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
@@ -134,12 +134,12 @@ export class ThrottlingException
 export class UnauthorizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnauthorizedException>()(
     "UnauthorizedException",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAuthError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type LandingZoneVersion = string;

--- a/packages/aws/src/services/cost-and-usage-report-service.ts
+++ b/packages/aws/src/services/cost-and-usage-report-service.ts
@@ -88,17 +88,17 @@ const rules = T.EndpointResolver((p, _) => {
 export class DuplicateReportNameException
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicateReportNameException>()(
     "DuplicateReportNameException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InternalErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalErrorException>()(
     "InternalErrorException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withServerError) {}
 export class ReportBucketNotVerified
   extends /*@__PURE__*/ S.TaggedErrorClass<ReportBucketNotVerified>()(
     "ReportBucketNotVerified",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "ValidationException",
       message: { matches: "[Bb]ucket" },
@@ -107,17 +107,17 @@ export class ReportBucketNotVerified
 export class ReportLimitReachedException
   extends /*@__PURE__*/ S.TaggedErrorClass<ReportLimitReachedException>()(
     "ReportLimitReachedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type ReportName = string;
 export interface DeleteReportDefinitionRequest {

--- a/packages/aws/src/services/cost-explorer.ts
+++ b/packages/aws/src/services/cost-explorer.ts
@@ -207,13 +207,13 @@ const rules = T.EndpointResolver((p, _) => {
 export class AnalysisNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<AnalysisNotFoundException>()(
     "AnalysisNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class AnomalyMonitorAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<AnomalyMonitorAlreadyExists>()(
     "AnomalyMonitorAlreadyExists",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "ValidationException",
       message: { includes: "same monitor name as an existing monitor" },
@@ -222,7 +222,7 @@ export class AnomalyMonitorAlreadyExists
 export class AnomalySubscriptionAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<AnomalySubscriptionAlreadyExists>()(
     "AnomalySubscriptionAlreadyExists",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "ValidationException",
       message: {
@@ -233,55 +233,58 @@ export class AnomalySubscriptionAlreadyExists
 export class BackfillLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<BackfillLimitExceededException>()(
     "BackfillLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class BillExpirationException
   extends /*@__PURE__*/ S.TaggedErrorClass<BillExpirationException>()(
     "BillExpirationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class BillingViewHealthStatusException
   extends /*@__PURE__*/ S.TaggedErrorClass<BillingViewHealthStatusException>()(
     "BillingViewHealthStatusException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class DataUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<DataUnavailableException>()(
     "DataUnavailableException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class GenerationExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<GenerationExistsException>()(
     "GenerationExistsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidNextTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNextTokenException>()(
     "InvalidNextTokenException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class RequestChangedException
   extends /*@__PURE__*/ S.TaggedErrorClass<RequestChangedException>()(
     "RequestChangedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String), ResourceName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ResourceName: S.optional(S.String),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class RightsizingRecommendationNotEnabled
   extends /*@__PURE__*/ S.TaggedErrorClass<RightsizingRecommendationNotEnabled>()(
     "RightsizingRecommendationNotEnabled",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "AccessDeniedException",
       message: { includes: "opt-in only feature" },
@@ -290,31 +293,34 @@ export class RightsizingRecommendationNotEnabled
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { Message: S.optional(S.String), ResourceName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ResourceName: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class UnknownMonitorException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnknownMonitorException>()(
     "UnknownMonitorException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class UnknownSubscriptionException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnknownSubscriptionException>()(
     "UnknownSubscriptionException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class UnresolvableUsageUnitException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnresolvableUsageUnitException>()(
     "UnresolvableUsageUnitException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type YearMonthDay = string;
 export type MonitorType = "DIMENSIONAL" | "CUSTOM" | (string & {});

--- a/packages/aws/src/services/cost-optimization-hub.ts
+++ b/packages/aws/src/services/cost-optimization-hub.ts
@@ -88,32 +88,32 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String, resourceId: S.String },
+    { message: S.String.pipe(T.ErrorMessage()), resourceId: S.String },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.optional(
         S.suspend(() => ValidationExceptionReason).annotate({
           identifier: "ValidationExceptionReason",

--- a/packages/aws/src/services/customer-profiles.ts
+++ b/packages/aws/src/services/customer-profiles.ts
@@ -90,31 +90,31 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export type Uuid = string;

--- a/packages/aws/src/services/data-pipeline.ts
+++ b/packages/aws/src/services/data-pipeline.ts
@@ -88,27 +88,27 @@ const rules = T.EndpointResolver((p, _) => {
 export class InternalServiceError
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServiceError>()(
     "InternalServiceError",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class PipelineDeletedException
   extends /*@__PURE__*/ S.TaggedErrorClass<PipelineDeletedException>()(
     "PipelineDeletedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class PipelineNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<PipelineNotFoundException>()(
     "PipelineNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TaskNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<TaskNotFoundException>()(
     "TaskNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type Id = string;
 export type FieldNameString = string;

--- a/packages/aws/src/services/database-migration-service.ts
+++ b/packages/aws/src/services/database-migration-service.ts
@@ -100,131 +100,134 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedFault
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedFault>()(
     "AccessDeniedFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAuthError) {}
 export class CollectorNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<CollectorNotFoundFault>()(
     "CollectorNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class FailedDependencyFault
   extends /*@__PURE__*/ S.TaggedErrorClass<FailedDependencyFault>()(
     "FailedDependencyFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InsufficientResourceCapacityFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InsufficientResourceCapacityFault>()(
     "InsufficientResourceCapacityFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidCertificateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCertificateFault>()(
     "InvalidCertificateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidOperationFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidOperationFault>()(
     "InvalidOperationFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidResourceStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidResourceStateFault>()(
     "InvalidResourceStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidSubnet
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSubnet>()("InvalidSubnet", {
-    message: S.optional(S.String),
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
   }) {}
 export class KMSAccessDeniedFault
   extends /*@__PURE__*/ S.TaggedErrorClass<KMSAccessDeniedFault>()(
     "KMSAccessDeniedFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAuthError) {}
 export class KMSDisabledFault
   extends /*@__PURE__*/ S.TaggedErrorClass<KMSDisabledFault>()(
     "KMSDisabledFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class KMSFault
   extends /*@__PURE__*/ S.TaggedErrorClass<KMSFault>()("KMSFault", {
-    message: S.optional(S.String),
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
   }) {}
 export class KMSInvalidStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<KMSInvalidStateFault>()(
     "KMSInvalidStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class KMSKeyNotAccessibleFault
   extends /*@__PURE__*/ S.TaggedErrorClass<KMSKeyNotAccessibleFault>()(
     "KMSKeyNotAccessibleFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class KMSNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<KMSNotFoundFault>()(
     "KMSNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class KMSThrottlingFault
   extends /*@__PURE__*/ S.TaggedErrorClass<KMSThrottlingFault>()(
     "KMSThrottlingFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ReplicationSubnetGroupDoesNotCoverEnoughAZs
   extends /*@__PURE__*/ S.TaggedErrorClass<ReplicationSubnetGroupDoesNotCoverEnoughAZs>()(
     "ReplicationSubnetGroupDoesNotCoverEnoughAZs",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceAlreadyExistsFault>()(
     "ResourceAlreadyExistsFault",
-    { message: S.optional(S.String), resourceArn: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      resourceArn: S.optional(S.String),
+    },
   ).pipe(C.withAlreadyExistsError) {}
 export class ResourceNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundFault>()(
     "ResourceNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceQuotaExceededFault>()(
     "ResourceQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class S3AccessDeniedFault
   extends /*@__PURE__*/ S.TaggedErrorClass<S3AccessDeniedFault>()(
     "S3AccessDeniedFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAuthError) {}
 export class S3ResourceNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<S3ResourceNotFoundFault>()(
     "S3ResourceNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class SNSInvalidTopicFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SNSInvalidTopicFault>()(
     "SNSInvalidTopicFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class SNSNoAuthorizationFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SNSNoAuthorizationFault>()(
     "SNSNoAuthorizationFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class StorageQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<StorageQuotaExceededFault>()(
     "StorageQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class SubnetAlreadyInUse
   extends /*@__PURE__*/ S.TaggedErrorClass<SubnetAlreadyInUse>()(
     "SubnetAlreadyInUse",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withDependencyViolationError) {}
 export class UpgradeDependencyFailureFault
   extends /*@__PURE__*/ S.TaggedErrorClass<UpgradeDependencyFailureFault>()(
     "UpgradeDependencyFailureFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export interface Tag {
   Key?: string;

--- a/packages/aws/src/services/databrew.ts
+++ b/packages/aws/src/services/databrew.ts
@@ -93,19 +93,19 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class DataBrewRoleNotAssumable
   extends /*@__PURE__*/ S.TaggedErrorClass<DataBrewRoleNotAssumable>()(
     "DataBrewRoleNotAssumable",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "ValidationException",
       message: { includes: "is not a trusted entity for the data access role" },
@@ -114,30 +114,30 @@ export class DataBrewRoleNotAssumable
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type RecipeName = string;

--- a/packages/aws/src/services/dataexchange.ts
+++ b/packages/aws/src/services/dataexchange.ts
@@ -90,14 +90,14 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       ResourceId: S.optional(S.String),
       ResourceType: S.optional(S.String),
     },
@@ -106,14 +106,14 @@ export class ConflictException
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       ResourceId: S.optional(S.String),
       ResourceType: S.optional(S.String),
     },
@@ -125,20 +125,23 @@ export class ServiceLimitExceededException
     {
       LimitName: S.optional(S.String),
       LimitValue: S.optional(S.Number),
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
     },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.String, ExceptionCause: S.optional(S.String) },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      ExceptionCause: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type DataGrantArn = string;

--- a/packages/aws/src/services/datasync.ts
+++ b/packages/aws/src/services/datasync.ts
@@ -90,13 +90,16 @@ const rules = T.EndpointResolver((p, _) => {
 export class InternalException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalException>()(
     "InternalException",
-    { message: S.optional(S.String), errorCode: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      errorCode: S.optional(S.String),
+    },
   ) {}
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       errorCode: S.optional(S.String),
       datasyncErrorCode: S.optional(S.String),
     },
@@ -105,7 +108,7 @@ export class LocationAccessTestFailed
   extends /*@__PURE__*/ S.TaggedErrorClass<LocationAccessTestFailed>()(
     "LocationAccessTestFailed",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       errorCode: S.optional(S.String),
       datasyncErrorCode: S.optional(S.String),
     },
@@ -118,7 +121,7 @@ export class LocationNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<LocationNotFound>()(
     "LocationNotFound",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       errorCode: S.optional(S.String),
       datasyncErrorCode: S.optional(S.String),
     },
@@ -131,7 +134,7 @@ export class LocationRoleNotAssumable
   extends /*@__PURE__*/ S.TaggedErrorClass<LocationRoleNotAssumable>()(
     "LocationRoleNotAssumable",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       errorCode: S.optional(S.String),
       datasyncErrorCode: S.optional(S.String),
     },
@@ -144,7 +147,7 @@ export class TaskNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<TaskNotFound>()(
     "TaskNotFound",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       errorCode: S.optional(S.String),
       datasyncErrorCode: S.optional(S.String),
     },

--- a/packages/aws/src/services/datazone.ts
+++ b/packages/aws/src/services/datazone.ts
@@ -77,43 +77,43 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(429), T.Retryable()),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type DomainId = string;

--- a/packages/aws/src/services/dax.ts
+++ b/packages/aws/src/services/dax.ts
@@ -85,7 +85,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class ClusterAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ClusterAlreadyExistsFault>()(
     "ClusterAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ClusterAlreadyExists", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -94,7 +94,7 @@ export class ClusterAlreadyExistsFault
 export class ClusterNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ClusterNotFoundFault>()(
     "ClusterNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ClusterNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -103,7 +103,7 @@ export class ClusterNotFoundFault
 export class ClusterQuotaForCustomerExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ClusterQuotaForCustomerExceededFault>()(
     "ClusterQuotaForCustomerExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ClusterQuotaForCustomerExceeded",
@@ -115,7 +115,7 @@ export class ClusterQuotaForCustomerExceededFault
 export class InsufficientClusterCapacityFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InsufficientClusterCapacityFault>()(
     "InsufficientClusterCapacityFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InsufficientClusterCapacity",
@@ -127,7 +127,7 @@ export class InsufficientClusterCapacityFault
 export class InvalidARNFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidARNFault>()(
     "InvalidARNFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidARN", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -136,7 +136,7 @@ export class InvalidARNFault
 export class InvalidClusterStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidClusterStateFault>()(
     "InvalidClusterStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidClusterState", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -145,7 +145,7 @@ export class InvalidClusterStateFault
 export class InvalidParameterCombinationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterCombinationException>()(
     "InvalidParameterCombinationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidParameterCombination",
@@ -157,7 +157,7 @@ export class InvalidParameterCombinationException
 export class InvalidParameterGroupStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterGroupStateFault>()(
     "InvalidParameterGroupStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidParameterGroupState",
@@ -169,7 +169,7 @@ export class InvalidParameterGroupStateFault
 export class InvalidParameterValueException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterValueException>()(
     "InvalidParameterValueException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidParameterValue", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -178,7 +178,7 @@ export class InvalidParameterValueException
 export class InvalidSubnet
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSubnet>()(
     "InvalidSubnet",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidSubnet", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -187,7 +187,7 @@ export class InvalidSubnet
 export class InvalidVPCNetworkStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidVPCNetworkStateFault>()(
     "InvalidVPCNetworkStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidVPCNetworkStateFault",
@@ -199,7 +199,7 @@ export class InvalidVPCNetworkStateFault
 export class NodeNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<NodeNotFoundFault>()(
     "NodeNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "NodeNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -208,7 +208,7 @@ export class NodeNotFoundFault
 export class NodeQuotaForClusterExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<NodeQuotaForClusterExceededFault>()(
     "NodeQuotaForClusterExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "NodeQuotaForClusterExceeded",
@@ -220,7 +220,7 @@ export class NodeQuotaForClusterExceededFault
 export class NodeQuotaForCustomerExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<NodeQuotaForCustomerExceededFault>()(
     "NodeQuotaForCustomerExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "NodeQuotaForCustomerExceeded",
@@ -232,7 +232,7 @@ export class NodeQuotaForCustomerExceededFault
 export class ParameterGroupAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ParameterGroupAlreadyExistsFault>()(
     "ParameterGroupAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ParameterGroupAlreadyExists",
@@ -244,7 +244,7 @@ export class ParameterGroupAlreadyExistsFault
 export class ParameterGroupNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ParameterGroupNotFoundFault>()(
     "ParameterGroupNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ParameterGroupNotFound",
@@ -256,7 +256,7 @@ export class ParameterGroupNotFoundFault
 export class ParameterGroupQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ParameterGroupQuotaExceededFault>()(
     "ParameterGroupQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ParameterGroupQuotaExceeded",
@@ -268,7 +268,7 @@ export class ParameterGroupQuotaExceededFault
 export class ServiceLinkedRoleNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceLinkedRoleNotFoundFault>()(
     "ServiceLinkedRoleNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ServiceLinkedRoleNotFoundFault",
@@ -280,7 +280,7 @@ export class ServiceLinkedRoleNotFoundFault
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ServiceQuotaExceeded", httpResponseCode: 402 }),
       T.HttpError(402),
@@ -289,7 +289,7 @@ export class ServiceQuotaExceededException
 export class SubnetGroupAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SubnetGroupAlreadyExistsFault>()(
     "SubnetGroupAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SubnetGroupAlreadyExists",
@@ -301,7 +301,7 @@ export class SubnetGroupAlreadyExistsFault
 export class SubnetGroupInUseFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SubnetGroupInUseFault>()(
     "SubnetGroupInUseFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SubnetGroupInUse", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -310,7 +310,7 @@ export class SubnetGroupInUseFault
 export class SubnetGroupNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SubnetGroupNotFoundFault>()(
     "SubnetGroupNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SubnetGroupNotFoundFault",
@@ -322,7 +322,7 @@ export class SubnetGroupNotFoundFault
 export class SubnetGroupQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SubnetGroupQuotaExceededFault>()(
     "SubnetGroupQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SubnetGroupQuotaExceeded",
@@ -334,7 +334,7 @@ export class SubnetGroupQuotaExceededFault
 export class SubnetInUse
   extends /*@__PURE__*/ S.TaggedErrorClass<SubnetInUse>()(
     "SubnetInUse",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SubnetInUse", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -343,7 +343,7 @@ export class SubnetInUse
 export class SubnetNotAllowedFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SubnetNotAllowedFault>()(
     "SubnetNotAllowedFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SubnetNotAllowedFault", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -352,7 +352,7 @@ export class SubnetNotAllowedFault
 export class SubnetQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SubnetQuotaExceededFault>()(
     "SubnetQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SubnetQuotaExceededFault",
@@ -364,7 +364,7 @@ export class SubnetQuotaExceededFault
 export class TagNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<TagNotFoundFault>()(
     "TagNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "TagNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -373,7 +373,7 @@ export class TagNotFoundFault
 export class TagQuotaPerResourceExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<TagQuotaPerResourceExceeded>()(
     "TagQuotaPerResourceExceeded",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "TagQuotaPerResourceExceeded",

--- a/packages/aws/src/services/deadline.ts
+++ b/packages/aws/src/services/deadline.ts
@@ -91,7 +91,7 @@ export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       context: S.optional(
         S.suspend(() => ExceptionContext).annotate({
           identifier: "ExceptionContext",
@@ -104,7 +104,7 @@ export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.suspend(() => ConflictExceptionReason).annotate({
         identifier: "ConflictExceptionReason",
       }),
@@ -122,7 +122,7 @@ export class InternalServerErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerErrorException>()(
     "InternalServerErrorException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.all(T.HttpError(500), T.Retryable()),
@@ -130,13 +130,13 @@ export class InternalServerErrorException
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.String,
       resourceType: S.String,
       context: S.optional(
@@ -151,7 +151,7 @@ export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.suspend(() => ServiceQuotaExceededExceptionReason).annotate({
         identifier: "ServiceQuotaExceededExceptionReason",
       }),
@@ -171,7 +171,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       serviceCode: S.optional(S.String),
       quotaCode: S.optional(S.String),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
@@ -187,7 +187,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.suspend(() => ValidationExceptionReason).annotate({
         identifier: "ValidationExceptionReason",
       }),

--- a/packages/aws/src/services/detective.ts
+++ b/packages/aws/src/services/detective.ts
@@ -127,7 +127,7 @@ export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       ErrorCode: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),
@@ -142,26 +142,26 @@ export class AccessDeniedException
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Resources: S.optional(
         S.suspend(() => ResourceList).annotate({ identifier: "ResourceList" }),
       ),
@@ -171,14 +171,14 @@ export class ServiceQuotaExceededException
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       ErrorCode: S.optional(
         S.suspend(() => ErrorCode).annotate({ identifier: "ErrorCode" }),
       ),

--- a/packages/aws/src/services/device-farm.ts
+++ b/packages/aws/src/services/device-farm.ts
@@ -91,66 +91,75 @@ const rules = T.EndpointResolver((p, _) => {
 export class ArgumentException
   extends /*@__PURE__*/ S.TaggedErrorClass<ArgumentException>()(
     "ArgumentException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class CannotDeleteException
   extends /*@__PURE__*/ S.TaggedErrorClass<CannotDeleteException>()(
     "CannotDeleteException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class IdempotencyException
   extends /*@__PURE__*/ S.TaggedErrorClass<IdempotencyException>()(
     "IdempotencyException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InternalServiceException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServiceException>()(
     "InternalServiceException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidOperationException>()(
     "InvalidOperationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NotEligibleException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotEligibleException>()(
     "NotEligibleException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ServiceAccountException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceAccountException>()(
     "ServiceAccountException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TagOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<TagOperationException>()(
     "TagOperationException",
-    { message: S.optional(S.String), resourceName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      resourceName: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TagPolicyException
   extends /*@__PURE__*/ S.TaggedErrorClass<TagPolicyException>()(
     "TagPolicyException",
-    { message: S.optional(S.String), resourceName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      resourceName: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { message: S.optional(S.String), resourceName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      resourceName: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type AmazonResourceName = string;

--- a/packages/aws/src/services/devops-agent.ts
+++ b/packages/aws/src/services/devops-agent.ts
@@ -57,62 +57,65 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ContentSizeExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ContentSizeExceededException>()(
     "ContentSizeExceededException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(413),
   ).pipe(C.withBadRequestError) {}
 export class IdentityCenterServiceException
   extends /*@__PURE__*/ S.TaggedErrorClass<IdentityCenterServiceException>()(
     "IdentityCenterServiceException",
-    { message: S.String, underlyingErrorCode: S.optional(S.String) },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      underlyingErrorCode: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class InvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterException>()(
     "InvalidParameterException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(429), T.Retryable()),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       fieldList: S.optional(
         S.suspend(() => ValidationExceptionFieldList).annotate({
           identifier: "ValidationExceptionFieldList",

--- a/packages/aws/src/services/devops-guru.ts
+++ b/packages/aws/src/services/devops-guru.ts
@@ -88,20 +88,24 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.String, ResourceId: S.String, ResourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      ResourceId: S.String,
+      ResourceType: S.String,
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       RetryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.HttpError(500),
@@ -109,20 +113,24 @@ export class InternalServerException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.String, ResourceId: S.String, ResourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      ResourceId: S.String,
+      ResourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       QuotaCode: S.optional(S.String),
       ServiceCode: S.optional(S.String),
       RetryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
@@ -133,7 +141,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => ValidationExceptionReason).annotate({
           identifier: "ValidationExceptionReason",

--- a/packages/aws/src/services/direct-connect.ts
+++ b/packages/aws/src/services/direct-connect.ts
@@ -88,29 +88,29 @@ const rules = T.EndpointResolver((p, _) => {
 export class DirectConnectClientException
   extends /*@__PURE__*/ S.TaggedErrorClass<DirectConnectClientException>()(
     "DirectConnectClientException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class DirectConnectServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<DirectConnectServerException>()(
     "DirectConnectServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class DuplicateTagKeysException
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicateTagKeysException>()(
     "DuplicateTagKeysException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type DirectConnectGatewayId = string;
 export type DirectConnectGatewayAssociationProposalId = string;

--- a/packages/aws/src/services/directory-service-data.ts
+++ b/packages/aws/src/services/directory-service-data.ts
@@ -94,7 +94,7 @@ export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => AccessDeniedReason).annotate({
           identifier: "AccessDeniedReason",
@@ -106,14 +106,14 @@ export class AccessDeniedException
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class DirectoryUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<DirectoryUnavailableException>()(
     "DirectoryUnavailableException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => DirectoryUnavailableReason).annotate({
           identifier: "DirectoryUnavailableReason",
@@ -125,20 +125,20 @@ export class DirectoryUnavailableException
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       RetryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.all(T.HttpError(429), T.Retryable({ throttling: true })),
@@ -147,7 +147,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => ValidationExceptionReason).annotate({
           identifier: "ValidationExceptionReason",

--- a/packages/aws/src/services/directory-service.ts
+++ b/packages/aws/src/services/directory-service.ts
@@ -93,202 +93,322 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ).pipe(C.withAuthError) {}
 export class ADAssessmentLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ADAssessmentLimitExceededException>()(
     "ADAssessmentLimitExceededException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export class AuthenticationFailedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AuthenticationFailedException>()(
     "AuthenticationFailedException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export class CertificateAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<CertificateAlreadyExistsException>()(
     "CertificateAlreadyExistsException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ).pipe(C.withAlreadyExistsError) {}
 export class CertificateDoesNotExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<CertificateDoesNotExistException>()(
     "CertificateDoesNotExistException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export class CertificateInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<CertificateInUseException>()(
     "CertificateInUseException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export class CertificateLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<CertificateLimitExceededException>()(
     "CertificateLimitExceededException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export class ClientException
   extends /*@__PURE__*/ S.TaggedErrorClass<ClientException>()(
     "ClientException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export class DirectoryAlreadyInRegionException
   extends /*@__PURE__*/ S.TaggedErrorClass<DirectoryAlreadyInRegionException>()(
     "DirectoryAlreadyInRegionException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export class DirectoryAlreadySharedException
   extends /*@__PURE__*/ S.TaggedErrorClass<DirectoryAlreadySharedException>()(
     "DirectoryAlreadySharedException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export class DirectoryDoesNotExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<DirectoryDoesNotExistException>()(
     "DirectoryDoesNotExistException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export class DirectoryInDesiredStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<DirectoryInDesiredStateException>()(
     "DirectoryInDesiredStateException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export class DirectoryLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<DirectoryLimitExceededException>()(
     "DirectoryLimitExceededException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export class DirectoryNotSharedException
   extends /*@__PURE__*/ S.TaggedErrorClass<DirectoryNotSharedException>()(
     "DirectoryNotSharedException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export class DirectoryUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<DirectoryUnavailableException>()(
     "DirectoryUnavailableException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export class DisableAlreadyInProgressException
   extends /*@__PURE__*/ S.TaggedErrorClass<DisableAlreadyInProgressException>()(
     "DisableAlreadyInProgressException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export class DomainControllerLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<DomainControllerLimitExceededException>()(
     "DomainControllerLimitExceededException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export class EnableAlreadyInProgressException
   extends /*@__PURE__*/ S.TaggedErrorClass<EnableAlreadyInProgressException>()(
     "EnableAlreadyInProgressException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export class EntityAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<EntityAlreadyExistsException>()(
     "EntityAlreadyExistsException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ).pipe(C.withAlreadyExistsError) {}
 export class EntityDoesNotExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<EntityDoesNotExistException>()(
     "EntityDoesNotExistException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export class IncompatibleSettingsException
   extends /*@__PURE__*/ S.TaggedErrorClass<IncompatibleSettingsException>()(
     "IncompatibleSettingsException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export class InsufficientPermissionsException
   extends /*@__PURE__*/ S.TaggedErrorClass<InsufficientPermissionsException>()(
     "InsufficientPermissionsException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export class InvalidCertificateException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCertificateException>()(
     "InvalidCertificateException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export class InvalidClientAuthStatusException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidClientAuthStatusException>()(
     "InvalidClientAuthStatusException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export class InvalidLDAPSStatusException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidLDAPSStatusException>()(
     "InvalidLDAPSStatusException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export class InvalidNextTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNextTokenException>()(
     "InvalidNextTokenException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export class InvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterException>()(
     "InvalidParameterException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export class InvalidPasswordException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPasswordException>()(
     "InvalidPasswordException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export class InvalidTargetException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTargetException>()(
     "InvalidTargetException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export class IpRouteLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<IpRouteLimitExceededException>()(
     "IpRouteLimitExceededException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export class NoAvailableCertificateException
   extends /*@__PURE__*/ S.TaggedErrorClass<NoAvailableCertificateException>()(
     "NoAvailableCertificateException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export class OrganizationsException
   extends /*@__PURE__*/ S.TaggedErrorClass<OrganizationsException>()(
     "OrganizationsException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export class RegionLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<RegionLimitExceededException>()(
     "RegionLimitExceededException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export class ServiceException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceException>()(
     "ServiceException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export class ShareLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ShareLimitExceededException>()(
     "ShareLimitExceededException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export class SnapshotLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<SnapshotLimitExceededException>()(
     "SnapshotLimitExceededException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export class TagLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<TagLimitExceededException>()(
     "TagLimitExceededException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export class UnsupportedOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedOperationException>()(
     "UnsupportedOperationException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export class UnsupportedSettingsException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedSettingsException>()(
     "UnsupportedSettingsException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export class UserDoesNotExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<UserDoesNotExistException>()(
     "UserDoesNotExistException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
   ) {}
 export type DirectoryId = string;
 export interface AcceptSharedDirectoryRequest {

--- a/packages/aws/src/services/dlm.ts
+++ b/packages/aws/src/services/dlm.ts
@@ -87,14 +87,17 @@ const rules = T.EndpointResolver((p, _) => {
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String), Code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Code: S.optional(S.String),
+    },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Code: S.optional(S.String),
       RequiredParameters: S.optional(
         S.suspend(() => ParameterList).annotate({
@@ -113,7 +116,7 @@ export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Code: S.optional(S.String),
       ResourceType: S.optional(S.String),
     },
@@ -123,7 +126,7 @@ export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Code: S.optional(S.String),
       ResourceType: S.optional(S.String),
       ResourceIds: S.optional(

--- a/packages/aws/src/services/docdb-elastic.ts
+++ b/packages/aws/src/services/docdb-elastic.ts
@@ -90,38 +90,46 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.all(T.HttpError(429), T.Retryable()),
@@ -130,7 +138,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.String,
       fieldList: S.optional(
         S.suspend(() => ValidationExceptionFieldList).annotate({

--- a/packages/aws/src/services/docdb.ts
+++ b/packages/aws/src/services/docdb.ts
@@ -94,7 +94,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class AuthorizationNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<AuthorizationNotFoundFault>()(
     "AuthorizationNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "AuthorizationNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -103,7 +103,7 @@ export class AuthorizationNotFoundFault
 export class CertificateNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<CertificateNotFoundFault>()(
     "CertificateNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "CertificateNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -112,7 +112,7 @@ export class CertificateNotFoundFault
 export class DBClusterAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBClusterAlreadyExistsFault>()(
     "DBClusterAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBClusterAlreadyExistsFault",
@@ -124,7 +124,7 @@ export class DBClusterAlreadyExistsFault
 export class DBClusterNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBClusterNotFoundFault>()(
     "DBClusterNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBClusterNotFoundFault",
@@ -136,7 +136,7 @@ export class DBClusterNotFoundFault
 export class DBClusterParameterGroupNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBClusterParameterGroupNotFoundFault>()(
     "DBClusterParameterGroupNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBClusterParameterGroupNotFound",
@@ -148,7 +148,7 @@ export class DBClusterParameterGroupNotFoundFault
 export class DBClusterQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBClusterQuotaExceededFault>()(
     "DBClusterQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBClusterQuotaExceededFault",
@@ -160,7 +160,7 @@ export class DBClusterQuotaExceededFault
 export class DBClusterSnapshotAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBClusterSnapshotAlreadyExistsFault>()(
     "DBClusterSnapshotAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBClusterSnapshotAlreadyExistsFault",
@@ -172,7 +172,7 @@ export class DBClusterSnapshotAlreadyExistsFault
 export class DBClusterSnapshotNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBClusterSnapshotNotFoundFault>()(
     "DBClusterSnapshotNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBClusterSnapshotNotFoundFault",
@@ -184,7 +184,7 @@ export class DBClusterSnapshotNotFoundFault
 export class DBInstanceAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBInstanceAlreadyExistsFault>()(
     "DBInstanceAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBInstanceAlreadyExists",
@@ -196,7 +196,7 @@ export class DBInstanceAlreadyExistsFault
 export class DBInstanceNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBInstanceNotFoundFault>()(
     "DBInstanceNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "DBInstanceNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -205,7 +205,7 @@ export class DBInstanceNotFoundFault
 export class DBParameterGroupAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBParameterGroupAlreadyExistsFault>()(
     "DBParameterGroupAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBParameterGroupAlreadyExists",
@@ -217,7 +217,7 @@ export class DBParameterGroupAlreadyExistsFault
 export class DBParameterGroupNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBParameterGroupNotFoundFault>()(
     "DBParameterGroupNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBParameterGroupNotFound",
@@ -229,7 +229,7 @@ export class DBParameterGroupNotFoundFault
 export class DBParameterGroupQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBParameterGroupQuotaExceededFault>()(
     "DBParameterGroupQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBParameterGroupQuotaExceeded",
@@ -241,7 +241,7 @@ export class DBParameterGroupQuotaExceededFault
 export class DBSecurityGroupNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBSecurityGroupNotFoundFault>()(
     "DBSecurityGroupNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBSecurityGroupNotFound",
@@ -253,7 +253,7 @@ export class DBSecurityGroupNotFoundFault
 export class DBSnapshotAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBSnapshotAlreadyExistsFault>()(
     "DBSnapshotAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBSnapshotAlreadyExists",
@@ -265,7 +265,7 @@ export class DBSnapshotAlreadyExistsFault
 export class DBSnapshotNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBSnapshotNotFoundFault>()(
     "DBSnapshotNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "DBSnapshotNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -274,7 +274,7 @@ export class DBSnapshotNotFoundFault
 export class DBSubnetGroupAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBSubnetGroupAlreadyExistsFault>()(
     "DBSubnetGroupAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBSubnetGroupAlreadyExists",
@@ -286,7 +286,7 @@ export class DBSubnetGroupAlreadyExistsFault
 export class DBSubnetGroupDoesNotCoverEnoughAZs
   extends /*@__PURE__*/ S.TaggedErrorClass<DBSubnetGroupDoesNotCoverEnoughAZs>()(
     "DBSubnetGroupDoesNotCoverEnoughAZs",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBSubnetGroupDoesNotCoverEnoughAZs",
@@ -298,7 +298,7 @@ export class DBSubnetGroupDoesNotCoverEnoughAZs
 export class DBSubnetGroupNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBSubnetGroupNotFoundFault>()(
     "DBSubnetGroupNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBSubnetGroupNotFoundFault",
@@ -310,7 +310,7 @@ export class DBSubnetGroupNotFoundFault
 export class DBSubnetGroupQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBSubnetGroupQuotaExceededFault>()(
     "DBSubnetGroupQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBSubnetGroupQuotaExceeded",
@@ -322,7 +322,7 @@ export class DBSubnetGroupQuotaExceededFault
 export class DBSubnetQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBSubnetQuotaExceededFault>()(
     "DBSubnetQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBSubnetQuotaExceededFault",
@@ -334,7 +334,7 @@ export class DBSubnetQuotaExceededFault
 export class DBUpgradeDependencyFailureFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBUpgradeDependencyFailureFault>()(
     "DBUpgradeDependencyFailureFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBUpgradeDependencyFailure",
@@ -346,7 +346,7 @@ export class DBUpgradeDependencyFailureFault
 export class EventSubscriptionQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<EventSubscriptionQuotaExceededFault>()(
     "EventSubscriptionQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "EventSubscriptionQuotaExceeded",
@@ -358,7 +358,7 @@ export class EventSubscriptionQuotaExceededFault
 export class GlobalClusterAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<GlobalClusterAlreadyExistsFault>()(
     "GlobalClusterAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "GlobalClusterAlreadyExistsFault",
@@ -370,7 +370,7 @@ export class GlobalClusterAlreadyExistsFault
 export class GlobalClusterNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<GlobalClusterNotFoundFault>()(
     "GlobalClusterNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "GlobalClusterNotFoundFault",
@@ -382,7 +382,7 @@ export class GlobalClusterNotFoundFault
 export class GlobalClusterQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<GlobalClusterQuotaExceededFault>()(
     "GlobalClusterQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "GlobalClusterQuotaExceededFault",
@@ -394,7 +394,7 @@ export class GlobalClusterQuotaExceededFault
 export class InstanceQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InstanceQuotaExceededFault>()(
     "InstanceQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InstanceQuotaExceeded", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -403,7 +403,7 @@ export class InstanceQuotaExceededFault
 export class InsufficientDBClusterCapacityFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InsufficientDBClusterCapacityFault>()(
     "InsufficientDBClusterCapacityFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InsufficientDBClusterCapacityFault",
@@ -415,7 +415,7 @@ export class InsufficientDBClusterCapacityFault
 export class InsufficientDBInstanceCapacityFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InsufficientDBInstanceCapacityFault>()(
     "InsufficientDBInstanceCapacityFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InsufficientDBInstanceCapacity",
@@ -427,7 +427,7 @@ export class InsufficientDBInstanceCapacityFault
 export class InsufficientStorageClusterCapacityFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InsufficientStorageClusterCapacityFault>()(
     "InsufficientStorageClusterCapacityFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InsufficientStorageClusterCapacity",
@@ -439,7 +439,7 @@ export class InsufficientStorageClusterCapacityFault
 export class InvalidDBClusterSnapshotStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDBClusterSnapshotStateFault>()(
     "InvalidDBClusterSnapshotStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidDBClusterSnapshotStateFault",
@@ -451,7 +451,7 @@ export class InvalidDBClusterSnapshotStateFault
 export class InvalidDBClusterStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDBClusterStateFault>()(
     "InvalidDBClusterStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidDBClusterStateFault",
@@ -463,7 +463,7 @@ export class InvalidDBClusterStateFault
 export class InvalidDBInstanceStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDBInstanceStateFault>()(
     "InvalidDBInstanceStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidDBInstanceState",
@@ -475,7 +475,7 @@ export class InvalidDBInstanceStateFault
 export class InvalidDBParameterGroupStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDBParameterGroupStateFault>()(
     "InvalidDBParameterGroupStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidDBParameterGroupState",
@@ -487,7 +487,7 @@ export class InvalidDBParameterGroupStateFault
 export class InvalidDBSecurityGroupStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDBSecurityGroupStateFault>()(
     "InvalidDBSecurityGroupStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidDBSecurityGroupState",
@@ -499,7 +499,7 @@ export class InvalidDBSecurityGroupStateFault
 export class InvalidDBSnapshotStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDBSnapshotStateFault>()(
     "InvalidDBSnapshotStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidDBSnapshotState",
@@ -511,7 +511,7 @@ export class InvalidDBSnapshotStateFault
 export class InvalidDBSubnetGroupStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDBSubnetGroupStateFault>()(
     "InvalidDBSubnetGroupStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidDBSubnetGroupStateFault",
@@ -523,7 +523,7 @@ export class InvalidDBSubnetGroupStateFault
 export class InvalidDBSubnetStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDBSubnetStateFault>()(
     "InvalidDBSubnetStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidDBSubnetStateFault",
@@ -535,7 +535,7 @@ export class InvalidDBSubnetStateFault
 export class InvalidEventSubscriptionStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidEventSubscriptionStateFault>()(
     "InvalidEventSubscriptionStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidEventSubscriptionState",
@@ -547,7 +547,7 @@ export class InvalidEventSubscriptionStateFault
 export class InvalidGlobalClusterStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidGlobalClusterStateFault>()(
     "InvalidGlobalClusterStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidGlobalClusterStateFault",
@@ -559,7 +559,7 @@ export class InvalidGlobalClusterStateFault
 export class InvalidRestoreFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRestoreFault>()(
     "InvalidRestoreFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidRestoreFault", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -568,7 +568,7 @@ export class InvalidRestoreFault
 export class InvalidSubnet
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSubnet>()(
     "InvalidSubnet",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidSubnet", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -577,7 +577,7 @@ export class InvalidSubnet
 export class InvalidVPCNetworkStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidVPCNetworkStateFault>()(
     "InvalidVPCNetworkStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidVPCNetworkStateFault",
@@ -589,7 +589,7 @@ export class InvalidVPCNetworkStateFault
 export class KMSKeyNotAccessibleFault
   extends /*@__PURE__*/ S.TaggedErrorClass<KMSKeyNotAccessibleFault>()(
     "KMSKeyNotAccessibleFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "KMSKeyNotAccessibleFault",
@@ -601,7 +601,7 @@ export class KMSKeyNotAccessibleFault
 export class NetworkTypeNotSupported
   extends /*@__PURE__*/ S.TaggedErrorClass<NetworkTypeNotSupported>()(
     "NetworkTypeNotSupported",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "NetworkTypeNotSupported",
@@ -613,7 +613,7 @@ export class NetworkTypeNotSupported
 export class ResourceNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundFault>()(
     "ResourceNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ResourceNotFoundFault", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -622,7 +622,7 @@ export class ResourceNotFoundFault
 export class SharedSnapshotQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SharedSnapshotQuotaExceededFault>()(
     "SharedSnapshotQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SharedSnapshotQuotaExceeded",
@@ -634,7 +634,7 @@ export class SharedSnapshotQuotaExceededFault
 export class SnapshotQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SnapshotQuotaExceededFault>()(
     "SnapshotQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SnapshotQuotaExceeded", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -643,7 +643,7 @@ export class SnapshotQuotaExceededFault
 export class SNSInvalidTopicFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SNSInvalidTopicFault>()(
     "SNSInvalidTopicFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SNSInvalidTopic", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -652,7 +652,7 @@ export class SNSInvalidTopicFault
 export class SNSNoAuthorizationFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SNSNoAuthorizationFault>()(
     "SNSNoAuthorizationFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SNSNoAuthorization", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -661,7 +661,7 @@ export class SNSNoAuthorizationFault
 export class SNSTopicArnNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SNSTopicArnNotFoundFault>()(
     "SNSTopicArnNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SNSTopicArnNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -670,7 +670,7 @@ export class SNSTopicArnNotFoundFault
 export class SourceNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SourceNotFoundFault>()(
     "SourceNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SourceNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -679,7 +679,7 @@ export class SourceNotFoundFault
 export class StorageQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<StorageQuotaExceededFault>()(
     "StorageQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "StorageQuotaExceeded", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -688,7 +688,7 @@ export class StorageQuotaExceededFault
 export class StorageTypeNotSupportedFault
   extends /*@__PURE__*/ S.TaggedErrorClass<StorageTypeNotSupportedFault>()(
     "StorageTypeNotSupportedFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "StorageTypeNotSupported",
@@ -700,7 +700,7 @@ export class StorageTypeNotSupportedFault
 export class SubnetAlreadyInUse
   extends /*@__PURE__*/ S.TaggedErrorClass<SubnetAlreadyInUse>()(
     "SubnetAlreadyInUse",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SubnetAlreadyInUse", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -709,7 +709,7 @@ export class SubnetAlreadyInUse
 export class SubscriptionAlreadyExistFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SubscriptionAlreadyExistFault>()(
     "SubscriptionAlreadyExistFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SubscriptionAlreadyExist",
@@ -721,7 +721,7 @@ export class SubscriptionAlreadyExistFault
 export class SubscriptionCategoryNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SubscriptionCategoryNotFoundFault>()(
     "SubscriptionCategoryNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SubscriptionCategoryNotFound",
@@ -733,7 +733,7 @@ export class SubscriptionCategoryNotFoundFault
 export class SubscriptionNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SubscriptionNotFoundFault>()(
     "SubscriptionNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SubscriptionNotFound", httpResponseCode: 404 }),
       T.HttpError(404),

--- a/packages/aws/src/services/drs.ts
+++ b/packages/aws/src/services/drs.ts
@@ -90,14 +90,17 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String), code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      code: S.optional(S.String),
+    },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       code: S.optional(S.String),
       resourceId: S.optional(S.String),
       resourceType: S.optional(S.String),
@@ -108,7 +111,7 @@ export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.HttpError(500),
@@ -117,7 +120,7 @@ export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       code: S.optional(S.String),
       resourceId: S.optional(S.String),
       resourceType: S.optional(S.String),
@@ -128,7 +131,7 @@ export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       code: S.optional(S.String),
       resourceId: S.optional(S.String),
       resourceType: S.optional(S.String),
@@ -141,7 +144,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       serviceCode: S.optional(S.String),
       quotaCode: S.optional(S.String),
       retryAfterSeconds: S.optional(S.String).pipe(T.HttpHeader("Retry-After")),
@@ -151,14 +154,17 @@ export class ThrottlingException
 export class UninitializedAccountException
   extends /*@__PURE__*/ S.TaggedErrorClass<UninitializedAccountException>()(
     "UninitializedAccountException",
-    { message: S.optional(S.String), code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      code: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       code: S.optional(S.String),
       reason: S.optional(S.String),
       fieldList: S.optional(

--- a/packages/aws/src/services/dsql.ts
+++ b/packages/aws/src/services/dsql.ts
@@ -53,7 +53,7 @@ export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceType: S.optional(S.String),
     },
@@ -63,7 +63,7 @@ export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.all(T.HttpError(500), T.Retryable()),
@@ -71,14 +71,18 @@ export class InternalServerException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.String,
       resourceType: S.String,
       serviceCode: S.String,
@@ -90,7 +94,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       serviceCode: S.optional(S.String),
       quotaCode: S.optional(S.String),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
@@ -101,7 +105,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.suspend(() => ValidationExceptionReason).annotate({
         identifier: "ValidationExceptionReason",
       }),

--- a/packages/aws/src/services/dynamodb-streams.ts
+++ b/packages/aws/src/services/dynamodb-streams.ts
@@ -150,27 +150,27 @@ const rules = T.EndpointResolver((p, _) => {
 export class ExpiredIteratorException
   extends /*@__PURE__*/ S.TaggedErrorClass<ExpiredIteratorException>()(
     "ExpiredIteratorException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InternalServerError
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerError>()(
     "InternalServerError",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TrimmedDataAccessException
   extends /*@__PURE__*/ S.TaggedErrorClass<TrimmedDataAccessException>()(
     "TrimmedDataAccessException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type StreamArn = string;
 export type PositiveIntegerObject = number;

--- a/packages/aws/src/services/dynamodb.ts
+++ b/packages/aws/src/services/dynamodb.ts
@@ -344,18 +344,18 @@ const rules = T.EndpointResolver((p, _) => {
 export class BackupInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<BackupInUseException>()(
     "BackupInUseException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withConflictError) {}
 export class BackupNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<BackupNotFoundException>()(
     "BackupNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withNotFoundError) {}
 export class ConditionalCheckFailedException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConditionalCheckFailedException>()(
     "ConditionalCheckFailedException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Item: S.optional(
         S.suspend(() => AttributeMap).annotate({ identifier: "AttributeMap" }),
       ),
@@ -364,99 +364,99 @@ export class ConditionalCheckFailedException
 export class ContinuousBackupsUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ContinuousBackupsUnavailableException>()(
     "ContinuousBackupsUnavailableException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withConflictError, C.withRetryableError) {}
 export class DuplicateItemException
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicateItemException>()(
     "DuplicateItemException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withConflictError) {}
 export class ExportConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ExportConflictException>()(
     "ExportConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withConflictError) {}
 export class ExportNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ExportNotFoundException>()(
     "ExportNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withNotFoundError) {}
 export class GlobalTableAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<GlobalTableAlreadyExistsException>()(
     "GlobalTableAlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class GlobalTableNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<GlobalTableNotFoundException>()(
     "GlobalTableNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withNotFoundError) {}
 export class IdempotentParameterMismatchException
   extends /*@__PURE__*/ S.TaggedErrorClass<IdempotentParameterMismatchException>()(
     "IdempotentParameterMismatchException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class ImportConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ImportConflictException>()(
     "ImportConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withConflictError) {}
 export class ImportNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ImportNotFoundException>()(
     "ImportNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withNotFoundError) {}
 export class IndexNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<IndexNotFoundException>()(
     "IndexNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withNotFoundError) {}
 export class InternalServerError
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerError>()(
     "InternalServerError",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class InvalidEndpointException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidEndpointException>()(
     "InvalidEndpointException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(421),
   ).pipe(C.withBadRequestError) {}
 export class InvalidExportTimeException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidExportTimeException>()(
     "InvalidExportTimeException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class InvalidRestoreTimeException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRestoreTimeException>()(
     "InvalidRestoreTimeException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class ItemCollectionSizeLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ItemCollectionSizeLimitExceededException>()(
     "ItemCollectionSizeLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withQuotaError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withQuotaError, C.withRetryableError) {}
 export class PointInTimeRecoveryUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<PointInTimeRecoveryUnavailableException>()(
     "PointInTimeRecoveryUnavailableException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class PolicyNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<PolicyNotFoundException>()(
     "PolicyNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withNotFoundError) {}
 export class ProvisionedThroughputExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ProvisionedThroughputExceededException>()(
     "ProvisionedThroughputExceededException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       ThrottlingReasons: S.optional(
         S.suspend(() => ThrottlingReasonList).annotate({
           identifier: "ThrottlingReasonList",
@@ -467,24 +467,24 @@ export class ProvisionedThroughputExceededException
 export class ReplicaAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ReplicaAlreadyExistsException>()(
     "ReplicaAlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class ReplicaNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ReplicaNotFoundException>()(
     "ReplicaNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withNotFoundError) {}
 export class ReplicatedWriteConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ReplicatedWriteConflictException>()(
     "ReplicatedWriteConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.Retryable(),
   ).pipe(C.withRetryableError) {}
 export class RequestLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<RequestLimitExceeded>()(
     "RequestLimitExceeded",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       ThrottlingReasons: S.optional(
         S.suspend(() => ThrottlingReasonList).annotate({
           identifier: "ThrottlingReasonList",
@@ -495,33 +495,33 @@ export class RequestLimitExceeded
 export class ResourceInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUseException>()(
     "ResourceInUseException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withConflictError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withNotFoundError) {}
 export class TableAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TableAlreadyExistsException>()(
     "TableAlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class TableInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<TableInUseException>()(
     "TableInUseException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withConflictError, C.withRetryableError) {}
 export class TableNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<TableNotFoundException>()(
     "TableNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withNotFoundError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       throttlingReasons: S.optional(
         S.suspend(() => ThrottlingReasonList).annotate({
           identifier: "ThrottlingReasonList",
@@ -537,7 +537,7 @@ export class TransactionCanceledException
   extends /*@__PURE__*/ S.TaggedErrorClass<TransactionCanceledException>()(
     "TransactionCanceledException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       CancellationReasons: S.optional(
         S.suspend(() => CancellationReasonList).annotate({
           identifier: "CancellationReasonList",
@@ -548,12 +548,12 @@ export class TransactionCanceledException
 export class TransactionConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<TransactionConflictException>()(
     "TransactionConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withConflictError, C.withRetryableError) {}
 export class TransactionInProgressException
   extends /*@__PURE__*/ S.TaggedErrorClass<TransactionInProgressException>()(
     "TransactionInProgressException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withConflictError, C.withRetryableError) {}
 export type PartiQLStatement = string;
 export type StringAttributeValue = string;

--- a/packages/aws/src/services/ebs.ts
+++ b/packages/aws/src/services/ebs.ts
@@ -88,7 +88,7 @@ export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Reason: S.suspend(() => AccessDeniedExceptionReason).annotate({
         identifier: "AccessDeniedExceptionReason",
       }),
@@ -98,31 +98,31 @@ export class AccessDeniedException
 export class ConcurrentLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentLimitExceededException>()(
     "ConcurrentLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidSignatureException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSignatureException>()(
     "InvalidSignatureException",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class RequestThrottledException
   extends /*@__PURE__*/ S.TaggedErrorClass<RequestThrottledException>()(
     "RequestThrottledException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => RequestThrottledExceptionReason).annotate({
           identifier: "RequestThrottledExceptionReason",
@@ -135,7 +135,7 @@ export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => ResourceNotFoundExceptionReason).annotate({
           identifier: "ResourceNotFoundExceptionReason",
@@ -148,7 +148,7 @@ export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => ServiceQuotaExceededExceptionReason).annotate({
           identifier: "ServiceQuotaExceededExceptionReason",
@@ -161,7 +161,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => ValidationExceptionReason).annotate({
           identifier: "ValidationExceptionReason",

--- a/packages/aws/src/services/ec2-instance-connect.ts
+++ b/packages/aws/src/services/ec2-instance-connect.ts
@@ -87,7 +87,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class AuthException
   extends /*@__PURE__*/ S.TaggedErrorClass<AuthException>()(
     "AuthException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "Forbidden", httpResponseCode: 403 }),
       T.HttpError(403),
@@ -96,7 +96,7 @@ export class AuthException
 export class EC2InstanceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<EC2InstanceNotFoundException>()(
     "EC2InstanceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "EC2InstanceNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -105,7 +105,7 @@ export class EC2InstanceNotFoundException
 export class EC2InstanceStateInvalidException
   extends /*@__PURE__*/ S.TaggedErrorClass<EC2InstanceStateInvalidException>()(
     "EC2InstanceStateInvalidException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "EC2InstanceStateInvalid",
@@ -117,7 +117,7 @@ export class EC2InstanceStateInvalidException
 export class EC2InstanceTypeInvalidException
   extends /*@__PURE__*/ S.TaggedErrorClass<EC2InstanceTypeInvalidException>()(
     "EC2InstanceTypeInvalidException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "EC2InstanceTypeInvalid",
@@ -129,7 +129,7 @@ export class EC2InstanceTypeInvalidException
 export class EC2InstanceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<EC2InstanceUnavailableException>()(
     "EC2InstanceUnavailableException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "EC2InstanceUnavailable",
@@ -141,7 +141,7 @@ export class EC2InstanceUnavailableException
 export class InvalidArgsException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidArgsException>()(
     "InvalidArgsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidArguments", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -150,7 +150,7 @@ export class InvalidArgsException
 export class SerialConsoleAccessDisabledException
   extends /*@__PURE__*/ S.TaggedErrorClass<SerialConsoleAccessDisabledException>()(
     "SerialConsoleAccessDisabledException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SerialConsoleAccessDisabled",
@@ -162,7 +162,7 @@ export class SerialConsoleAccessDisabledException
 export class SerialConsoleSessionLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<SerialConsoleSessionLimitExceededException>()(
     "SerialConsoleSessionLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SerialConsoleSessionLimitExceeded",
@@ -174,7 +174,7 @@ export class SerialConsoleSessionLimitExceededException
 export class SerialConsoleSessionUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<SerialConsoleSessionUnavailableException>()(
     "SerialConsoleSessionUnavailableException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SerialConsoleSessionUnavailable",
@@ -186,7 +186,7 @@ export class SerialConsoleSessionUnavailableException
 export class SerialConsoleSessionUnsupportedException
   extends /*@__PURE__*/ S.TaggedErrorClass<SerialConsoleSessionUnsupportedException>()(
     "SerialConsoleSessionUnsupportedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SerialConsoleSessionUnsupported",
@@ -198,7 +198,7 @@ export class SerialConsoleSessionUnsupportedException
 export class ServiceException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceException>()(
     "ServiceException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InternalServerError", httpResponseCode: 500 }),
       T.HttpError(500),
@@ -207,7 +207,7 @@ export class ServiceException
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "TooManyRequests", httpResponseCode: 429 }),
       T.HttpError(429),

--- a/packages/aws/src/services/ec2.ts
+++ b/packages/aws/src/services/ec2.ts
@@ -91,1144 +91,1138 @@ const rules = T.EndpointResolver((p, _) => {
 export class AddressLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<AddressLimitExceeded>()(
     "AddressLimitExceeded",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withThrottlingError) {}
 export class AuthFailure
-  extends /*@__PURE__*/ S.TaggedErrorClass<AuthFailure>()(
-    "AuthFailure",
-    {},
-  ).pipe(C.withAuthError) {}
+  extends /*@__PURE__*/ S.TaggedErrorClass<AuthFailure>()("AuthFailure", {
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
+  }).pipe(C.withAuthError) {}
 export class CannotDelete
-  extends /*@__PURE__*/ S.TaggedErrorClass<CannotDelete>()(
-    "CannotDelete",
-    {},
-  ) {}
+  extends /*@__PURE__*/ S.TaggedErrorClass<CannotDelete>()("CannotDelete", {
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
+  }) {}
 export class CapacityManagerDisabled
   extends /*@__PURE__*/ S.TaggedErrorClass<CapacityManagerDisabled>()(
     "CapacityManager.Disabled",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class CidrConflict
-  extends /*@__PURE__*/ S.TaggedErrorClass<CidrConflict>()(
-    "CidrConflict",
-    {},
-  ).pipe(C.withConflictError) {}
+  extends /*@__PURE__*/ S.TaggedErrorClass<CidrConflict>()("CidrConflict", {
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
+  }).pipe(C.withConflictError) {}
 export class DeclarativePoliciesAccessDenied
   extends /*@__PURE__*/ S.TaggedErrorClass<DeclarativePoliciesAccessDenied>()(
     "DeclarativePoliciesAccessDenied",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAuthError) {}
 export class DefaultSubnetAlreadyExistsInAvailabilityZone
   extends /*@__PURE__*/ S.TaggedErrorClass<DefaultSubnetAlreadyExistsInAvailabilityZone>()(
     "DefaultSubnetAlreadyExistsInAvailabilityZone",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class DefaultVpcAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<DefaultVpcAlreadyExists>()(
     "DefaultVpcAlreadyExists",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class DependencyViolation
   extends /*@__PURE__*/ S.TaggedErrorClass<DependencyViolation>()(
     "DependencyViolation",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withDependencyViolationError) {}
 export class DryRunOperation
   extends /*@__PURE__*/ S.TaggedErrorClass<DryRunOperation>()(
     "DryRunOperation",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class FilterLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<FilterLimitExceeded>()(
     "FilterLimitExceeded",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withThrottlingError) {}
 export class GatewayNotAttached
   extends /*@__PURE__*/ S.TaggedErrorClass<GatewayNotAttached>()(
     "Gateway.NotAttached",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class IdempotentParameterMismatch
   extends /*@__PURE__*/ S.TaggedErrorClass<IdempotentParameterMismatch>()(
     "IdempotentParameterMismatch",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withConflictError) {}
 export class InaccessibleStorageLocation
   extends /*@__PURE__*/ S.TaggedErrorClass<InaccessibleStorageLocation>()(
     "InaccessibleStorageLocation",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class IncorrectState
-  extends /*@__PURE__*/ S.TaggedErrorClass<IncorrectState>()(
-    "IncorrectState",
-    {},
-  ).pipe(C.withConflictError) {}
+  extends /*@__PURE__*/ S.TaggedErrorClass<IncorrectState>()("IncorrectState", {
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
+  }).pipe(C.withConflictError) {}
 export class InternetGatewayLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<InternetGatewayLimitExceeded>()(
     "InternetGatewayLimitExceeded",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withThrottlingError) {}
 export class InvalidAction
-  extends /*@__PURE__*/ S.TaggedErrorClass<InvalidAction>()(
-    "InvalidAction",
-    {},
-  ) {}
+  extends /*@__PURE__*/ S.TaggedErrorClass<InvalidAction>()("InvalidAction", {
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
+  }) {}
 export class InvalidAddressMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidAddressMalformed>()(
     "InvalidAddress.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidAddressNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidAddressNotFound>()(
     "InvalidAddress.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidAllocationIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidAllocationIDNotFound>()(
     "InvalidAllocationID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidAMIIDMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidAMIIDMalformed>()(
     "InvalidAMIID.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidAMIIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidAMIIDNotFound>()(
     "InvalidAMIID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidAssociationIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidAssociationIDNotFound>()(
     "InvalidAssociationID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidAttachmentIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidAttachmentIDNotFound>()(
     "InvalidAttachmentID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidBundleIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidBundleIDNotFound>()(
     "InvalidBundleID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidCapacityBlockIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCapacityBlockIdMalformed>()(
     "InvalidCapacityBlockId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidCapacityManagerDataExportIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCapacityManagerDataExportIdMalformed>()(
     "InvalidCapacityManagerDataExportId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidCapacityManagerDataExportIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCapacityManagerDataExportIdNotFound>()(
     "InvalidCapacityManagerDataExportId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidCapacityReservationFleetIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCapacityReservationFleetIdMalformed>()(
     "InvalidCapacityReservationFleetId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidCapacityReservationIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCapacityReservationIdMalformed>()(
     "InvalidCapacityReservationId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidCapacityReservationIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCapacityReservationIdNotFound>()(
     "InvalidCapacityReservationId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidCarrierGatewayIDMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCarrierGatewayIDMalformed>()(
     "InvalidCarrierGatewayID.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidCarrierGatewayIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCarrierGatewayIDNotFound>()(
     "InvalidCarrierGatewayID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidCertificateArnMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCertificateArnMalformed>()(
     "InvalidCertificateArn.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidCidrBlockMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCidrBlockMalformed>()(
     "InvalidCidrBlock.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidCidrNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCidrNotFound>()(
     "InvalidCidr.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidClientVpnEndpointIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidClientVpnEndpointIdNotFound>()(
     "InvalidClientVpnEndpointId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidConnectionNotification
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidConnectionNotification>()(
     "InvalidConnectionNotification",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidConversionTaskIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidConversionTaskIdMalformed>()(
     "InvalidConversionTaskId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidCustomerGatewayIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCustomerGatewayIdMalformed>()(
     "InvalidCustomerGatewayId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidCustomerGatewayIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCustomerGatewayIDNotFound>()(
     "InvalidCustomerGatewayID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidDeclarativePoliciesReportIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDeclarativePoliciesReportIdMalformed>()(
     "InvalidDeclarativePoliciesReportId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidDhcpOptionIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDhcpOptionIDNotFound>()(
     "InvalidDhcpOptionID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidDhcpOptionsIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDhcpOptionsIdMalformed>()(
     "InvalidDhcpOptionsId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidDhcpOptionsIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDhcpOptionsIDNotFound>()(
     "InvalidDhcpOptionsID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidEgressOnlyInternetGatewayIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidEgressOnlyInternetGatewayIdMalformed>()(
     "InvalidEgressOnlyInternetGatewayId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidEgressOnlyInternetGatewayIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidEgressOnlyInternetGatewayIdNotFound>()(
     "InvalidEgressOnlyInternetGatewayId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidElasticIpIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidElasticIpIDNotFound>()(
     "InvalidElasticIpID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidExportTaskIDMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidExportTaskIDMalformed>()(
     "InvalidExportTaskID.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidFleetIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidFleetIdMalformed>()(
     "InvalidFleetId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidFlowLogIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidFlowLogIdNotFound>()(
     "InvalidFlowLogId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidFpgaImageIDMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidFpgaImageIDMalformed>()(
     "InvalidFpgaImageID.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidFpgaImageIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidFpgaImageIDNotFound>()(
     "InvalidFpgaImageID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidGatewayIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidGatewayIDNotFound>()(
     "InvalidGatewayID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidGroupDuplicate
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidGroupDuplicate>()(
     "InvalidGroup.Duplicate",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class InvalidGroupIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidGroupIdMalformed>()(
     "InvalidGroupId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidGroupNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidGroupNotFound>()(
     "InvalidGroup.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidHostConfiguration
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidHostConfiguration>()(
     "InvalidHostConfiguration",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidHostIDMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidHostIDMalformed>()(
     "InvalidHostID.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidHostReservationOfferingIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidHostReservationOfferingIdMalformed>()(
     "InvalidHostReservationOfferingId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidID
-  extends /*@__PURE__*/ S.TaggedErrorClass<InvalidID>()("InvalidID", {}) {}
+  extends /*@__PURE__*/ S.TaggedErrorClass<InvalidID>()("InvalidID", {
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
+  }) {}
 export class InvalidImageUsageReportIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidImageUsageReportIdMalformed>()(
     "InvalidImageUsageReportId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidInput
-  extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInput>()(
-    "InvalidInput",
-    {},
-  ) {}
+  extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInput>()("InvalidInput", {
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
+  }) {}
 export class InvalidInstanceConnectEndpointIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInstanceConnectEndpointIdMalformed>()(
     "InvalidInstanceConnectEndpointId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidInstanceConnectEndpointIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInstanceConnectEndpointIdNotFound>()(
     "InvalidInstanceConnectEndpointId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidInstanceEventWindowIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInstanceEventWindowIdMalformed>()(
     "InvalidInstanceEventWindowId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidInstanceEventWindowIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInstanceEventWindowIDNotFound>()(
     "InvalidInstanceEventWindowIDNotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidInstanceIDMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInstanceIDMalformed>()(
     "InvalidInstanceID.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidInstanceIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInstanceIDNotFound>()(
     "InvalidInstanceID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidInternetGatewayIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInternetGatewayIdMalformed>()(
     "InvalidInternetGatewayId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidInternetGatewayIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInternetGatewayIDNotFound>()(
     "InvalidInternetGatewayID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidIPAddressInUse
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidIPAddressInUse>()(
     "InvalidIPAddress.InUse",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withDependencyViolationError) {}
 export class InvalidIpamExternalResourceVerificationTokenIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidIpamExternalResourceVerificationTokenIdMalformed>()(
     "InvalidIpamExternalResourceVerificationTokenId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidIpamExternalResourceVerificationTokenIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidIpamExternalResourceVerificationTokenIdNotFound>()(
     "InvalidIpamExternalResourceVerificationTokenId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidIpamIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidIpamIdNotFound>()(
     "InvalidIpamId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidIpamPolicyIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidIpamPolicyIdMalformed>()(
     "InvalidIpamPolicyId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidIpamPolicyIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidIpamPolicyIdNotFound>()(
     "InvalidIpamPolicyId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidIpamPoolIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidIpamPoolIdNotFound>()(
     "InvalidIpamPoolId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidIpamPrefixListResolverIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidIpamPrefixListResolverIdMalformed>()(
     "InvalidIpamPrefixListResolverId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidIpamPrefixListResolverIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidIpamPrefixListResolverIdNotFound>()(
     "InvalidIpamPrefixListResolverId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidIpamPrefixListResolverTargetIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidIpamPrefixListResolverTargetIdMalformed>()(
     "InvalidIpamPrefixListResolverTargetId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidIpamResourceDiscoveryAssociationIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidIpamResourceDiscoveryAssociationIdMalformed>()(
     "InvalidIpamResourceDiscoveryAssociationId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidIpamResourceDiscoveryAssociationIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidIpamResourceDiscoveryAssociationIdNotFound>()(
     "InvalidIpamResourceDiscoveryAssociationId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidIpamResourceDiscoveryIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidIpamResourceDiscoveryIdMalformed>()(
     "InvalidIpamResourceDiscoveryId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidIpamResourceDiscoveryIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidIpamResourceDiscoveryIdNotFound>()(
     "InvalidIpamResourceDiscoveryId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidIpamScopeIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidIpamScopeIdMalformed>()(
     "InvalidIpamScopeId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidIpamScopeIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidIpamScopeIdNotFound>()(
     "InvalidIpamScopeId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidIpv4PoolCoipIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidIpv4PoolCoipIdMalformed>()(
     "InvalidIpv4PoolCoipId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidIpv6PoolIDMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidIpv6PoolIDMalformed>()(
     "InvalidIpv6PoolID.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidIpv6PoolIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidIpv6PoolIDNotFound>()(
     "InvalidIpv6PoolID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidKeyPairDuplicate
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidKeyPairDuplicate>()(
     "InvalidKeyPair.Duplicate",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class InvalidKeyPairNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidKeyPairNotFound>()(
     "InvalidKeyPair.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidLaunchTemplateIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidLaunchTemplateIdMalformed>()(
     "InvalidLaunchTemplateId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidLaunchTemplateIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidLaunchTemplateIdNotFound>()(
     "InvalidLaunchTemplateId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidLaunchTemplateNameNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidLaunchTemplateNameNotFoundException>()(
     "InvalidLaunchTemplateName.NotFoundException",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidLocalGatewayIDMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidLocalGatewayIDMalformed>()(
     "InvalidLocalGatewayID.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidLocalGatewayIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidLocalGatewayIDNotFound>()(
     "InvalidLocalGatewayID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidLocalGatewayRouteTableIDMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidLocalGatewayRouteTableIDMalformed>()(
     "InvalidLocalGatewayRouteTableID.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidLocalGatewayRouteTableIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidLocalGatewayRouteTableIDNotFound>()(
     "InvalidLocalGatewayRouteTableID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidLocalGatewayRouteTableVirtualInterfaceGroupAssociationIDMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidLocalGatewayRouteTableVirtualInterfaceGroupAssociationIDMalformed>()(
     "InvalidLocalGatewayRouteTableVirtualInterfaceGroupAssociationID.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidLocalGatewayRouteTableVirtualInterfaceGroupAssociationIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidLocalGatewayRouteTableVirtualInterfaceGroupAssociationIDNotFound>()(
     "InvalidLocalGatewayRouteTableVirtualInterfaceGroupAssociationID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidLocalGatewayRouteTableVpcAssociationIDMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidLocalGatewayRouteTableVpcAssociationIDMalformed>()(
     "InvalidLocalGatewayRouteTableVpcAssociationID.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidLocalGatewayRouteTableVpcAssociationIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidLocalGatewayRouteTableVpcAssociationIDNotFound>()(
     "InvalidLocalGatewayRouteTableVpcAssociationID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidLocalGatewayVirtualInterfaceGroupIDMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidLocalGatewayVirtualInterfaceGroupIDMalformed>()(
     "InvalidLocalGatewayVirtualInterfaceGroupID.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidLocalGatewayVirtualInterfaceGroupIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidLocalGatewayVirtualInterfaceGroupIDNotFound>()(
     "InvalidLocalGatewayVirtualInterfaceGroupID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidLocalGatewayVirtualInterfaceIDMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidLocalGatewayVirtualInterfaceIDMalformed>()(
     "InvalidLocalGatewayVirtualInterfaceID.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidLocalGatewayVirtualInterfaceIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidLocalGatewayVirtualInterfaceIDNotFound>()(
     "InvalidLocalGatewayVirtualInterfaceID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidNetworkAclEntryNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNetworkAclEntryNotFound>()(
     "InvalidNetworkAclEntry.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidNetworkAclIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNetworkAclIdMalformed>()(
     "InvalidNetworkAclId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidNetworkAclIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNetworkAclIDNotFound>()(
     "InvalidNetworkAclID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidNetworkInsightsAccessScopeIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNetworkInsightsAccessScopeIdNotFound>()(
     "InvalidNetworkInsightsAccessScopeId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidNetworkInterfaceAttachmentIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNetworkInterfaceAttachmentIdMalformed>()(
     "InvalidNetworkInterfaceAttachmentId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidNetworkInterfaceIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNetworkInterfaceIdMalformed>()(
     "InvalidNetworkInterfaceId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidNetworkInterfaceIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNetworkInterfaceIDNotFound>()(
     "InvalidNetworkInterfaceID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidNetworkInterfaceInUse
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNetworkInterfaceInUse>()(
     "InvalidNetworkInterface.InUse",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withDependencyViolationError) {}
 export class InvalidOutpostLagIDMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidOutpostLagIDMalformed>()(
     "InvalidOutpostLagID.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidParameter
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameter>()(
     "InvalidParameter",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidParameterCombination
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterCombination>()(
     "InvalidParameterCombination",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidParameterValue
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterValue>()(
     "InvalidParameterValue",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidPermissionDuplicate
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPermissionDuplicate>()(
     "InvalidPermission.Duplicate",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class InvalidPermissionIDMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPermissionIDMalformed>()(
     "InvalidPermissionID.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidPermissionIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPermissionIDNotFound>()(
     "InvalidPermissionID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidPermissionNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPermissionNotFound>()(
     "InvalidPermission.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidPlacementGroupUnknown
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPlacementGroupUnknown>()(
     "InvalidPlacementGroup.Unknown",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidPoolIDMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPoolIDMalformed>()(
     "InvalidPoolID.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidPoolIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPoolIDNotFound>()(
     "InvalidPoolID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidPrefixListIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPrefixListIdMalformed>()(
     "InvalidPrefixListId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidPrefixListIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPrefixListIdNotFound>()(
     "InvalidPrefixListId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidPrefixListIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPrefixListIDNotFound>()(
     "InvalidPrefixListID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidPublicIpv4PoolIDMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPublicIpv4PoolIDMalformed>()(
     "InvalidPublicIpv4PoolID.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidPublicIpv4PoolIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPublicIpv4PoolIDNotFound>()(
     "InvalidPublicIpv4PoolID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidPublicIpv4PoolNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPublicIpv4PoolNotFound>()(
     "InvalidPublicIpv4Pool.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidPurchaseTokenMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPurchaseTokenMalformed>()(
     "InvalidPurchaseToken.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRegion
-  extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRegion>()(
-    "InvalidRegion",
-    {},
-  ) {}
+  extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRegion>()("InvalidRegion", {
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
+  }) {}
 export class InvalidRequest
-  extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequest>()(
-    "InvalidRequest",
-    {},
-  ) {}
+  extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequest>()("InvalidRequest", {
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
+  }) {}
 export class InvalidReservedInstancesIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidReservedInstancesIDNotFound>()(
     "InvalidReservedInstancesID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRoleArnMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRoleArnMalformed>()(
     "InvalidRoleArn.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRouteMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRouteMalformed>()(
     "InvalidRoute.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRouteNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRouteNotFound>()(
     "InvalidRoute.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRouteServerEndpointIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRouteServerEndpointIdNotFound>()(
     "InvalidRouteServerEndpointId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRouteServerIdNotAssociated
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRouteServerIdNotAssociated>()(
     "InvalidRouteServerId.NotAssociated",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRouteServerIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRouteServerIdNotFound>()(
     "InvalidRouteServerId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRouteServerPeerIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRouteServerPeerIdMalformed>()(
     "InvalidRouteServerPeerId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRouteServerPeerIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRouteServerPeerIdNotFound>()(
     "InvalidRouteServerPeerId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRouteTableAssociationIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRouteTableAssociationIdMalformed>()(
     "InvalidRouteTableAssociationId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRouteTableIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRouteTableIdMalformed>()(
     "InvalidRouteTableId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRouteTableIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRouteTableIDNotFound>()(
     "InvalidRouteTableID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidScheduledInstance
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidScheduledInstance>()(
     "InvalidScheduledInstance",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidSecurityGroupRuleIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSecurityGroupRuleIdMalformed>()(
     "InvalidSecurityGroupRuleId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidSecurityGroupRuleIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSecurityGroupRuleIdNotFound>()(
     "InvalidSecurityGroupRuleId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidServiceLinkVirtualInterfaceIDMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidServiceLinkVirtualInterfaceIDMalformed>()(
     "InvalidServiceLinkVirtualInterfaceID.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidServiceName
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidServiceName>()(
     "InvalidServiceName",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidSnapshotIDMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSnapshotIDMalformed>()(
     "InvalidSnapshotID.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidSnapshotNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSnapshotNotFound>()(
     "InvalidSnapshot.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidSpotDatafeedNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSpotDatafeedNotFound>()(
     "InvalidSpotDatafeed.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidSpotInstanceRequestIDMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSpotInstanceRequestIDMalformed>()(
     "InvalidSpotInstanceRequestID.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidState
-  extends /*@__PURE__*/ S.TaggedErrorClass<InvalidState>()(
-    "InvalidState",
-    {},
-  ) {}
+  extends /*@__PURE__*/ S.TaggedErrorClass<InvalidState>()("InvalidState", {
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
+  }) {}
 export class InvalidSubnet
-  extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSubnet>()(
-    "InvalidSubnet",
-    {},
-  ) {}
+  extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSubnet>()("InvalidSubnet", {
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
+  }) {}
 export class InvalidSubnetCidrBlockAssociationIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSubnetCidrBlockAssociationIdMalformed>()(
     "InvalidSubnetCidrBlockAssociationId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidSubnetCidrBlockAssociationIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSubnetCidrBlockAssociationIDNotFound>()(
     "InvalidSubnetCidrBlockAssociationID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidSubnetCidrReservationIDMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSubnetCidrReservationIDMalformed>()(
     "InvalidSubnetCidrReservationID.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidSubnetCidrReservationIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSubnetCidrReservationIDNotFound>()(
     "InvalidSubnetCidrReservationID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidSubnetConflict
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSubnetConflict>()(
     "InvalidSubnet.Conflict",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidSubnetIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSubnetIdMalformed>()(
     "InvalidSubnetId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidSubnetIDMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSubnetIDMalformed>()(
     "InvalidSubnetID.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidSubnetIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSubnetIDNotFound>()(
     "InvalidSubnetID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTargetArnUnknown
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTargetArnUnknown>()(
     "InvalidTargetArn.Unknown",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTrafficMirrorFilterIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTrafficMirrorFilterIdNotFound>()(
     "InvalidTrafficMirrorFilterId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTrafficMirrorFilterRuleIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTrafficMirrorFilterRuleIdNotFound>()(
     "InvalidTrafficMirrorFilterRuleId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTrafficMirrorSessionIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTrafficMirrorSessionIdNotFound>()(
     "InvalidTrafficMirrorSessionId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTrafficMirrorTargetIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTrafficMirrorTargetIdNotFound>()(
     "InvalidTrafficMirrorTargetId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTransitGatewayAttachmentIDMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTransitGatewayAttachmentIDMalformed>()(
     "InvalidTransitGatewayAttachmentID.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTransitGatewayAttachmentIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTransitGatewayAttachmentIDNotFound>()(
     "InvalidTransitGatewayAttachmentID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTransitGatewayConnectPeerIDMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTransitGatewayConnectPeerIDMalformed>()(
     "InvalidTransitGatewayConnectPeerID.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTransitGatewayConnectPeerIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTransitGatewayConnectPeerIDNotFound>()(
     "InvalidTransitGatewayConnectPeerID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTransitGatewayIDMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTransitGatewayIDMalformed>()(
     "InvalidTransitGatewayID.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTransitGatewayIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTransitGatewayIDNotFound>()(
     "InvalidTransitGatewayID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTransitGatewayMeteringPolicyIdMalformedException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTransitGatewayMeteringPolicyIdMalformedException>()(
     "InvalidTransitGatewayMeteringPolicyIdMalformedException",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTransitGatewayMeteringPolicyIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTransitGatewayMeteringPolicyIdNotFound>()(
     "InvalidTransitGatewayMeteringPolicyId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTransitGatewayMulticastDomainIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTransitGatewayMulticastDomainIdMalformed>()(
     "InvalidTransitGatewayMulticastDomainId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTransitGatewayMulticastDomainIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTransitGatewayMulticastDomainIdNotFound>()(
     "InvalidTransitGatewayMulticastDomainId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTransitGatewayPolicyTableIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTransitGatewayPolicyTableIdMalformed>()(
     "InvalidTransitGatewayPolicyTableId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTransitGatewayPolicyTableIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTransitGatewayPolicyTableIdNotFound>()(
     "InvalidTransitGatewayPolicyTableId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTransitGatewayRouteTableAnnouncementIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTransitGatewayRouteTableAnnouncementIdMalformed>()(
     "InvalidTransitGatewayRouteTableAnnouncementId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidUserIDMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidUserIDMalformed>()(
     "InvalidUserID.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidVerifiedAccessEndpointIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidVerifiedAccessEndpointIdNotFound>()(
     "InvalidVerifiedAccessEndpointId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidVerifiedAccessGroupIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidVerifiedAccessGroupIdNotFound>()(
     "InvalidVerifiedAccessGroupId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidVerifiedAccessInstanceIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidVerifiedAccessInstanceIdNotFound>()(
     "InvalidVerifiedAccessInstanceId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidVerifiedAccessTrustProviderIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidVerifiedAccessTrustProviderIdNotFound>()(
     "InvalidVerifiedAccessTrustProviderId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidVolumeIDMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidVolumeIDMalformed>()(
     "InvalidVolumeID.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidVolumeNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidVolumeNotFound>()(
     "InvalidVolume.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidVpcCidrBlockAssociationIdErrorNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidVpcCidrBlockAssociationIdErrorNotFound>()(
     "InvalidVpcCidrBlockAssociationIdError.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidVpcCidrBlockAssociationIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidVpcCidrBlockAssociationIdMalformed>()(
     "InvalidVpcCidrBlockAssociationId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidVpcCidrBlockAssociationIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidVpcCidrBlockAssociationIDNotFound>()(
     "InvalidVpcCidrBlockAssociationID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidVpcEncryptionControlIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidVpcEncryptionControlIdMalformed>()(
     "InvalidVpcEncryptionControlId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidVpcEncryptionControlIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidVpcEncryptionControlIdNotFound>()(
     "InvalidVpcEncryptionControlId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidVpcEndpointIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidVpcEndpointIdNotFound>()(
     "InvalidVpcEndpointId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidVpcEndpointServiceIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidVpcEndpointServiceIdMalformed>()(
     "InvalidVpcEndpointServiceId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidVpcEndpointServiceIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidVpcEndpointServiceIdNotFound>()(
     "InvalidVpcEndpointServiceId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidVpcIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidVpcIdMalformed>()(
     "InvalidVpcId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidVpcIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidVpcIdNotFound>()(
     "InvalidVpcId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidVpcIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidVpcIDNotFound>()(
     "InvalidVpcID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidVpcPeeringConnectionIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidVpcPeeringConnectionIdNotFound>()(
     "InvalidVpcPeeringConnectionId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidVpcPeeringConnectionIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidVpcPeeringConnectionIDNotFound>()(
     "InvalidVpcPeeringConnectionID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidVpnConcentratorIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidVpnConcentratorIdMalformed>()(
     "InvalidVpnConcentratorId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidVpnConcentratorIDMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidVpnConcentratorIDMalformed>()(
     "InvalidVpnConcentratorID.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidVpnConnectionDeviceTypeIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidVpnConnectionDeviceTypeIdNotFound>()(
     "InvalidVpnConnectionDeviceTypeId.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidVpnConnectionId
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidVpnConnectionId>()(
     "InvalidVpnConnectionId",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidVpnConnectionIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidVpnConnectionIDNotFound>()(
     "InvalidVpnConnectionID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidVpnGatewayIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidVpnGatewayIDNotFound>()(
     "InvalidVpnGatewayID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidZoneNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidZoneNotFound>()(
     "InvalidZone.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MalformedGatewayIDNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<MalformedGatewayIDNotFound>()(
     "MalformedGatewayID.NotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MissingParameter
   extends /*@__PURE__*/ S.TaggedErrorClass<MissingParameter>()(
     "MissingParameter",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MissingRequiredParameter
   extends /*@__PURE__*/ S.TaggedErrorClass<MissingRequiredParameter>()(
     "MissingRequiredParameter",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NatGatewayMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<NatGatewayMalformed>()(
     "NatGatewayMalformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NatGatewayNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<NatGatewayNotFound>()(
     "NatGatewayNotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class OperationNotPermitted
   extends /*@__PURE__*/ S.TaggedErrorClass<OperationNotPermitted>()(
     "OperationNotPermitted",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ParseError
-  extends /*@__PURE__*/ S.TaggedErrorClass<ParseError>()("ParseError", {}) {}
+  extends /*@__PURE__*/ S.TaggedErrorClass<ParseError>()("ParseError", {
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
+  }) {}
 export class RequestError
-  extends /*@__PURE__*/ S.TaggedErrorClass<RequestError>()(
-    "RequestError",
-    {},
-  ) {}
+  extends /*@__PURE__*/ S.TaggedErrorClass<RequestError>()("RequestError", {
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
+  }) {}
 export class RequestLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<RequestLimitExceeded>()(
     "RequestLimitExceeded",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withThrottlingError) {}
 export class ResourceLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceLimitExceeded>()(
     "ResourceLimitExceeded",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withThrottlingError) {}
 export class RouteAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<RouteAlreadyExists>()(
     "RouteAlreadyExists",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class TransitGatewayLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<TransitGatewayLimitExceeded>()(
     "TransitGatewayLimitExceeded",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withThrottlingError) {}
 export class UnauthorizedOperation
   extends /*@__PURE__*/ S.TaggedErrorClass<UnauthorizedOperation>()(
     "UnauthorizedOperation",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAuthError) {}
 export class UnknownParameter
   extends /*@__PURE__*/ S.TaggedErrorClass<UnknownParameter>()(
     "UnknownParameter",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class UnknownResource
   extends /*@__PURE__*/ S.TaggedErrorClass<UnknownResource>()(
     "UnknownResource",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class Unsupported
-  extends /*@__PURE__*/ S.TaggedErrorClass<Unsupported>()("Unsupported", {}) {}
+  extends /*@__PURE__*/ S.TaggedErrorClass<Unsupported>()("Unsupported", {
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
+  }) {}
 export class UnsupportedOperation
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedOperation>()(
     "UnsupportedOperation",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class VerifiedAccessInstanceLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<VerifiedAccessInstanceLimitExceeded>()(
     "VerifiedAccessInstanceLimitExceeded",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withThrottlingError) {}
 export class VolumeInUse
-  extends /*@__PURE__*/ S.TaggedErrorClass<VolumeInUse>()(
-    "VolumeInUse",
-    {},
-  ).pipe(
+  extends /*@__PURE__*/ S.TaggedErrorClass<VolumeInUse>()("VolumeInUse", {
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
+  }).pipe(
     C.withConflictError,
     C.withRetryableError,
     C.withDependencyViolationError,
@@ -1236,17 +1230,17 @@ export class VolumeInUse
 export class VpcBlockPublicAccessExclusionIdMalformed
   extends /*@__PURE__*/ S.TaggedErrorClass<VpcBlockPublicAccessExclusionIdMalformed>()(
     "VpcBlockPublicAccessExclusionId.Malformed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class VPCIdNotSpecified
   extends /*@__PURE__*/ S.TaggedErrorClass<VPCIdNotSpecified>()(
     "VPCIdNotSpecified",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class VpcLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<VpcLimitExceeded>()(
     "VpcLimitExceeded",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withThrottlingError) {}
 export type ResourceType =
   | "capacity-reservation"

--- a/packages/aws/src/services/ecr-public.ts
+++ b/packages/aws/src/services/ecr-public.ts
@@ -94,32 +94,32 @@ const rules = T.EndpointResolver((p, _) => {
 export class EmptyUploadException
   extends /*@__PURE__*/ S.TaggedErrorClass<EmptyUploadException>()(
     "EmptyUploadException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ImageAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ImageAlreadyExistsException>()(
     "ImageAlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class ImageDigestDoesNotMatchException
   extends /*@__PURE__*/ S.TaggedErrorClass<ImageDigestDoesNotMatchException>()(
     "ImageDigestDoesNotMatchException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ImageNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ImageNotFoundException>()(
     "ImageNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ImageTagAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ImageTagAlreadyExistsException>()(
     "ImageTagAlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class InvalidLayerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidLayerException>()(
     "InvalidLayerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidLayerPartException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidLayerPartException>()(
@@ -129,93 +129,93 @@ export class InvalidLayerPartException
       repositoryName: S.optional(S.String),
       uploadId: S.optional(S.String),
       lastValidByteReceived: S.optional(S.Number),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
   ) {}
 export class InvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterException>()(
     "InvalidParameterException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTagParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTagParameterException>()(
     "InvalidTagParameterException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LayerAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<LayerAlreadyExistsException>()(
     "LayerAlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class LayerPartTooSmallException
   extends /*@__PURE__*/ S.TaggedErrorClass<LayerPartTooSmallException>()(
     "LayerPartTooSmallException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LayersNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<LayersNotFoundException>()(
     "LayersNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ReferencedImagesNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ReferencedImagesNotFoundException>()(
     "ReferencedImagesNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class RegistryNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<RegistryNotFoundException>()(
     "RegistryNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class RepositoryAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<RepositoryAlreadyExistsException>()(
     "RepositoryAlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class RepositoryCatalogDataNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<RepositoryCatalogDataNotFoundException>()(
     "RepositoryCatalogDataNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class RepositoryNotEmptyException
   extends /*@__PURE__*/ S.TaggedErrorClass<RepositoryNotEmptyException>()(
     "RepositoryNotEmptyException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class RepositoryNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<RepositoryNotFoundException>()(
     "RepositoryNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class RepositoryPolicyNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<RepositoryPolicyNotFoundException>()(
     "RepositoryPolicyNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServerException>()(
     "ServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class UnsupportedCommandException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedCommandException>()(
     "UnsupportedCommandException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class UploadNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<UploadNotFoundException>()(
     "UploadNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type RegistryIdOrAlias = string;
 export type RepositoryName = string;

--- a/packages/aws/src/services/ecr.ts
+++ b/packages/aws/src/services/ecr.ts
@@ -379,57 +379,57 @@ const rules = T.EndpointResolver((p, _) => {
 export class BlockedByOrganizationPolicyException
   extends /*@__PURE__*/ S.TaggedErrorClass<BlockedByOrganizationPolicyException>()(
     "BlockedByOrganizationPolicyException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class EmptyUploadException
   extends /*@__PURE__*/ S.TaggedErrorClass<EmptyUploadException>()(
     "EmptyUploadException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ExclusionAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ExclusionAlreadyExistsException>()(
     "ExclusionAlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class ExclusionNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ExclusionNotFoundException>()(
     "ExclusionNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ImageAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ImageAlreadyExistsException>()(
     "ImageAlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class ImageArchivedException
   extends /*@__PURE__*/ S.TaggedErrorClass<ImageArchivedException>()(
     "ImageArchivedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ImageDigestDoesNotMatchException
   extends /*@__PURE__*/ S.TaggedErrorClass<ImageDigestDoesNotMatchException>()(
     "ImageDigestDoesNotMatchException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ImageNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ImageNotFoundException>()(
     "ImageNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ImageStorageClassUpdateNotSupportedException
   extends /*@__PURE__*/ S.TaggedErrorClass<ImageStorageClassUpdateNotSupportedException>()(
     "ImageStorageClassUpdateNotSupportedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ImageTagAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ImageTagAlreadyExistsException>()(
     "ImageTagAlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class InvalidLayerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidLayerException>()(
     "InvalidLayerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidLayerPartException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidLayerPartException>()(
@@ -439,183 +439,183 @@ export class InvalidLayerPartException
       repositoryName: S.optional(S.String),
       uploadId: S.optional(S.String),
       lastValidByteReceived: S.optional(S.Number),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
   ) {}
 export class InvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterException>()(
     "InvalidParameterException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class InvalidTagParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTagParameterException>()(
     "InvalidTagParameterException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class KmsException
   extends /*@__PURE__*/ S.TaggedErrorClass<KmsException>()("KmsException", {
-    message: S.optional(S.String),
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
     kmsError: S.optional(S.String),
   }) {}
 export class LayerAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<LayerAlreadyExistsException>()(
     "LayerAlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class LayerInaccessibleException
   extends /*@__PURE__*/ S.TaggedErrorClass<LayerInaccessibleException>()(
     "LayerInaccessibleException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LayerPartTooSmallException
   extends /*@__PURE__*/ S.TaggedErrorClass<LayerPartTooSmallException>()(
     "LayerPartTooSmallException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LayersNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<LayersNotFoundException>()(
     "LayersNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LifecyclePolicyNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<LifecyclePolicyNotFoundException>()(
     "LifecyclePolicyNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withNotFoundError) {}
 export class LifecyclePolicyPreviewInProgressException
   extends /*@__PURE__*/ S.TaggedErrorClass<LifecyclePolicyPreviewInProgressException>()(
     "LifecyclePolicyPreviewInProgressException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LifecyclePolicyPreviewNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<LifecyclePolicyPreviewNotFoundException>()(
     "LifecyclePolicyPreviewNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withQuotaError) {}
 export class PullThroughCacheRuleAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<PullThroughCacheRuleAlreadyExistsException>()(
     "PullThroughCacheRuleAlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class PullThroughCacheRuleNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<PullThroughCacheRuleNotFoundException>()(
     "PullThroughCacheRuleNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ReferencedImagesNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ReferencedImagesNotFoundException>()(
     "ReferencedImagesNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class RegistryPolicyNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<RegistryPolicyNotFoundException>()(
     "RegistryPolicyNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class RepositoryAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<RepositoryAlreadyExistsException>()(
     "RepositoryAlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class RepositoryNotEmptyException
   extends /*@__PURE__*/ S.TaggedErrorClass<RepositoryNotEmptyException>()(
     "RepositoryNotEmptyException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withConflictError, C.withDependencyViolationError) {}
 export class RepositoryNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<RepositoryNotFoundException>()(
     "RepositoryNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withNotFoundError) {}
 export class RepositoryPolicyNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<RepositoryPolicyNotFoundException>()(
     "RepositoryPolicyNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withNotFoundError) {}
 export class ScanNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ScanNotFoundException>()(
     "ScanNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class SecretNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<SecretNotFoundException>()(
     "SecretNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServerException>()(
     "ServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class SigningConfigurationNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<SigningConfigurationNotFoundException>()(
     "SigningConfigurationNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TemplateAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TemplateAlreadyExistsException>()(
     "TemplateAlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class TemplateNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<TemplateNotFoundException>()(
     "TemplateNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withQuotaError, C.withBadRequestError) {}
 export class UnableToAccessSecretException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnableToAccessSecretException>()(
     "UnableToAccessSecretException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class UnableToDecryptSecretValueException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnableToDecryptSecretValueException>()(
     "UnableToDecryptSecretValueException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class UnableToGetUpstreamImageException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnableToGetUpstreamImageException>()(
     "UnableToGetUpstreamImageException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class UnableToGetUpstreamLayerException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnableToGetUpstreamLayerException>()(
     "UnableToGetUpstreamLayerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class UnableToListUpstreamImageReferrersException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnableToListUpstreamImageReferrersException>()(
     "UnableToListUpstreamImageReferrersException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class UnsupportedImageTypeException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedImageTypeException>()(
     "UnsupportedImageTypeException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class UnsupportedUpstreamRegistryException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedUpstreamRegistryException>()(
     "UnsupportedUpstreamRegistryException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class UploadNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<UploadNotFoundException>()(
     "UploadNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type RegistryId = string;

--- a/packages/aws/src/services/ecs.ts
+++ b/packages/aws/src/services/ecs.ts
@@ -91,48 +91,48 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class AttributeLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<AttributeLimitExceededException>()(
     "AttributeLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withQuotaError) {}
 export class BlockedException
   extends /*@__PURE__*/ S.TaggedErrorClass<BlockedException>()(
     "BlockedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class ClientException
   extends /*@__PURE__*/ S.TaggedErrorClass<ClientException>()(
     "ClientException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class ClusterContainsCapacityProviderException
   extends /*@__PURE__*/ S.TaggedErrorClass<ClusterContainsCapacityProviderException>()(
     "ClusterContainsCapacityProviderException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withDependencyViolationError) {}
 export class ClusterContainsContainerInstancesException
   extends /*@__PURE__*/ S.TaggedErrorClass<ClusterContainsContainerInstancesException>()(
     "ClusterContainsContainerInstancesException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withDependencyViolationError) {}
 export class ClusterContainsServicesException
   extends /*@__PURE__*/ S.TaggedErrorClass<ClusterContainsServicesException>()(
     "ClusterContainsServicesException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withDependencyViolationError) {}
 export class ClusterContainsTasksException
   extends /*@__PURE__*/ S.TaggedErrorClass<ClusterContainsTasksException>()(
     "ClusterContainsTasksException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withDependencyViolationError) {}
 export class ClusterNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ClusterNotFoundException>()(
     "ClusterNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withNotFoundError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
@@ -141,108 +141,108 @@ export class ConflictException
       resourceIds: S.optional(
         S.suspend(() => ResourceIds).annotate({ identifier: "ResourceIds" }),
       ),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
   ).pipe(C.withConflictError) {}
 export class DaemonNotActiveException
   extends /*@__PURE__*/ S.TaggedErrorClass<DaemonNotActiveException>()(
     "DaemonNotActiveException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withConflictError) {}
 export class DaemonNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<DaemonNotFoundException>()(
     "DaemonNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withNotFoundError) {}
 export class InvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterException>()(
     "InvalidParameterException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withQuotaError) {}
 export class MissingVersionException
   extends /*@__PURE__*/ S.TaggedErrorClass<MissingVersionException>()(
     "MissingVersionException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class NamespaceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NamespaceNotFoundException>()(
     "NamespaceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withNotFoundError) {}
 export class NoUpdateAvailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<NoUpdateAvailableException>()(
     "NoUpdateAvailableException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class PlatformTaskDefinitionIncompatibilityException
   extends /*@__PURE__*/ S.TaggedErrorClass<PlatformTaskDefinitionIncompatibilityException>()(
     "PlatformTaskDefinitionIncompatibilityException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class PlatformUnknownException
   extends /*@__PURE__*/ S.TaggedErrorClass<PlatformUnknownException>()(
     "PlatformUnknownException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class ResourceInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUseException>()(
     "ResourceInUseException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withConflictError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withNotFoundError) {}
 export class ServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServerException>()(
     "ServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ServiceDeploymentNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceDeploymentNotFoundException>()(
     "ServiceDeploymentNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withNotFoundError) {}
 export class ServiceNotActiveException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceNotActiveException>()(
     "ServiceNotActiveException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withConflictError) {}
 export class ServiceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceNotFoundException>()(
     "ServiceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withNotFoundError) {}
 export class TargetNotConnectedException
   extends /*@__PURE__*/ S.TaggedErrorClass<TargetNotConnectedException>()(
     "TargetNotConnectedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withConflictError) {}
 export class TargetNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<TargetNotFoundException>()(
     "TargetNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withNotFoundError) {}
 export class TaskSetNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<TaskSetNotFoundException>()(
     "TaskSetNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withNotFoundError) {}
 export class UnsupportedFeatureException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedFeatureException>()(
     "UnsupportedFeatureException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class UpdateInProgressException
   extends /*@__PURE__*/ S.TaggedErrorClass<UpdateInProgressException>()(
     "UpdateInProgressException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withConflictError, C.withRetryableError) {}
 export type DeploymentLifecycleHookAction =
   | "ROLLBACK"

--- a/packages/aws/src/services/efs.ts
+++ b/packages/aws/src/services/efs.ts
@@ -144,7 +144,7 @@ export class AccessPointAlreadyExists
     "AccessPointAlreadyExists",
     {
       ErrorCode: S.String,
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       AccessPointId: S.String,
     },
     T.HttpError(409),
@@ -152,37 +152,55 @@ export class AccessPointAlreadyExists
 export class AccessPointLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessPointLimitExceeded>()(
     "AccessPointLimitExceeded",
-    { ErrorCode: S.String, Message: S.optional(S.String) },
+    {
+      ErrorCode: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(403),
   ).pipe(C.withAuthError, C.withThrottlingError) {}
 export class AccessPointNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessPointNotFound>()(
     "AccessPointNotFound",
-    { ErrorCode: S.String, Message: S.optional(S.String) },
+    {
+      ErrorCode: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class AvailabilityZonesMismatch
   extends /*@__PURE__*/ S.TaggedErrorClass<AvailabilityZonesMismatch>()(
     "AvailabilityZonesMismatch",
-    { ErrorCode: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      ErrorCode: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class BadRequest
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequest>()(
     "BadRequest",
-    { ErrorCode: S.String, Message: S.optional(S.String) },
+    {
+      ErrorCode: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { ErrorCode: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      ErrorCode: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class DependencyTimeout
   extends /*@__PURE__*/ S.TaggedErrorClass<DependencyTimeout>()(
     "DependencyTimeout",
-    { ErrorCode: S.String, Message: S.optional(S.String) },
+    {
+      ErrorCode: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(504),
   ).pipe(C.withTimeoutError) {}
 export class FileSystemAlreadyExists
@@ -190,7 +208,7 @@ export class FileSystemAlreadyExists
     "FileSystemAlreadyExists",
     {
       ErrorCode: S.String,
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       FileSystemId: S.String,
     },
     T.HttpError(409),
@@ -198,145 +216,217 @@ export class FileSystemAlreadyExists
 export class FileSystemInUse
   extends /*@__PURE__*/ S.TaggedErrorClass<FileSystemInUse>()(
     "FileSystemInUse",
-    { ErrorCode: S.String, Message: S.optional(S.String) },
+    {
+      ErrorCode: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withDependencyViolationError) {}
 export class FileSystemLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<FileSystemLimitExceeded>()(
     "FileSystemLimitExceeded",
-    { ErrorCode: S.String, Message: S.optional(S.String) },
+    {
+      ErrorCode: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(403),
   ).pipe(C.withAuthError, C.withThrottlingError) {}
 export class FileSystemNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<FileSystemNotFound>()(
     "FileSystemNotFound",
-    { ErrorCode: S.String, Message: S.optional(S.String) },
+    {
+      ErrorCode: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class IncorrectFileSystemLifeCycleState
   extends /*@__PURE__*/ S.TaggedErrorClass<IncorrectFileSystemLifeCycleState>()(
     "IncorrectFileSystemLifeCycleState",
-    { ErrorCode: S.String, Message: S.optional(S.String) },
+    {
+      ErrorCode: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class IncorrectMountTargetState
   extends /*@__PURE__*/ S.TaggedErrorClass<IncorrectMountTargetState>()(
     "IncorrectMountTargetState",
-    { ErrorCode: S.String, Message: S.optional(S.String) },
+    {
+      ErrorCode: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InsufficientThroughputCapacity
   extends /*@__PURE__*/ S.TaggedErrorClass<InsufficientThroughputCapacity>()(
     "InsufficientThroughputCapacity",
-    { ErrorCode: S.String, Message: S.optional(S.String) },
+    {
+      ErrorCode: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class InternalServerError
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerError>()(
     "InternalServerError",
-    { ErrorCode: S.String, Message: S.optional(S.String) },
+    {
+      ErrorCode: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidPolicyException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPolicyException>()(
     "InvalidPolicyException",
-    { ErrorCode: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      ErrorCode: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class IpAddressInUse
   extends /*@__PURE__*/ S.TaggedErrorClass<IpAddressInUse>()(
     "IpAddressInUse",
-    { ErrorCode: S.String, Message: S.optional(S.String) },
+    {
+      ErrorCode: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withDependencyViolationError) {}
 export class MountTargetConflict
   extends /*@__PURE__*/ S.TaggedErrorClass<MountTargetConflict>()(
     "MountTargetConflict",
-    { ErrorCode: S.String, Message: S.optional(S.String) },
+    {
+      ErrorCode: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class MountTargetNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<MountTargetNotFound>()(
     "MountTargetNotFound",
-    { ErrorCode: S.String, Message: S.optional(S.String) },
+    {
+      ErrorCode: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class NetworkInterfaceLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<NetworkInterfaceLimitExceeded>()(
     "NetworkInterfaceLimitExceeded",
-    { ErrorCode: S.String, Message: S.optional(S.String) },
+    {
+      ErrorCode: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withThrottlingError) {}
 export class NoFreeAddressesInSubnet
   extends /*@__PURE__*/ S.TaggedErrorClass<NoFreeAddressesInSubnet>()(
     "NoFreeAddressesInSubnet",
-    { ErrorCode: S.String, Message: S.optional(S.String) },
+    {
+      ErrorCode: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class PolicyNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<PolicyNotFound>()(
     "PolicyNotFound",
-    { ErrorCode: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      ErrorCode: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ReplicationAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<ReplicationAlreadyExists>()(
     "ReplicationAlreadyExists",
-    { ErrorCode: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      ErrorCode: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class ReplicationNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<ReplicationNotFound>()(
     "ReplicationNotFound",
-    { ErrorCode: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      ErrorCode: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class SecurityGroupLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<SecurityGroupLimitExceeded>()(
     "SecurityGroupLimitExceeded",
-    { ErrorCode: S.String, Message: S.optional(S.String) },
+    {
+      ErrorCode: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError, C.withThrottlingError) {}
 export class SecurityGroupNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<SecurityGroupNotFound>()(
     "SecurityGroupNotFound",
-    { ErrorCode: S.String, Message: S.optional(S.String) },
+    {
+      ErrorCode: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class SubnetNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<SubnetNotFound>()(
     "SubnetNotFound",
-    { ErrorCode: S.String, Message: S.optional(S.String) },
+    {
+      ErrorCode: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { ErrorCode: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      ErrorCode: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ThroughputLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<ThroughputLimitExceeded>()(
     "ThroughputLimitExceeded",
-    { ErrorCode: S.String, Message: S.optional(S.String) },
+    {
+      ErrorCode: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError, C.withThrottlingError) {}
 export class TooManyRequests
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequests>()(
     "TooManyRequests",
-    { ErrorCode: S.String, Message: S.optional(S.String) },
+    {
+      ErrorCode: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class UnsupportedAvailabilityZone
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedAvailabilityZone>()(
     "UnsupportedAvailabilityZone",
-    { ErrorCode: S.String, Message: S.optional(S.String) },
+    {
+      ErrorCode: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { ErrorCode: S.String, Message: S.optional(S.String) },
+    {
+      ErrorCode: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type ClientToken = string;

--- a/packages/aws/src/services/eks-auth.ts
+++ b/packages/aws/src/services/eks-auth.ts
@@ -76,55 +76,55 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError, C.withAuthError) {}
 export class ExpiredTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<ExpiredTokenException>()(
     "ExpiredTokenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterException>()(
     "InvalidParameterException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTokenException>()(
     "InvalidTokenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export type ClusterName = string;

--- a/packages/aws/src/services/eks.ts
+++ b/packages/aws/src/services/eks.ts
@@ -94,13 +94,13 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ClientException
@@ -111,7 +111,7 @@ export class ClientException
       nodegroupName: S.optional(S.String),
       addonName: S.optional(S.String),
       subscriptionId: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
@@ -124,7 +124,7 @@ export class InvalidParameterException
       fargateProfileName: S.optional(S.String),
       addonName: S.optional(S.String),
       subscriptionId: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
@@ -136,20 +136,23 @@ export class InvalidRequestException
       nodegroupName: S.optional(S.String),
       addonName: S.optional(S.String),
       subscriptionId: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidStateException>()(
     "InvalidStateException",
-    { clusterName: S.optional(S.String), message: S.optional(S.String) },
+    {
+      clusterName: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ResourceInUseException
@@ -159,7 +162,7 @@ export class ResourceInUseException
       clusterName: S.optional(S.String),
       nodegroupName: S.optional(S.String),
       addonName: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
@@ -170,7 +173,7 @@ export class ResourceLimitExceededException
       clusterName: S.optional(S.String),
       nodegroupName: S.optional(S.String),
       subscriptionId: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
@@ -183,14 +186,14 @@ export class ResourceNotFoundException
       fargateProfileName: S.optional(S.String),
       addonName: S.optional(S.String),
       subscriptionId: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ResourcePropagationDelayException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourcePropagationDelayException>()(
     "ResourcePropagationDelayException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(428),
   ) {}
 export class ServerException
@@ -201,27 +204,30 @@ export class ServerException
       nodegroupName: S.optional(S.String),
       addonName: S.optional(S.String),
       subscriptionId: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { clusterName: S.optional(S.String), message: S.optional(S.String) },
+    {
+      clusterName: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class UnsupportedAvailabilityZoneException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedAvailabilityZoneException>()(
     "UnsupportedAvailabilityZoneException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       clusterName: S.optional(S.String),
       nodegroupName: S.optional(S.String),
       validZones: S.optional(

--- a/packages/aws/src/services/elastic-beanstalk.ts
+++ b/packages/aws/src/services/elastic-beanstalk.ts
@@ -94,7 +94,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class CodeBuildNotInServiceRegionException
   extends /*@__PURE__*/ S.TaggedErrorClass<CodeBuildNotInServiceRegionException>()(
     "CodeBuildNotInServiceRegionException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CodeBuildNotInServiceRegionException",
@@ -106,12 +106,12 @@ export class CodeBuildNotInServiceRegionException
 export class ElasticBeanstalkServiceException
   extends /*@__PURE__*/ S.TaggedErrorClass<ElasticBeanstalkServiceException>()(
     "ElasticBeanstalkServiceException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InsufficientPrivilegesException
   extends /*@__PURE__*/ S.TaggedErrorClass<InsufficientPrivilegesException>()(
     "InsufficientPrivilegesException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InsufficientPrivilegesException",
@@ -123,7 +123,7 @@ export class InsufficientPrivilegesException
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidRequestException",
@@ -135,7 +135,7 @@ export class InvalidRequestException
 export class ManagedActionInvalidStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<ManagedActionInvalidStateException>()(
     "ManagedActionInvalidStateException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ManagedActionInvalidStateException",
@@ -147,7 +147,7 @@ export class ManagedActionInvalidStateException
 export class OperationInProgressException
   extends /*@__PURE__*/ S.TaggedErrorClass<OperationInProgressException>()(
     "OperationInProgressException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "OperationInProgressFailure",
@@ -159,7 +159,7 @@ export class OperationInProgressException
 export class PlatformVersionStillReferencedException
   extends /*@__PURE__*/ S.TaggedErrorClass<PlatformVersionStillReferencedException>()(
     "PlatformVersionStillReferencedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "PlatformVersionStillReferencedException",
@@ -171,7 +171,7 @@ export class PlatformVersionStillReferencedException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ResourceNotFoundException",
@@ -183,7 +183,7 @@ export class ResourceNotFoundException
 export class ResourceTypeNotSupportedException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceTypeNotSupportedException>()(
     "ResourceTypeNotSupportedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ResourceTypeNotSupportedException",
@@ -195,7 +195,7 @@ export class ResourceTypeNotSupportedException
 export class S3LocationNotInServiceRegionException
   extends /*@__PURE__*/ S.TaggedErrorClass<S3LocationNotInServiceRegionException>()(
     "S3LocationNotInServiceRegionException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "S3LocationNotInServiceRegionException",
@@ -207,7 +207,7 @@ export class S3LocationNotInServiceRegionException
 export class S3SubscriptionRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<S3SubscriptionRequiredException>()(
     "S3SubscriptionRequiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "S3SubscriptionRequiredException",
@@ -219,7 +219,7 @@ export class S3SubscriptionRequiredException
 export class SourceBundleDeletionException
   extends /*@__PURE__*/ S.TaggedErrorClass<SourceBundleDeletionException>()(
     "SourceBundleDeletionException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SourceBundleDeletionFailure",
@@ -231,7 +231,7 @@ export class SourceBundleDeletionException
 export class TooManyApplicationsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyApplicationsException>()(
     "TooManyApplicationsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "TooManyApplicationsException",
@@ -243,12 +243,12 @@ export class TooManyApplicationsException
 export class TooManyApplicationVersionsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyApplicationVersionsException>()(
     "TooManyApplicationVersionsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TooManyBucketsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyBucketsException>()(
     "TooManyBucketsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "TooManyBucketsException",
@@ -260,7 +260,7 @@ export class TooManyBucketsException
 export class TooManyConfigurationTemplatesException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyConfigurationTemplatesException>()(
     "TooManyConfigurationTemplatesException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "TooManyConfigurationTemplatesException",
@@ -272,7 +272,7 @@ export class TooManyConfigurationTemplatesException
 export class TooManyEnvironmentsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyEnvironmentsException>()(
     "TooManyEnvironmentsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "TooManyEnvironmentsException",
@@ -284,7 +284,7 @@ export class TooManyEnvironmentsException
 export class TooManyPlatformsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyPlatformsException>()(
     "TooManyPlatformsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "TooManyPlatformsException",
@@ -296,7 +296,7 @@ export class TooManyPlatformsException
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "TooManyTagsException", httpResponseCode: 400 }),
       T.HttpError(400),

--- a/packages/aws/src/services/elastic-load-balancing-v2.ts
+++ b/packages/aws/src/services/elastic-load-balancing-v2.ts
@@ -96,7 +96,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class AllocationIdNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<AllocationIdNotFoundException>()(
     "AllocationIdNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "AllocationIdNotFound", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -105,7 +105,7 @@ export class AllocationIdNotFoundException
 export class ALPNPolicyNotSupportedException
   extends /*@__PURE__*/ S.TaggedErrorClass<ALPNPolicyNotSupportedException>()(
     "ALPNPolicyNotSupportedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ALPNPolicyNotFound", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -114,7 +114,7 @@ export class ALPNPolicyNotSupportedException
 export class AvailabilityZoneNotSupportedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AvailabilityZoneNotSupportedException>()(
     "AvailabilityZoneNotSupportedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "AvailabilityZoneNotSupported",
@@ -126,7 +126,7 @@ export class AvailabilityZoneNotSupportedException
 export class CaCertificatesBundleNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<CaCertificatesBundleNotFoundException>()(
     "CaCertificatesBundleNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CaCertificatesBundleNotFound",
@@ -138,7 +138,7 @@ export class CaCertificatesBundleNotFoundException
 export class CapacityDecreaseRequestsLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<CapacityDecreaseRequestsLimitExceededException>()(
     "CapacityDecreaseRequestsLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CapacityDecreaseRequestLimitExceeded",
@@ -150,7 +150,7 @@ export class CapacityDecreaseRequestsLimitExceededException
 export class CapacityReservationPendingException
   extends /*@__PURE__*/ S.TaggedErrorClass<CapacityReservationPendingException>()(
     "CapacityReservationPendingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CapacityReservationPending",
@@ -162,7 +162,7 @@ export class CapacityReservationPendingException
 export class CapacityUnitsLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<CapacityUnitsLimitExceededException>()(
     "CapacityUnitsLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CapacityUnitsLimitExceeded",
@@ -174,7 +174,7 @@ export class CapacityUnitsLimitExceededException
 export class CertificateNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<CertificateNotFoundException>()(
     "CertificateNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "CertificateNotFound", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -183,7 +183,7 @@ export class CertificateNotFoundException
 export class DeleteAssociationSameAccountException
   extends /*@__PURE__*/ S.TaggedErrorClass<DeleteAssociationSameAccountException>()(
     "DeleteAssociationSameAccountException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DeleteAssociationSameAccount",
@@ -195,7 +195,7 @@ export class DeleteAssociationSameAccountException
 export class DuplicateListenerException
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicateListenerException>()(
     "DuplicateListenerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "DuplicateListener", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -204,7 +204,7 @@ export class DuplicateListenerException
 export class DuplicateLoadBalancerNameException
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicateLoadBalancerNameException>()(
     "DuplicateLoadBalancerNameException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DuplicateLoadBalancerName",
@@ -216,7 +216,7 @@ export class DuplicateLoadBalancerNameException
 export class DuplicateTagKeysException
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicateTagKeysException>()(
     "DuplicateTagKeysException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "DuplicateTagKeys", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -225,7 +225,7 @@ export class DuplicateTagKeysException
 export class DuplicateTargetGroupNameException
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicateTargetGroupNameException>()(
     "DuplicateTargetGroupNameException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DuplicateTargetGroupName",
@@ -237,7 +237,7 @@ export class DuplicateTargetGroupNameException
 export class DuplicateTrustStoreNameException
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicateTrustStoreNameException>()(
     "DuplicateTrustStoreNameException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DuplicateTrustStoreName",
@@ -249,7 +249,7 @@ export class DuplicateTrustStoreNameException
 export class HealthUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<HealthUnavailableException>()(
     "HealthUnavailableException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "HealthUnavailable", httpResponseCode: 500 }),
       T.HttpError(500),
@@ -258,7 +258,7 @@ export class HealthUnavailableException
 export class IncompatibleProtocolsException
   extends /*@__PURE__*/ S.TaggedErrorClass<IncompatibleProtocolsException>()(
     "IncompatibleProtocolsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "IncompatibleProtocols", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -267,7 +267,7 @@ export class IncompatibleProtocolsException
 export class InsufficientCapacityException
   extends /*@__PURE__*/ S.TaggedErrorClass<InsufficientCapacityException>()(
     "InsufficientCapacityException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InsufficientCapacity", httpResponseCode: 500 }),
       T.HttpError(500),
@@ -276,7 +276,7 @@ export class InsufficientCapacityException
 export class InvalidCaCertificatesBundleException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCaCertificatesBundleException>()(
     "InvalidCaCertificatesBundleException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidCaCertificatesBundle",
@@ -288,7 +288,7 @@ export class InvalidCaCertificatesBundleException
 export class InvalidConfigurationRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidConfigurationRequestException>()(
     "InvalidConfigurationRequestException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidConfigurationRequest",
@@ -300,7 +300,7 @@ export class InvalidConfigurationRequestException
 export class InvalidLoadBalancerActionException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidLoadBalancerActionException>()(
     "InvalidLoadBalancerActionException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidLoadBalancerAction",
@@ -312,7 +312,7 @@ export class InvalidLoadBalancerActionException
 export class InvalidRevocationContentException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRevocationContentException>()(
     "InvalidRevocationContentException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidRevocationContent",
@@ -324,7 +324,7 @@ export class InvalidRevocationContentException
 export class InvalidSchemeException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSchemeException>()(
     "InvalidSchemeException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidScheme", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -333,7 +333,7 @@ export class InvalidSchemeException
 export class InvalidSecurityGroupException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSecurityGroupException>()(
     "InvalidSecurityGroupException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidSecurityGroup", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -342,7 +342,7 @@ export class InvalidSecurityGroupException
 export class InvalidSubnetException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSubnetException>()(
     "InvalidSubnetException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidSubnet", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -351,7 +351,7 @@ export class InvalidSubnetException
 export class InvalidTargetException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTargetException>()(
     "InvalidTargetException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidTarget", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -360,7 +360,7 @@ export class InvalidTargetException
 export class ListenerNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ListenerNotFoundException>()(
     "ListenerNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ListenerNotFound", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -369,7 +369,7 @@ export class ListenerNotFoundException
 export class LoadBalancerNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<LoadBalancerNotFoundException>()(
     "LoadBalancerNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "LoadBalancerNotFound", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -378,7 +378,7 @@ export class LoadBalancerNotFoundException
 export class OperationNotPermittedException
   extends /*@__PURE__*/ S.TaggedErrorClass<OperationNotPermittedException>()(
     "OperationNotPermittedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "OperationNotPermitted", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -387,7 +387,7 @@ export class OperationNotPermittedException
 export class PriorityInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<PriorityInUseException>()(
     "PriorityInUseException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "PriorityInUse", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -396,7 +396,7 @@ export class PriorityInUseException
 export class PriorRequestNotCompleteException
   extends /*@__PURE__*/ S.TaggedErrorClass<PriorRequestNotCompleteException>()(
     "PriorRequestNotCompleteException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "PriorRequestNotComplete",
@@ -408,7 +408,7 @@ export class PriorRequestNotCompleteException
 export class ResourceInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUseException>()(
     "ResourceInUseException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ResourceInUse", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -417,7 +417,7 @@ export class ResourceInUseException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ResourceNotFound", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -426,7 +426,7 @@ export class ResourceNotFoundException
 export class RevocationContentNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<RevocationContentNotFoundException>()(
     "RevocationContentNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "RevocationContentNotFound",
@@ -438,7 +438,7 @@ export class RevocationContentNotFoundException
 export class RevocationIdNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<RevocationIdNotFoundException>()(
     "RevocationIdNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "RevocationIdNotFound", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -447,7 +447,7 @@ export class RevocationIdNotFoundException
 export class RuleNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<RuleNotFoundException>()(
     "RuleNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "RuleNotFound", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -456,7 +456,7 @@ export class RuleNotFoundException
 export class SSLPolicyNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<SSLPolicyNotFoundException>()(
     "SSLPolicyNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SSLPolicyNotFound", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -465,7 +465,7 @@ export class SSLPolicyNotFoundException
 export class SubnetNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<SubnetNotFoundException>()(
     "SubnetNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SubnetNotFound", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -474,7 +474,7 @@ export class SubnetNotFoundException
 export class TargetGroupAssociationLimitException
   extends /*@__PURE__*/ S.TaggedErrorClass<TargetGroupAssociationLimitException>()(
     "TargetGroupAssociationLimitException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "TargetGroupAssociationLimit",
@@ -486,7 +486,7 @@ export class TargetGroupAssociationLimitException
 export class TargetGroupNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<TargetGroupNotFoundException>()(
     "TargetGroupNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "TargetGroupNotFound", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -495,7 +495,7 @@ export class TargetGroupNotFoundException
 export class TooManyActionsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyActionsException>()(
     "TooManyActionsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "TooManyActions", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -504,7 +504,7 @@ export class TooManyActionsException
 export class TooManyCertificatesException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyCertificatesException>()(
     "TooManyCertificatesException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "TooManyCertificates", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -513,7 +513,7 @@ export class TooManyCertificatesException
 export class TooManyListenersException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyListenersException>()(
     "TooManyListenersException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "TooManyListeners", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -522,7 +522,7 @@ export class TooManyListenersException
 export class TooManyLoadBalancersException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyLoadBalancersException>()(
     "TooManyLoadBalancersException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "TooManyLoadBalancers", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -531,7 +531,7 @@ export class TooManyLoadBalancersException
 export class TooManyRegistrationsForTargetIdException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRegistrationsForTargetIdException>()(
     "TooManyRegistrationsForTargetIdException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "TooManyRegistrationsForTargetId",
@@ -543,7 +543,7 @@ export class TooManyRegistrationsForTargetIdException
 export class TooManyRulesException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRulesException>()(
     "TooManyRulesException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "TooManyRules", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -552,7 +552,7 @@ export class TooManyRulesException
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "TooManyTags", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -561,7 +561,7 @@ export class TooManyTagsException
 export class TooManyTargetGroupsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTargetGroupsException>()(
     "TooManyTargetGroupsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "TooManyTargetGroups", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -570,7 +570,7 @@ export class TooManyTargetGroupsException
 export class TooManyTargetsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTargetsException>()(
     "TooManyTargetsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "TooManyTargets", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -579,7 +579,7 @@ export class TooManyTargetsException
 export class TooManyTrustStoreRevocationEntriesException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTrustStoreRevocationEntriesException>()(
     "TooManyTrustStoreRevocationEntriesException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "TooManyTrustStoreRevocationEntries",
@@ -591,7 +591,7 @@ export class TooManyTrustStoreRevocationEntriesException
 export class TooManyTrustStoresException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTrustStoresException>()(
     "TooManyTrustStoresException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "TooManyTrustStores", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -600,7 +600,7 @@ export class TooManyTrustStoresException
 export class TooManyUniqueTargetGroupsPerLoadBalancerException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyUniqueTargetGroupsPerLoadBalancerException>()(
     "TooManyUniqueTargetGroupsPerLoadBalancerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "TooManyUniqueTargetGroupsPerLoadBalancer",
@@ -612,7 +612,7 @@ export class TooManyUniqueTargetGroupsPerLoadBalancerException
 export class TrustStoreAssociationNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<TrustStoreAssociationNotFoundException>()(
     "TrustStoreAssociationNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "AssociationNotFound", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -621,7 +621,7 @@ export class TrustStoreAssociationNotFoundException
 export class TrustStoreInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<TrustStoreInUseException>()(
     "TrustStoreInUseException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "TrustStoreInUse", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -630,7 +630,7 @@ export class TrustStoreInUseException
 export class TrustStoreNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<TrustStoreNotFoundException>()(
     "TrustStoreNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "TrustStoreNotFound", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -639,7 +639,7 @@ export class TrustStoreNotFoundException
 export class TrustStoreNotReadyException
   extends /*@__PURE__*/ S.TaggedErrorClass<TrustStoreNotReadyException>()(
     "TrustStoreNotReadyException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "TrustStoreNotReady", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -648,7 +648,7 @@ export class TrustStoreNotReadyException
 export class UnsupportedProtocolException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedProtocolException>()(
     "UnsupportedProtocolException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "UnsupportedProtocol", httpResponseCode: 400 }),
       T.HttpError(400),

--- a/packages/aws/src/services/elastic-load-balancing.ts
+++ b/packages/aws/src/services/elastic-load-balancing.ts
@@ -94,7 +94,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessPointNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessPointNotFoundException>()(
     "AccessPointNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "LoadBalancerNotFound", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -103,7 +103,7 @@ export class AccessPointNotFoundException
 export class CertificateNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<CertificateNotFoundException>()(
     "CertificateNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "CertificateNotFound", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -112,7 +112,7 @@ export class CertificateNotFoundException
 export class DependencyThrottleException
   extends /*@__PURE__*/ S.TaggedErrorClass<DependencyThrottleException>()(
     "DependencyThrottleException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "DependencyThrottle", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -121,7 +121,7 @@ export class DependencyThrottleException
 export class DuplicateAccessPointNameException
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicateAccessPointNameException>()(
     "DuplicateAccessPointNameException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DuplicateLoadBalancerName",
@@ -133,7 +133,7 @@ export class DuplicateAccessPointNameException
 export class DuplicateListenerException
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicateListenerException>()(
     "DuplicateListenerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "DuplicateListener", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -142,7 +142,7 @@ export class DuplicateListenerException
 export class DuplicatePolicyNameException
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicatePolicyNameException>()(
     "DuplicatePolicyNameException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "DuplicatePolicyName", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -151,7 +151,7 @@ export class DuplicatePolicyNameException
 export class DuplicateTagKeysException
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicateTagKeysException>()(
     "DuplicateTagKeysException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "DuplicateTagKeys", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -160,7 +160,7 @@ export class DuplicateTagKeysException
 export class InvalidConfigurationRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidConfigurationRequestException>()(
     "InvalidConfigurationRequestException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidConfigurationRequest",
@@ -172,7 +172,7 @@ export class InvalidConfigurationRequestException
 export class InvalidEndPointException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidEndPointException>()(
     "InvalidEndPointException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidInstance", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -181,7 +181,7 @@ export class InvalidEndPointException
 export class InvalidSchemeException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSchemeException>()(
     "InvalidSchemeException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidScheme", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -190,7 +190,7 @@ export class InvalidSchemeException
 export class InvalidSecurityGroupException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSecurityGroupException>()(
     "InvalidSecurityGroupException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidSecurityGroup", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -199,7 +199,7 @@ export class InvalidSecurityGroupException
 export class InvalidSubnetException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSubnetException>()(
     "InvalidSubnetException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidSubnet", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -208,7 +208,7 @@ export class InvalidSubnetException
 export class ListenerNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ListenerNotFoundException>()(
     "ListenerNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ListenerNotFound", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -217,7 +217,7 @@ export class ListenerNotFoundException
 export class LoadBalancerAttributeNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<LoadBalancerAttributeNotFoundException>()(
     "LoadBalancerAttributeNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "LoadBalancerAttributeNotFound",
@@ -229,7 +229,7 @@ export class LoadBalancerAttributeNotFoundException
 export class OperationNotPermittedException
   extends /*@__PURE__*/ S.TaggedErrorClass<OperationNotPermittedException>()(
     "OperationNotPermittedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "OperationNotPermitted", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -238,7 +238,7 @@ export class OperationNotPermittedException
 export class PolicyNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<PolicyNotFoundException>()(
     "PolicyNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "PolicyNotFound", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -247,7 +247,7 @@ export class PolicyNotFoundException
 export class PolicyTypeNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<PolicyTypeNotFoundException>()(
     "PolicyTypeNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "PolicyTypeNotFound", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -256,7 +256,7 @@ export class PolicyTypeNotFoundException
 export class SubnetNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<SubnetNotFoundException>()(
     "SubnetNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SubnetNotFound", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -265,7 +265,7 @@ export class SubnetNotFoundException
 export class TooManyAccessPointsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyAccessPointsException>()(
     "TooManyAccessPointsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "TooManyLoadBalancers", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -274,7 +274,7 @@ export class TooManyAccessPointsException
 export class TooManyPoliciesException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyPoliciesException>()(
     "TooManyPoliciesException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "TooManyPolicies", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -283,7 +283,7 @@ export class TooManyPoliciesException
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "TooManyTags", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -292,7 +292,7 @@ export class TooManyTagsException
 export class UnsupportedProtocolException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedProtocolException>()(
     "UnsupportedProtocolException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "UnsupportedProtocol", httpResponseCode: 400 }),
       T.HttpError(400),

--- a/packages/aws/src/services/elasticache.ts
+++ b/packages/aws/src/services/elasticache.ts
@@ -94,7 +94,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class APICallRateForCustomerExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<APICallRateForCustomerExceededFault>()(
     "APICallRateForCustomerExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "APICallRateForCustomerExceeded",
@@ -106,7 +106,7 @@ export class APICallRateForCustomerExceededFault
 export class AuthorizationAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<AuthorizationAlreadyExistsFault>()(
     "AuthorizationAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "AuthorizationAlreadyExists",
@@ -118,7 +118,7 @@ export class AuthorizationAlreadyExistsFault
 export class AuthorizationNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<AuthorizationNotFoundFault>()(
     "AuthorizationNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "AuthorizationNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -127,7 +127,7 @@ export class AuthorizationNotFoundFault
 export class CacheClusterAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<CacheClusterAlreadyExistsFault>()(
     "CacheClusterAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CacheClusterAlreadyExists",
@@ -139,7 +139,7 @@ export class CacheClusterAlreadyExistsFault
 export class CacheClusterNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<CacheClusterNotFoundFault>()(
     "CacheClusterNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "CacheClusterNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -148,7 +148,7 @@ export class CacheClusterNotFoundFault
 export class CacheParameterGroupAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<CacheParameterGroupAlreadyExistsFault>()(
     "CacheParameterGroupAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CacheParameterGroupAlreadyExists",
@@ -160,7 +160,7 @@ export class CacheParameterGroupAlreadyExistsFault
 export class CacheParameterGroupNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<CacheParameterGroupNotFoundFault>()(
     "CacheParameterGroupNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CacheParameterGroupNotFound",
@@ -172,7 +172,7 @@ export class CacheParameterGroupNotFoundFault
 export class CacheParameterGroupQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<CacheParameterGroupQuotaExceededFault>()(
     "CacheParameterGroupQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CacheParameterGroupQuotaExceeded",
@@ -184,7 +184,7 @@ export class CacheParameterGroupQuotaExceededFault
 export class CacheSecurityGroupAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<CacheSecurityGroupAlreadyExistsFault>()(
     "CacheSecurityGroupAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CacheSecurityGroupAlreadyExists",
@@ -196,7 +196,7 @@ export class CacheSecurityGroupAlreadyExistsFault
 export class CacheSecurityGroupNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<CacheSecurityGroupNotFoundFault>()(
     "CacheSecurityGroupNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CacheSecurityGroupNotFound",
@@ -208,7 +208,7 @@ export class CacheSecurityGroupNotFoundFault
 export class CacheSecurityGroupQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<CacheSecurityGroupQuotaExceededFault>()(
     "CacheSecurityGroupQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "QuotaExceeded.CacheSecurityGroup",
@@ -220,7 +220,7 @@ export class CacheSecurityGroupQuotaExceededFault
 export class CacheSubnetGroupAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<CacheSubnetGroupAlreadyExistsFault>()(
     "CacheSubnetGroupAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CacheSubnetGroupAlreadyExists",
@@ -232,7 +232,7 @@ export class CacheSubnetGroupAlreadyExistsFault
 export class CacheSubnetGroupInUse
   extends /*@__PURE__*/ S.TaggedErrorClass<CacheSubnetGroupInUse>()(
     "CacheSubnetGroupInUse",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "CacheSubnetGroupInUse", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -241,7 +241,7 @@ export class CacheSubnetGroupInUse
 export class CacheSubnetGroupNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<CacheSubnetGroupNotFoundFault>()(
     "CacheSubnetGroupNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CacheSubnetGroupNotFoundFault",
@@ -253,7 +253,7 @@ export class CacheSubnetGroupNotFoundFault
 export class CacheSubnetGroupQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<CacheSubnetGroupQuotaExceededFault>()(
     "CacheSubnetGroupQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CacheSubnetGroupQuotaExceeded",
@@ -265,7 +265,7 @@ export class CacheSubnetGroupQuotaExceededFault
 export class CacheSubnetQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<CacheSubnetQuotaExceededFault>()(
     "CacheSubnetQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CacheSubnetQuotaExceededFault",
@@ -277,7 +277,7 @@ export class CacheSubnetQuotaExceededFault
 export class ClusterQuotaForCustomerExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ClusterQuotaForCustomerExceededFault>()(
     "ClusterQuotaForCustomerExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ClusterQuotaForCustomerExceeded",
@@ -289,7 +289,7 @@ export class ClusterQuotaForCustomerExceededFault
 export class DefaultUserAssociatedToUserGroupFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DefaultUserAssociatedToUserGroupFault>()(
     "DefaultUserAssociatedToUserGroupFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DefaultUserAssociatedToUserGroup",
@@ -301,7 +301,7 @@ export class DefaultUserAssociatedToUserGroupFault
 export class DefaultUserRequired
   extends /*@__PURE__*/ S.TaggedErrorClass<DefaultUserRequired>()(
     "DefaultUserRequired",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "DefaultUserRequired", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -310,7 +310,7 @@ export class DefaultUserRequired
 export class DuplicateUserNameFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicateUserNameFault>()(
     "DuplicateUserNameFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "DuplicateUserName", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -319,7 +319,7 @@ export class DuplicateUserNameFault
 export class GlobalReplicationGroupAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<GlobalReplicationGroupAlreadyExistsFault>()(
     "GlobalReplicationGroupAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "GlobalReplicationGroupAlreadyExistsFault",
@@ -331,7 +331,7 @@ export class GlobalReplicationGroupAlreadyExistsFault
 export class GlobalReplicationGroupNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<GlobalReplicationGroupNotFoundFault>()(
     "GlobalReplicationGroupNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "GlobalReplicationGroupNotFoundFault",
@@ -343,7 +343,7 @@ export class GlobalReplicationGroupNotFoundFault
 export class InsufficientCacheClusterCapacityFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InsufficientCacheClusterCapacityFault>()(
     "InsufficientCacheClusterCapacityFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InsufficientCacheClusterCapacity",
@@ -355,7 +355,7 @@ export class InsufficientCacheClusterCapacityFault
 export class InvalidARNFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidARNFault>()(
     "InvalidARNFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidARN", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -364,7 +364,7 @@ export class InvalidARNFault
 export class InvalidCacheClusterStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCacheClusterStateFault>()(
     "InvalidCacheClusterStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidCacheClusterState",
@@ -376,7 +376,7 @@ export class InvalidCacheClusterStateFault
 export class InvalidCacheParameterGroupStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCacheParameterGroupStateFault>()(
     "InvalidCacheParameterGroupStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidCacheParameterGroupState",
@@ -388,7 +388,7 @@ export class InvalidCacheParameterGroupStateFault
 export class InvalidCacheSecurityGroupStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCacheSecurityGroupStateFault>()(
     "InvalidCacheSecurityGroupStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidCacheSecurityGroupState",
@@ -400,7 +400,7 @@ export class InvalidCacheSecurityGroupStateFault
 export class InvalidCredentialsException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCredentialsException>()(
     "InvalidCredentialsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidCredentialsException",
@@ -412,7 +412,7 @@ export class InvalidCredentialsException
 export class InvalidGlobalReplicationGroupStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidGlobalReplicationGroupStateFault>()(
     "InvalidGlobalReplicationGroupStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidGlobalReplicationGroupState",
@@ -424,7 +424,7 @@ export class InvalidGlobalReplicationGroupStateFault
 export class InvalidKMSKeyFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidKMSKeyFault>()(
     "InvalidKMSKeyFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidKMSKeyFault", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -433,7 +433,7 @@ export class InvalidKMSKeyFault
 export class InvalidParameterCombinationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterCombinationException>()(
     "InvalidParameterCombinationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidParameterCombination",
@@ -445,7 +445,7 @@ export class InvalidParameterCombinationException
 export class InvalidParameterValueException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterValueException>()(
     "InvalidParameterValueException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidParameterValue", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -454,7 +454,7 @@ export class InvalidParameterValueException
 export class InvalidReplicationGroupStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidReplicationGroupStateFault>()(
     "InvalidReplicationGroupStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidReplicationGroupState",
@@ -466,7 +466,7 @@ export class InvalidReplicationGroupStateFault
 export class InvalidServerlessCacheSnapshotStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidServerlessCacheSnapshotStateFault>()(
     "InvalidServerlessCacheSnapshotStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidServerlessCacheSnapshotStateFault",
@@ -478,7 +478,7 @@ export class InvalidServerlessCacheSnapshotStateFault
 export class InvalidServerlessCacheStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidServerlessCacheStateFault>()(
     "InvalidServerlessCacheStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidServerlessCacheStateFault",
@@ -490,7 +490,7 @@ export class InvalidServerlessCacheStateFault
 export class InvalidSnapshotStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSnapshotStateFault>()(
     "InvalidSnapshotStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidSnapshotState", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -499,7 +499,7 @@ export class InvalidSnapshotStateFault
 export class InvalidSubnet
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSubnet>()(
     "InvalidSubnet",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidSubnet", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -508,7 +508,7 @@ export class InvalidSubnet
 export class InvalidUserGroupStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidUserGroupStateFault>()(
     "InvalidUserGroupStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidUserGroupState", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -517,7 +517,7 @@ export class InvalidUserGroupStateFault
 export class InvalidUserStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidUserStateFault>()(
     "InvalidUserStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidUserState", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -526,7 +526,7 @@ export class InvalidUserStateFault
 export class InvalidVPCNetworkStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidVPCNetworkStateFault>()(
     "InvalidVPCNetworkStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidVPCNetworkStateFault",
@@ -538,7 +538,7 @@ export class InvalidVPCNetworkStateFault
 export class NodeGroupNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<NodeGroupNotFoundFault>()(
     "NodeGroupNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "NodeGroupNotFoundFault",
@@ -550,7 +550,7 @@ export class NodeGroupNotFoundFault
 export class NodeGroupsPerReplicationGroupQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<NodeGroupsPerReplicationGroupQuotaExceededFault>()(
     "NodeGroupsPerReplicationGroupQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "NodeGroupsPerReplicationGroupQuotaExceeded",
@@ -562,7 +562,7 @@ export class NodeGroupsPerReplicationGroupQuotaExceededFault
 export class NodeQuotaForClusterExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<NodeQuotaForClusterExceededFault>()(
     "NodeQuotaForClusterExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "NodeQuotaForClusterExceeded",
@@ -574,7 +574,7 @@ export class NodeQuotaForClusterExceededFault
 export class NodeQuotaForCustomerExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<NodeQuotaForCustomerExceededFault>()(
     "NodeQuotaForCustomerExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "NodeQuotaForCustomerExceeded",
@@ -586,7 +586,7 @@ export class NodeQuotaForCustomerExceededFault
 export class NoOperationFault
   extends /*@__PURE__*/ S.TaggedErrorClass<NoOperationFault>()(
     "NoOperationFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "NoOperationFault", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -595,7 +595,7 @@ export class NoOperationFault
 export class ReplicationGroupAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ReplicationGroupAlreadyExistsFault>()(
     "ReplicationGroupAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ReplicationGroupAlreadyExists",
@@ -607,7 +607,7 @@ export class ReplicationGroupAlreadyExistsFault
 export class ReplicationGroupAlreadyUnderMigrationFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ReplicationGroupAlreadyUnderMigrationFault>()(
     "ReplicationGroupAlreadyUnderMigrationFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ReplicationGroupAlreadyUnderMigrationFault",
@@ -619,7 +619,7 @@ export class ReplicationGroupAlreadyUnderMigrationFault
 export class ReplicationGroupNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ReplicationGroupNotFoundFault>()(
     "ReplicationGroupNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ReplicationGroupNotFoundFault",
@@ -631,7 +631,7 @@ export class ReplicationGroupNotFoundFault
 export class ReplicationGroupNotUnderMigrationFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ReplicationGroupNotUnderMigrationFault>()(
     "ReplicationGroupNotUnderMigrationFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ReplicationGroupNotUnderMigrationFault",
@@ -643,7 +643,7 @@ export class ReplicationGroupNotUnderMigrationFault
 export class ReservedCacheNodeAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ReservedCacheNodeAlreadyExistsFault>()(
     "ReservedCacheNodeAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ReservedCacheNodeAlreadyExists",
@@ -655,7 +655,7 @@ export class ReservedCacheNodeAlreadyExistsFault
 export class ReservedCacheNodeNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ReservedCacheNodeNotFoundFault>()(
     "ReservedCacheNodeNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ReservedCacheNodeNotFound",
@@ -667,7 +667,7 @@ export class ReservedCacheNodeNotFoundFault
 export class ReservedCacheNodeQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ReservedCacheNodeQuotaExceededFault>()(
     "ReservedCacheNodeQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ReservedCacheNodeQuotaExceeded",
@@ -679,7 +679,7 @@ export class ReservedCacheNodeQuotaExceededFault
 export class ReservedCacheNodesOfferingNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ReservedCacheNodesOfferingNotFoundFault>()(
     "ReservedCacheNodesOfferingNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ReservedCacheNodesOfferingNotFound",
@@ -691,7 +691,7 @@ export class ReservedCacheNodesOfferingNotFoundFault
 export class ServerlessCacheAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ServerlessCacheAlreadyExistsFault>()(
     "ServerlessCacheAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ServerlessCacheAlreadyExistsFault",
@@ -703,7 +703,7 @@ export class ServerlessCacheAlreadyExistsFault
 export class ServerlessCacheNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ServerlessCacheNotFoundFault>()(
     "ServerlessCacheNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ServerlessCacheNotFoundFault",
@@ -715,7 +715,7 @@ export class ServerlessCacheNotFoundFault
 export class ServerlessCacheQuotaForCustomerExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ServerlessCacheQuotaForCustomerExceededFault>()(
     "ServerlessCacheQuotaForCustomerExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ServerlessCacheQuotaForCustomerExceededFault",
@@ -727,7 +727,7 @@ export class ServerlessCacheQuotaForCustomerExceededFault
 export class ServerlessCacheSnapshotAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ServerlessCacheSnapshotAlreadyExistsFault>()(
     "ServerlessCacheSnapshotAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ServerlessCacheSnapshotAlreadyExistsFault",
@@ -739,7 +739,7 @@ export class ServerlessCacheSnapshotAlreadyExistsFault
 export class ServerlessCacheSnapshotNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ServerlessCacheSnapshotNotFoundFault>()(
     "ServerlessCacheSnapshotNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ServerlessCacheSnapshotNotFoundFault",
@@ -751,7 +751,7 @@ export class ServerlessCacheSnapshotNotFoundFault
 export class ServerlessCacheSnapshotQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ServerlessCacheSnapshotQuotaExceededFault>()(
     "ServerlessCacheSnapshotQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ServerlessCacheSnapshotQuotaExceededFault",
@@ -763,7 +763,7 @@ export class ServerlessCacheSnapshotQuotaExceededFault
 export class ServiceLinkedRoleNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceLinkedRoleNotFoundFault>()(
     "ServiceLinkedRoleNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ServiceLinkedRoleNotFoundFault",
@@ -775,7 +775,7 @@ export class ServiceLinkedRoleNotFoundFault
 export class ServiceUpdateNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUpdateNotFoundFault>()(
     "ServiceUpdateNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ServiceUpdateNotFoundFault",
@@ -787,7 +787,7 @@ export class ServiceUpdateNotFoundFault
 export class SnapshotAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SnapshotAlreadyExistsFault>()(
     "SnapshotAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SnapshotAlreadyExistsFault",
@@ -799,7 +799,7 @@ export class SnapshotAlreadyExistsFault
 export class SnapshotFeatureNotSupportedFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SnapshotFeatureNotSupportedFault>()(
     "SnapshotFeatureNotSupportedFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SnapshotFeatureNotSupportedFault",
@@ -811,7 +811,7 @@ export class SnapshotFeatureNotSupportedFault
 export class SnapshotNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SnapshotNotFoundFault>()(
     "SnapshotNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SnapshotNotFoundFault", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -820,7 +820,7 @@ export class SnapshotNotFoundFault
 export class SnapshotQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SnapshotQuotaExceededFault>()(
     "SnapshotQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SnapshotQuotaExceededFault",
@@ -832,7 +832,7 @@ export class SnapshotQuotaExceededFault
 export class SubnetInUse
   extends /*@__PURE__*/ S.TaggedErrorClass<SubnetInUse>()(
     "SubnetInUse",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SubnetInUse", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -841,7 +841,7 @@ export class SubnetInUse
 export class SubnetNotAllowedFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SubnetNotAllowedFault>()(
     "SubnetNotAllowedFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SubnetNotAllowedFault", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -850,7 +850,7 @@ export class SubnetNotAllowedFault
 export class TagNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<TagNotFoundFault>()(
     "TagNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "TagNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -859,7 +859,7 @@ export class TagNotFoundFault
 export class TagQuotaPerResourceExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<TagQuotaPerResourceExceeded>()(
     "TagQuotaPerResourceExceeded",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "TagQuotaPerResourceExceeded",
@@ -871,7 +871,7 @@ export class TagQuotaPerResourceExceeded
 export class TestFailoverNotAvailableFault
   extends /*@__PURE__*/ S.TaggedErrorClass<TestFailoverNotAvailableFault>()(
     "TestFailoverNotAvailableFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "TestFailoverNotAvailableFault",
@@ -883,7 +883,7 @@ export class TestFailoverNotAvailableFault
 export class UserAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<UserAlreadyExistsFault>()(
     "UserAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "UserAlreadyExists", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -892,7 +892,7 @@ export class UserAlreadyExistsFault
 export class UserGroupAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<UserGroupAlreadyExistsFault>()(
     "UserGroupAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "UserGroupAlreadyExists",
@@ -904,7 +904,7 @@ export class UserGroupAlreadyExistsFault
 export class UserGroupNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<UserGroupNotFoundFault>()(
     "UserGroupNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "UserGroupNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -913,7 +913,7 @@ export class UserGroupNotFoundFault
 export class UserGroupQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<UserGroupQuotaExceededFault>()(
     "UserGroupQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "UserGroupQuotaExceeded",
@@ -925,7 +925,7 @@ export class UserGroupQuotaExceededFault
 export class UserNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<UserNotFoundFault>()(
     "UserNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "UserNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -934,7 +934,7 @@ export class UserNotFoundFault
 export class UserQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<UserQuotaExceededFault>()(
     "UserQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "UserQuotaExceeded", httpResponseCode: 400 }),
       T.HttpError(400),

--- a/packages/aws/src/services/elasticsearch-service.ts
+++ b/packages/aws/src/services/elasticsearch-service.ts
@@ -100,65 +100,65 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class BaseException
   extends /*@__PURE__*/ S.TaggedErrorClass<BaseException>()("BaseException", {
-    message: S.optional(S.String),
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
   }) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class DisabledOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<DisabledOperationException>()(
     "DisabledOperationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalException>()(
     "InternalException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidPaginationTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPaginationTokenException>()(
     "InvalidPaginationTokenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidTypeException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTypeException>()(
     "InvalidTypeException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ResourceAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceAlreadyExistsException>()(
     "ResourceAlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type CrossClusterSearchConnectionId = string;

--- a/packages/aws/src/services/elementalinference.ts
+++ b/packages/aws/src/services/elementalinference.ts
@@ -88,43 +88,43 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(409), T.Retryable()),
   ).pipe(C.withConflictError, C.withRetryableError) {}
 export class InternalServerErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerErrorException>()(
     "InternalServerErrorException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class TooManyRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestException>()(
     "TooManyRequestException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(429), T.Retryable()),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type FeedId = string;

--- a/packages/aws/src/services/emr-containers.ts
+++ b/packages/aws/src/services/emr-containers.ts
@@ -96,19 +96,19 @@ const rules = T.EndpointResolver((p, _) => {
 export class EKSRequestThrottledException
   extends /*@__PURE__*/ S.TaggedErrorClass<EKSRequestThrottledException>()(
     "EKSRequestThrottledException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidResourceArn
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidResourceArn>()(
     "InvalidResourceArn",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "BadRequestException",
       message: { includes: "Invalid input resource arn" },
@@ -117,24 +117,24 @@ export class InvalidResourceArn
 export class RequestThrottledException
   extends /*@__PURE__*/ S.TaggedErrorClass<RequestThrottledException>()(
     "RequestThrottledException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type ResourceIdString = string;

--- a/packages/aws/src/services/emr-serverless.ts
+++ b/packages/aws/src/services/emr-serverless.ts
@@ -90,31 +90,31 @@ const rules = T.EndpointResolver((p, _) => {
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type ApplicationId = string;

--- a/packages/aws/src/services/emr.ts
+++ b/packages/aws/src/services/emr.ts
@@ -96,7 +96,10 @@ const rules = T.EndpointResolver((p, _) => {
 export class ClusterNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<ClusterNotFound>()(
     "ClusterNotFound",
-    { ErrorCode: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      ErrorCode: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.SyntheticError({
       from: "InvalidRequestException",
       message: { matches: "^Cluster id .* is not valid" },
@@ -105,7 +108,7 @@ export class ClusterNotFound
 export class InternalServerError
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerError>()(
     "InternalServerError",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InternalFailure", httpResponseCode: 500 }),
       T.HttpError(500),
@@ -114,17 +117,20 @@ export class InternalServerError
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
-    { ErrorCode: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      ErrorCode: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
   ) {}
 export class JobFlowNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<JobFlowNotFound>()(
     "JobFlowNotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "ValidationException",
       message: { includes: "Specified job flow ID not valid" },
@@ -133,7 +139,10 @@ export class JobFlowNotFound
 export class SecurityConfigurationAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<SecurityConfigurationAlreadyExists>()(
     "SecurityConfigurationAlreadyExists",
-    { ErrorCode: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      ErrorCode: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.SyntheticError({
       from: "InvalidRequestException",
       message: {
@@ -144,7 +153,10 @@ export class SecurityConfigurationAlreadyExists
 export class SecurityConfigurationNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<SecurityConfigurationNotFound>()(
     "SecurityConfigurationNotFound",
-    { ErrorCode: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      ErrorCode: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.SyntheticError({
       from: "InvalidRequestException",
       message: {
@@ -155,7 +167,10 @@ export class SecurityConfigurationNotFound
 export class StudioNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<StudioNotFound>()(
     "StudioNotFound",
-    { ErrorCode: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      ErrorCode: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.SyntheticError({
       from: "InvalidRequestException",
       message: { includes: "Studio does not exist" },
@@ -164,7 +179,10 @@ export class StudioNotFound
 export class StudioServiceRoleMissingS3Access
   extends /*@__PURE__*/ S.TaggedErrorClass<StudioServiceRoleMissingS3Access>()(
     "StudioServiceRoleMissingS3Access",
-    { ErrorCode: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      ErrorCode: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.SyntheticError({
       from: "InvalidRequestException",
       message: {
@@ -175,7 +193,10 @@ export class StudioServiceRoleMissingS3Access
 export class StudioServiceRoleNotAssumable
   extends /*@__PURE__*/ S.TaggedErrorClass<StudioServiceRoleNotAssumable>()(
     "StudioServiceRoleNotAssumable",
-    { ErrorCode: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      ErrorCode: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.SyntheticError({
       from: "InvalidRequestException",
       message: { includes: "does not have permissions to assume role" },

--- a/packages/aws/src/services/entityresolution.ts
+++ b/packages/aws/src/services/entityresolution.ts
@@ -88,20 +88,20 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ExceedsLimitException
   extends /*@__PURE__*/ S.TaggedErrorClass<ExceedsLimitException>()(
     "ExceedsLimitException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       quotaName: S.optional(S.String),
       quotaValue: S.optional(S.Number),
     },
@@ -110,25 +110,25 @@ export class ExceedsLimitException
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(429), T.Retryable({ throttling: true })),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type VeniceGlobalArn = string;

--- a/packages/aws/src/services/eventbridge.ts
+++ b/packages/aws/src/services/eventbridge.ts
@@ -161,17 +161,17 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAuthError) {}
 export class ConcurrentModificationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentModificationException>()(
     "ConcurrentModificationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withConflictError, C.withRetryableError) {}
 export class EventBusHasRules
   extends /*@__PURE__*/ S.TaggedErrorClass<EventBusHasRules>()(
     "EventBusHasRules",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "ValidationException",
       message: { includes: "has rules" },
@@ -180,57 +180,57 @@ export class EventBusHasRules
 export class IllegalStatusException
   extends /*@__PURE__*/ S.TaggedErrorClass<IllegalStatusException>()(
     "IllegalStatusException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withConflictError) {}
 export class InternalException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalException>()(
     "InternalException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class InvalidEventPatternException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidEventPatternException>()(
     "InvalidEventPatternException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class InvalidStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidStateException>()(
     "InvalidStateException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withConflictError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withQuotaError) {}
 export class ManagedRuleException
   extends /*@__PURE__*/ S.TaggedErrorClass<ManagedRuleException>()(
     "ManagedRuleException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class OperationDisabledException
   extends /*@__PURE__*/ S.TaggedErrorClass<OperationDisabledException>()(
     "OperationDisabledException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class PolicyLengthExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<PolicyLengthExceededException>()(
     "PolicyLengthExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withQuotaError) {}
 export class ResourceAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceAlreadyExistsException>()(
     "ResourceAlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export type EventSourceName = string;
 export interface ActivateEventSourceRequest {

--- a/packages/aws/src/services/evs.ts
+++ b/packages/aws/src/services/evs.ts
@@ -90,32 +90,36 @@ const rules = T.EndpointResolver((p, _) => {
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class TagPolicyException
   extends /*@__PURE__*/ S.TaggedErrorClass<TagPolicyException>()(
     "TagPolicyException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.all(T.HttpError(429), T.Retryable()),
@@ -123,14 +127,14 @@ export class ThrottlingException
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.suspend(() => ValidationExceptionReason).annotate({
         identifier: "ValidationExceptionReason",
       }),

--- a/packages/aws/src/services/finspace-data.ts
+++ b/packages/aws/src/services/finspace-data.ts
@@ -90,43 +90,52 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String), reason: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      reason: S.optional(S.String),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String), reason: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      reason: S.optional(S.String),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String), reason: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      reason: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type PermissionGroupId = string;

--- a/packages/aws/src/services/finspace.ts
+++ b/packages/aws/src/services/finspace.ts
@@ -90,61 +90,64 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String), reason: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      reason: S.optional(S.String),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceAlreadyExistsException>()(
     "ResourceAlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type EnvironmentName = string;

--- a/packages/aws/src/services/firehose.ts
+++ b/packages/aws/src/services/firehose.ts
@@ -90,42 +90,48 @@ const rules = T.EndpointResolver((p, _) => {
 export class ConcurrentModificationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentModificationException>()(
     "ConcurrentModificationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidArgumentException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidArgumentException>()(
     "InvalidArgumentException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidKMSResourceException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidKMSResourceException>()(
     "InvalidKMSResourceException",
-    { code: S.optional(S.String), message: S.optional(S.String) },
+    {
+      code: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
   ) {}
 export class InvalidSourceException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSourceException>()(
     "InvalidSourceException",
-    { code: S.optional(S.String), message: S.optional(S.String) },
+    {
+      code: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
   ) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUseException>()(
     "ResourceInUseException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export type DeliveryStreamName = string;

--- a/packages/aws/src/services/fis.ts
+++ b/packages/aws/src/services/fis.ts
@@ -91,7 +91,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ConflictException", httpResponseCode: 409 }),
       T.HttpError(409),
@@ -100,7 +100,7 @@ export class ConflictException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ResourceNotFoundException",
@@ -112,7 +112,7 @@ export class ResourceNotFoundException
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ServiceQuotaExceededException",
@@ -124,7 +124,7 @@ export class ServiceQuotaExceededException
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ValidationException", httpResponseCode: 400 }),
       T.HttpError(400),

--- a/packages/aws/src/services/fms.ts
+++ b/packages/aws/src/services/fms.ts
@@ -88,32 +88,32 @@ const rules = T.EndpointResolver((p, _) => {
 export class InternalErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalErrorException>()(
     "InternalErrorException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withServerError) {}
 export class InvalidInputException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInputException>()(
     "InvalidInputException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidOperationException>()(
     "InvalidOperationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTypeException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTypeException>()(
     "InvalidTypeException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type AWSAccountId = string;
 export interface AssociateAdminAccountRequest {

--- a/packages/aws/src/services/forecast.ts
+++ b/packages/aws/src/services/forecast.ts
@@ -90,37 +90,37 @@ const rules = T.EndpointResolver((p, _) => {
 export class InvalidInputException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInputException>()(
     "InvalidInputException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidNextTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNextTokenException>()(
     "InvalidNextTokenException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ResourceAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceAlreadyExistsException>()(
     "ResourceAlreadyExistsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError, C.withAlreadyExistsError) {}
 export class ResourceInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUseException>()(
     "ResourceInUseException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export type Name = string;

--- a/packages/aws/src/services/forecastquery.ts
+++ b/packages/aws/src/services/forecastquery.ts
@@ -87,31 +87,31 @@ const rules = T.EndpointResolver((p, _) => {
 export class InvalidInputException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInputException>()(
     "InvalidInputException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidNextTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNextTokenException>()(
     "InvalidNextTokenException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ResourceInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUseException>()(
     "ResourceInUseException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export type Arn = string;

--- a/packages/aws/src/services/frauddetector.ts
+++ b/packages/aws/src/services/frauddetector.ts
@@ -91,43 +91,43 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ResourceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceUnavailableException>()(
     "ResourceUnavailableException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export interface VariableEntry {

--- a/packages/aws/src/services/freetier.ts
+++ b/packages/aws/src/services/freetier.ts
@@ -121,31 +121,31 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type ActivityId = string;

--- a/packages/aws/src/services/fsx.ts
+++ b/packages/aws/src/services/fsx.ts
@@ -90,7 +90,10 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessPointAlreadyOwnedByYou
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessPointAlreadyOwnedByYou>()(
     "AccessPointAlreadyOwnedByYou",
-    { ErrorCode: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      ErrorCode: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ActiveDirectoryError
@@ -103,108 +106,120 @@ export class ActiveDirectoryError
           identifier: "ActiveDirectoryErrorType",
         }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
   ) {}
 export class BackupBeingCopied
   extends /*@__PURE__*/ S.TaggedErrorClass<BackupBeingCopied>()(
     "BackupBeingCopied",
-    { Message: S.optional(S.String), BackupId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      BackupId: S.optional(S.String),
+    },
   ) {}
 export class BackupInProgress
   extends /*@__PURE__*/ S.TaggedErrorClass<BackupInProgress>()(
     "BackupInProgress",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class BackupNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<BackupNotFound>()("BackupNotFound", {
-    Message: S.optional(S.String),
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
   }) {}
 export class BackupRestoring
   extends /*@__PURE__*/ S.TaggedErrorClass<BackupRestoring>()(
     "BackupRestoring",
-    { Message: S.optional(S.String), FileSystemId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      FileSystemId: S.optional(S.String),
+    },
   ) {}
 export class BadRequest
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequest>()("BadRequest", {
-    Message: S.optional(S.String),
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
   }) {}
 export class DataRepositoryAssociationNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<DataRepositoryAssociationNotFound>()(
     "DataRepositoryAssociationNotFound",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class DataRepositoryTaskEnded
   extends /*@__PURE__*/ S.TaggedErrorClass<DataRepositoryTaskEnded>()(
     "DataRepositoryTaskEnded",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class DataRepositoryTaskExecuting
   extends /*@__PURE__*/ S.TaggedErrorClass<DataRepositoryTaskExecuting>()(
     "DataRepositoryTaskExecuting",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class DataRepositoryTaskNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<DataRepositoryTaskNotFound>()(
     "DataRepositoryTaskNotFound",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class FileCacheNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<FileCacheNotFound>()(
     "FileCacheNotFound",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class FileSystemNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<FileSystemNotFound>()(
     "FileSystemNotFound",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class IncompatibleParameterError
   extends /*@__PURE__*/ S.TaggedErrorClass<IncompatibleParameterError>()(
     "IncompatibleParameterError",
-    { Parameter: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Parameter: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
   ) {}
 export class IncompatibleRegionForMultiAZ
   extends /*@__PURE__*/ S.TaggedErrorClass<IncompatibleRegionForMultiAZ>()(
     "IncompatibleRegionForMultiAZ",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InternalServerError
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerError>()(
     "InternalServerError",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidAccessPoint
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidAccessPoint>()(
     "InvalidAccessPoint",
-    { ErrorCode: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      ErrorCode: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidDataRepositoryType
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDataRepositoryType>()(
     "InvalidDataRepositoryType",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidDestinationKmsKey
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDestinationKmsKey>()(
     "InvalidDestinationKmsKey",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidExportPath
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidExportPath>()(
     "InvalidExportPath",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidImportPath
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidImportPath>()(
     "InvalidImportPath",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidNetworkSettings
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNetworkSettings>()(
     "InvalidNetworkSettings",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       InvalidSubnetId: S.optional(S.String),
       InvalidSecurityGroupId: S.optional(S.String),
       InvalidRouteTableId: S.optional(S.String),
@@ -213,57 +228,69 @@ export class InvalidNetworkSettings
 export class InvalidPerUnitStorageThroughput
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPerUnitStorageThroughput>()(
     "InvalidPerUnitStorageThroughput",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRegion
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRegion>()("InvalidRegion", {
-    Message: S.optional(S.String),
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
   }) {}
 export class InvalidRequest
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequest>()(
     "InvalidRequest",
-    { ErrorCode: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      ErrorCode: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidSourceKmsKey
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSourceKmsKey>()(
     "InvalidSourceKmsKey",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MissingFileCacheConfiguration
   extends /*@__PURE__*/ S.TaggedErrorClass<MissingFileCacheConfiguration>()(
     "MissingFileCacheConfiguration",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MissingFileSystemConfiguration
   extends /*@__PURE__*/ S.TaggedErrorClass<MissingFileSystemConfiguration>()(
     "MissingFileSystemConfiguration",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MissingVolumeConfiguration
   extends /*@__PURE__*/ S.TaggedErrorClass<MissingVolumeConfiguration>()(
     "MissingVolumeConfiguration",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NotServiceResourceError
   extends /*@__PURE__*/ S.TaggedErrorClass<NotServiceResourceError>()(
     "NotServiceResourceError",
-    { ResourceARN: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      ResourceARN: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
   ) {}
 export class ResourceDoesNotSupportTagging
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceDoesNotSupportTagging>()(
     "ResourceDoesNotSupportTagging",
-    { ResourceARN: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      ResourceARN: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
   ) {}
 export class ResourceNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFound>()(
     "ResourceNotFound",
-    { ResourceARN: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      ResourceARN: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
   ) {}
 export class RestoreSnapshotNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<RestoreSnapshotNotFound>()(
     "RestoreSnapshotNotFound",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "BadRequest",
       message: { includes: "snapshot cannot be found" },
@@ -272,7 +299,7 @@ export class RestoreSnapshotNotFound
 export class S3AccessPointAttachmentNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<S3AccessPointAttachmentNotFound>()(
     "S3AccessPointAttachmentNotFound",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ServiceLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceLimitExceeded>()(
@@ -281,18 +308,18 @@ export class ServiceLimitExceeded
       Limit: S.optional(
         S.suspend(() => ServiceLimit).annotate({ identifier: "ServiceLimit" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
   ).pipe(C.withThrottlingError) {}
 export class SnapshotNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<SnapshotNotFound>()(
     "SnapshotNotFound",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class SnapshotVolumeNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<SnapshotVolumeNotFound>()(
     "SnapshotVolumeNotFound",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "BadRequest",
       message: { includes: "volume was not found" },
@@ -301,12 +328,15 @@ export class SnapshotVolumeNotFound
 export class SourceBackupUnavailable
   extends /*@__PURE__*/ S.TaggedErrorClass<SourceBackupUnavailable>()(
     "SourceBackupUnavailable",
-    { Message: S.optional(S.String), BackupId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      BackupId: S.optional(S.String),
+    },
   ) {}
 export class SourceSnapshotNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<SourceSnapshotNotFound>()(
     "SourceSnapshotNotFound",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "BadRequest",
       message: { includes: "SourceSnapshotARN provided is not a valid ARN" },
@@ -315,23 +345,26 @@ export class SourceSnapshotNotFound
 export class StorageVirtualMachineNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<StorageVirtualMachineNotFound>()(
     "StorageVirtualMachineNotFound",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TooManyAccessPoints
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyAccessPoints>()(
     "TooManyAccessPoints",
-    { ErrorCode: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      ErrorCode: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class UnsupportedOperation
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedOperation>()(
     "UnsupportedOperation",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class UpdateSnapshotNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<UpdateSnapshotNotFound>()(
     "UpdateSnapshotNotFound",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "BadRequest",
       message: { includes: "the snapshot is not found" },
@@ -339,7 +372,7 @@ export class UpdateSnapshotNotFound
   ).pipe(C.withNotFoundError) {}
 export class VolumeNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<VolumeNotFound>()("VolumeNotFound", {
-    Message: S.optional(S.String),
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
   }) {}
 export type ClientRequestToken = string;
 export type FileSystemId = string;

--- a/packages/aws/src/services/gamelift.ts
+++ b/packages/aws/src/services/gamelift.ts
@@ -91,82 +91,82 @@ const rules = T.EndpointResolver((p, _) => {
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class FleetCapacityExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<FleetCapacityExceededException>()(
     "FleetCapacityExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class GameSessionFullException
   extends /*@__PURE__*/ S.TaggedErrorClass<GameSessionFullException>()(
     "GameSessionFullException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class IdempotentParameterMismatchException
   extends /*@__PURE__*/ S.TaggedErrorClass<IdempotentParameterMismatchException>()(
     "IdempotentParameterMismatchException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InternalServiceException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServiceException>()(
     "InternalServiceException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidFleetStatusException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidFleetStatusException>()(
     "InvalidFleetStatusException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidGameSessionStatusException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidGameSessionStatusException>()(
     "InvalidGameSessionStatusException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NotReadyException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotReadyException>()(
     "NotReadyException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class OutOfCapacityException
   extends /*@__PURE__*/ S.TaggedErrorClass<OutOfCapacityException>()(
     "OutOfCapacityException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TaggingFailedException
   extends /*@__PURE__*/ S.TaggedErrorClass<TaggingFailedException>()(
     "TaggingFailedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TerminalRoutingStrategyException
   extends /*@__PURE__*/ S.TaggedErrorClass<TerminalRoutingStrategyException>()(
     "TerminalRoutingStrategyException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class UnauthorizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnauthorizedException>()(
     "UnauthorizedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAuthError) {}
 export class UnsupportedRegionException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedRegionException>()(
     "UnsupportedRegionException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type MatchmakingIdStringModel = string;
 export type PlayerId = string | redacted.Redacted<string>;

--- a/packages/aws/src/services/gameliftstreams.ts
+++ b/packages/aws/src/services/gameliftstreams.ts
@@ -57,43 +57,43 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(429), T.Retryable({ throttling: true })),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type Identifier = string;

--- a/packages/aws/src/services/geo-maps.ts
+++ b/packages/aws/src/services/geo-maps.ts
@@ -161,32 +161,32 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(429), T.Retryable()),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       Reason: S.String,
       FieldList: S.suspend(() => ValidationExceptionFieldList).annotate({
         identifier: "ValidationExceptionFieldList",

--- a/packages/aws/src/services/geo-places.ts
+++ b/packages/aws/src/services/geo-places.ts
@@ -161,26 +161,26 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(429), T.Retryable()),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       Reason: S.String,
       FieldList: S.suspend(() => ValidationExceptionFieldList).annotate({
         identifier: "ValidationExceptionFieldList",

--- a/packages/aws/src/services/geo-routes.ts
+++ b/packages/aws/src/services/geo-routes.ts
@@ -161,26 +161,26 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(429), T.Retryable()),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       Reason: S.suspend(() => ValidationExceptionReason).annotate({
         identifier: "ValidationExceptionReason",
       }),

--- a/packages/aws/src/services/glacier.ts
+++ b/packages/aws/src/services/glacier.ts
@@ -92,7 +92,7 @@ export class InsufficientCapacityException
     {
       type: S.optional(S.String),
       code: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
@@ -102,7 +102,7 @@ export class InvalidParameterValueException
     {
       type: S.optional(S.String),
       code: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
@@ -112,7 +112,7 @@ export class LimitExceededException
     {
       type: S.optional(S.String),
       code: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
@@ -122,7 +122,7 @@ export class MissingParameterValueException
     {
       type: S.optional(S.String),
       code: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
@@ -132,7 +132,7 @@ export class NoLongerSupportedException
     {
       type: S.optional(S.String),
       code: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
@@ -142,7 +142,7 @@ export class PolicyEnforcedException
     {
       type: S.optional(S.String),
       code: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
@@ -152,7 +152,7 @@ export class RequestTimeoutException
     {
       type: S.optional(S.String),
       code: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(408),
   ).pipe(C.withTimeoutError) {}
@@ -162,7 +162,7 @@ export class ResourceNotFoundException
     {
       type: S.optional(S.String),
       code: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
@@ -172,7 +172,7 @@ export class ServiceUnavailableException
     {
       type: S.optional(S.String),
       code: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(500),
   ).pipe(C.withServerError) {}

--- a/packages/aws/src/services/global-accelerator.ts
+++ b/packages/aws/src/services/global-accelerator.ts
@@ -88,121 +88,121 @@ const rules = T.EndpointResolver((p, _) => {
 export class AcceleratorNotDisabledException
   extends /*@__PURE__*/ S.TaggedErrorClass<AcceleratorNotDisabledException>()(
     "AcceleratorNotDisabledException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class AcceleratorNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<AcceleratorNotFoundException>()(
     "AcceleratorNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class AssociatedEndpointGroupFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<AssociatedEndpointGroupFoundException>()(
     "AssociatedEndpointGroupFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class AssociatedListenerFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<AssociatedListenerFoundException>()(
     "AssociatedListenerFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class AttachmentNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<AttachmentNotFoundException>()(
     "AttachmentNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ByoipCidrNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ByoipCidrNotFoundException>()(
     "ByoipCidrNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class EndpointAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<EndpointAlreadyExistsException>()(
     "EndpointAlreadyExistsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError, C.withAlreadyExistsError) {}
 export class EndpointGroupAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<EndpointGroupAlreadyExistsException>()(
     "EndpointGroupAlreadyExistsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError, C.withAlreadyExistsError) {}
 export class EndpointGroupNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<EndpointGroupNotFoundException>()(
     "EndpointGroupNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class EndpointNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<EndpointNotFoundException>()(
     "EndpointNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class IncorrectCidrStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<IncorrectCidrStateException>()(
     "IncorrectCidrStateException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class InternalServiceErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServiceErrorException>()(
     "InternalServiceErrorException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidArgumentException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidArgumentException>()(
     "InvalidArgumentException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidNextTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNextTokenException>()(
     "InvalidNextTokenException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidPortRangeException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPortRangeException>()(
     "InvalidPortRangeException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ListenerNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ListenerNotFoundException>()(
     "ListenerNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class TransactionInProgressException
   extends /*@__PURE__*/ S.TaggedErrorClass<TransactionInProgressException>()(
     "TransactionInProgressException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export interface CustomRoutingEndpointConfiguration {

--- a/packages/aws/src/services/glue.ts
+++ b/packages/aws/src/services/glue.ts
@@ -87,68 +87,68 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAuthError) {}
 export class AlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<AlreadyExistsException>()(
     "AlreadyExistsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class ColumnStatisticsTaskNotRunningException
   extends /*@__PURE__*/ S.TaggedErrorClass<ColumnStatisticsTaskNotRunningException>()(
     "ColumnStatisticsTaskNotRunningException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ColumnStatisticsTaskRunningException
   extends /*@__PURE__*/ S.TaggedErrorClass<ColumnStatisticsTaskRunningException>()(
     "ColumnStatisticsTaskRunningException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ColumnStatisticsTaskStoppingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ColumnStatisticsTaskStoppingException>()(
     "ColumnStatisticsTaskStoppingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ConcurrentModificationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentModificationException>()(
     "ConcurrentModificationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ConcurrentRunsExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentRunsExceededException>()(
     "ConcurrentRunsExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ConditionCheckFailureException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConditionCheckFailureException>()(
     "ConditionCheckFailureException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class CrawlerNotRunningException
   extends /*@__PURE__*/ S.TaggedErrorClass<CrawlerNotRunningException>()(
     "CrawlerNotRunningException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class CrawlerRunningException
   extends /*@__PURE__*/ S.TaggedErrorClass<CrawlerRunningException>()(
     "CrawlerRunningException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class CrawlerStoppingException
   extends /*@__PURE__*/ S.TaggedErrorClass<CrawlerStoppingException>()(
     "CrawlerStoppingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class EntityNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<EntityNotFoundException>()(
     "EntityNotFoundException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       FromFederationSource: S.optional(S.Boolean),
     },
   ) {}
@@ -156,7 +156,7 @@ export class FederatedResourceAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<FederatedResourceAlreadyExistsException>()(
     "FederatedResourceAlreadyExistsException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       AssociatedGlueResource: S.optional(S.String),
     },
   ).pipe(C.withAlreadyExistsError) {}
@@ -169,24 +169,24 @@ export class FederationSourceException
           identifier: "FederationSourceErrorCode",
         }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
   ) {}
 export class FederationSourceRetryableException
   extends /*@__PURE__*/ S.TaggedErrorClass<FederationSourceRetryableException>()(
     "FederationSourceRetryableException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class GlueEncryptionException
   extends /*@__PURE__*/ S.TaggedErrorClass<GlueEncryptionException>()(
     "GlueEncryptionException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class GlueRoleNotAssumable
   extends /*@__PURE__*/ S.TaggedErrorClass<GlueRoleNotAssumable>()(
     "GlueRoleNotAssumable",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       FromFederationSource: S.optional(S.Boolean),
     },
     T.SyntheticError({
@@ -198,7 +198,7 @@ export class GlueS3TargetNotReady
   extends /*@__PURE__*/ S.TaggedErrorClass<GlueS3TargetNotReady>()(
     "GlueS3TargetNotReady",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       FromFederationSource: S.optional(S.Boolean),
     },
     T.SyntheticError({
@@ -209,173 +209,173 @@ export class GlueS3TargetNotReady
 export class IdempotentParameterMismatchException
   extends /*@__PURE__*/ S.TaggedErrorClass<IdempotentParameterMismatchException>()(
     "IdempotentParameterMismatchException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class IllegalBlueprintStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<IllegalBlueprintStateException>()(
     "IllegalBlueprintStateException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class IllegalSessionStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<IllegalSessionStateException>()(
     "IllegalSessionStateException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class IllegalWorkflowStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<IllegalWorkflowStateException>()(
     "IllegalWorkflowStateException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class IntegrationConflictOperationFault
   extends /*@__PURE__*/ S.TaggedErrorClass<IntegrationConflictOperationFault>()(
     "IntegrationConflictOperationFault",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class IntegrationNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<IntegrationNotFoundFault>()(
     "IntegrationNotFoundFault",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class IntegrationQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<IntegrationQuotaExceededFault>()(
     "IntegrationQuotaExceededFault",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InternalServiceException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServiceException>()(
     "InternalServiceException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidInputException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInputException>()(
     "InvalidInputException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       FromFederationSource: S.optional(S.Boolean),
     },
   ) {}
 export class InvalidIntegrationStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidIntegrationStateFault>()(
     "InvalidIntegrationStateFault",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidStateException>()(
     "InvalidStateException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class KMSKeyNotAccessibleFault
   extends /*@__PURE__*/ S.TaggedErrorClass<KMSKeyNotAccessibleFault>()(
     "KMSKeyNotAccessibleFault",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class MaterializedViewRefreshTaskNotRunningException
   extends /*@__PURE__*/ S.TaggedErrorClass<MaterializedViewRefreshTaskNotRunningException>()(
     "MaterializedViewRefreshTaskNotRunningException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MaterializedViewRefreshTaskRunningException
   extends /*@__PURE__*/ S.TaggedErrorClass<MaterializedViewRefreshTaskRunningException>()(
     "MaterializedViewRefreshTaskRunningException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MaterializedViewRefreshTaskStoppingException
   extends /*@__PURE__*/ S.TaggedErrorClass<MaterializedViewRefreshTaskStoppingException>()(
     "MaterializedViewRefreshTaskStoppingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MLTransformNotReadyException
   extends /*@__PURE__*/ S.TaggedErrorClass<MLTransformNotReadyException>()(
     "MLTransformNotReadyException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NoScheduleException
   extends /*@__PURE__*/ S.TaggedErrorClass<NoScheduleException>()(
     "NoScheduleException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class OperationNotSupportedException
   extends /*@__PURE__*/ S.TaggedErrorClass<OperationNotSupportedException>()(
     "OperationNotSupportedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class OperationTimeoutException
   extends /*@__PURE__*/ S.TaggedErrorClass<OperationTimeoutException>()(
     "OperationTimeoutException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class PermissionTypeMismatchException
   extends /*@__PURE__*/ S.TaggedErrorClass<PermissionTypeMismatchException>()(
     "PermissionTypeMismatchException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotReadyException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotReadyException>()(
     "ResourceNotReadyException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceNumberLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNumberLimitExceededException>()(
     "ResourceNumberLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class SchedulerNotRunningException
   extends /*@__PURE__*/ S.TaggedErrorClass<SchedulerNotRunningException>()(
     "SchedulerNotRunningException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class SchedulerRunningException
   extends /*@__PURE__*/ S.TaggedErrorClass<SchedulerRunningException>()(
     "SchedulerRunningException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class SchedulerTransitioningException
   extends /*@__PURE__*/ S.TaggedErrorClass<SchedulerTransitioningException>()(
     "SchedulerTransitioningException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class SessionBusyException
   extends /*@__PURE__*/ S.TaggedErrorClass<SessionBusyException>()(
     "SessionBusyException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TargetResourceNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<TargetResourceNotFound>()(
     "TargetResourceNotFound",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class VersionMismatchException
   extends /*@__PURE__*/ S.TaggedErrorClass<VersionMismatchException>()(
     "VersionMismatchException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type AssetId = string;
 export type GlossaryTermId = string;

--- a/packages/aws/src/services/grafana.ts
+++ b/packages/aws/src/services/grafana.ts
@@ -90,20 +90,24 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.all(T.HttpError(500), T.Retryable()),
@@ -111,14 +115,18 @@ export class InternalServerException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.String,
       resourceType: S.String,
       serviceCode: S.String,
@@ -130,7 +138,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       serviceCode: S.optional(S.String),
       quotaCode: S.optional(S.String),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
@@ -141,7 +149,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.String,
       fieldList: S.optional(
         S.suspend(() => ValidationExceptionFieldList).annotate({

--- a/packages/aws/src/services/greengrass.ts
+++ b/packages/aws/src/services/greengrass.ts
@@ -127,7 +127,7 @@ export class BadRequestException
       ErrorDetails: S.optional(
         S.suspend(() => ErrorDetails).annotate({ identifier: "ErrorDetails" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
@@ -138,7 +138,7 @@ export class InternalServerErrorException
       ErrorDetails: S.optional(
         S.suspend(() => ErrorDetails).annotate({ identifier: "ErrorDetails" }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(500),
   ).pipe(C.withServerError) {}

--- a/packages/aws/src/services/greengrassv2.ts
+++ b/packages/aws/src/services/greengrassv2.ts
@@ -124,20 +124,24 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.HttpError(500),
@@ -145,20 +149,24 @@ export class InternalServerException
 export class RequestAlreadyInProgressException
   extends /*@__PURE__*/ S.TaggedErrorClass<RequestAlreadyInProgressException>()(
     "RequestAlreadyInProgressException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceType: S.optional(S.String),
       quotaCode: S.String,
@@ -170,7 +178,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       quotaCode: S.optional(S.String),
       serviceCode: S.optional(S.String),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
@@ -181,7 +189,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.optional(
         S.suspend(() => ValidationExceptionReason).annotate({
           identifier: "ValidationExceptionReason",

--- a/packages/aws/src/services/groundstation.ts
+++ b/packages/aws/src/services/groundstation.ts
@@ -88,37 +88,49 @@ const rules = T.EndpointResolver((p, _) => {
 export class DependencyException
   extends /*@__PURE__*/ S.TaggedErrorClass<DependencyException>()(
     "DependencyException",
-    { message: S.optional(S.String), parameterName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      parameterName: S.optional(S.String),
+    },
     T.HttpError(531),
   ).pipe(C.withServerError) {}
 export class InvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterException>()(
     "InvalidParameterException",
-    { message: S.optional(S.String), parameterName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      parameterName: S.optional(S.String),
+    },
     T.HttpError(431),
   ) {}
 export class ResourceInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUseException>()(
     "ResourceInUseException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ResourceLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceLimitExceededException>()(
     "ResourceLimitExceededException",
-    { message: S.optional(S.String), parameterName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      parameterName: S.optional(S.String),
+    },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(434),
   ) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String), parameterName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      parameterName: S.optional(S.String),
+    },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export type Uuid = string;

--- a/packages/aws/src/services/guardduty.ts
+++ b/packages/aws/src/services/guardduty.ts
@@ -93,31 +93,46 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String), Type: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Type: S.optional(S.String),
+    },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { Message: S.optional(S.String), Type: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Type: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String), Type: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Type: S.optional(S.String),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerErrorException>()(
     "InternalServerErrorException",
-    { Message: S.optional(S.String), Type: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Type: S.optional(S.String),
+    },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String), Type: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Type: S.optional(S.String),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export type DetectorId = string;

--- a/packages/aws/src/services/health.ts
+++ b/packages/aws/src/services/health.ts
@@ -143,17 +143,17 @@ const rules = T.EndpointResolver((p, _) => {
 export class ConcurrentModificationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentModificationException>()(
     "ConcurrentModificationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidPaginationToken
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPaginationToken>()(
     "InvalidPaginationToken",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class UnsupportedLocale
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedLocale>()(
     "UnsupportedLocale",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type EventArn = string;
 export type NextToken = string;

--- a/packages/aws/src/services/healthlake.ts
+++ b/packages/aws/src/services/healthlake.ts
@@ -88,37 +88,37 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type DatastoreName = string;

--- a/packages/aws/src/services/iam.ts
+++ b/packages/aws/src/services/iam.ts
@@ -251,19 +251,19 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccountNotManagementOrDelegatedAdministratorException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccountNotManagementOrDelegatedAdministratorException>()(
     "AccountNotManagementOrDelegatedAdministratorException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class CallerIsNotManagementAccountException
   extends /*@__PURE__*/ S.TaggedErrorClass<CallerIsNotManagementAccountException>()(
     "CallerIsNotManagementAccountException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ConcurrentModificationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentModificationException>()(
     "ConcurrentModificationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ConcurrentModification",
@@ -275,7 +275,7 @@ export class ConcurrentModificationException
 export class CredentialReportExpiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<CredentialReportExpiredException>()(
     "CredentialReportExpiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ReportExpired", httpResponseCode: 410 }),
       T.HttpError(410),
@@ -284,7 +284,7 @@ export class CredentialReportExpiredException
 export class CredentialReportNotPresentException
   extends /*@__PURE__*/ S.TaggedErrorClass<CredentialReportNotPresentException>()(
     "CredentialReportNotPresentException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ReportNotPresent", httpResponseCode: 410 }),
       T.HttpError(410),
@@ -293,7 +293,7 @@ export class CredentialReportNotPresentException
 export class CredentialReportNotReadyException
   extends /*@__PURE__*/ S.TaggedErrorClass<CredentialReportNotReadyException>()(
     "CredentialReportNotReadyException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ReportInProgress", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -302,7 +302,7 @@ export class CredentialReportNotReadyException
 export class DeleteConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<DeleteConflictException>()(
     "DeleteConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "DeleteConflict", httpResponseCode: 409 }),
       T.HttpError(409),
@@ -311,7 +311,7 @@ export class DeleteConflictException
 export class DuplicateCertificateException
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicateCertificateException>()(
     "DuplicateCertificateException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "DuplicateCertificate", httpResponseCode: 409 }),
       T.HttpError(409),
@@ -320,7 +320,7 @@ export class DuplicateCertificateException
 export class DuplicateSSHPublicKeyException
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicateSSHPublicKeyException>()(
     "DuplicateSSHPublicKeyException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "DuplicateSSHPublicKey", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -329,7 +329,7 @@ export class DuplicateSSHPublicKeyException
 export class EntityAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<EntityAlreadyExistsException>()(
     "EntityAlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "EntityAlreadyExists", httpResponseCode: 409 }),
       T.HttpError(409),
@@ -338,7 +338,7 @@ export class EntityAlreadyExistsException
 export class EntityTemporarilyUnmodifiableException
   extends /*@__PURE__*/ S.TaggedErrorClass<EntityTemporarilyUnmodifiableException>()(
     "EntityTemporarilyUnmodifiableException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "EntityTemporarilyUnmodifiable",
@@ -350,7 +350,7 @@ export class EntityTemporarilyUnmodifiableException
 export class FeatureDisabledException
   extends /*@__PURE__*/ S.TaggedErrorClass<FeatureDisabledException>()(
     "FeatureDisabledException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "FeatureDisabled", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -359,7 +359,7 @@ export class FeatureDisabledException
 export class FeatureEnabledException
   extends /*@__PURE__*/ S.TaggedErrorClass<FeatureEnabledException>()(
     "FeatureEnabledException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "FeatureEnabled", httpResponseCode: 409 }),
       T.HttpError(409),
@@ -368,7 +368,7 @@ export class FeatureEnabledException
 export class InvalidAuthenticationCodeException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidAuthenticationCodeException>()(
     "InvalidAuthenticationCodeException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidAuthenticationCode",
@@ -380,21 +380,20 @@ export class InvalidAuthenticationCodeException
 export class InvalidCertificateException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCertificateException>()(
     "InvalidCertificateException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidCertificate", httpResponseCode: 400 }),
       T.HttpError(400),
     ),
   ).pipe(C.withBadRequestError) {}
 export class InvalidInput
-  extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInput>()(
-    "InvalidInput",
-    {},
-  ) {}
+  extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInput>()("InvalidInput", {
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
+  }) {}
 export class InvalidInputException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInputException>()(
     "InvalidInputException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidInput", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -403,7 +402,7 @@ export class InvalidInputException
 export class InvalidPublicKeyException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPublicKeyException>()(
     "InvalidPublicKeyException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidPublicKey", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -412,7 +411,7 @@ export class InvalidPublicKeyException
 export class InvalidUserTypeException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidUserTypeException>()(
     "InvalidUserTypeException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidUserType", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -421,7 +420,7 @@ export class InvalidUserTypeException
 export class KeyPairMismatchException
   extends /*@__PURE__*/ S.TaggedErrorClass<KeyPairMismatchException>()(
     "KeyPairMismatchException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "KeyPairMismatch", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -430,7 +429,7 @@ export class KeyPairMismatchException
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "LimitExceeded", httpResponseCode: 409 }),
       T.HttpError(409),
@@ -439,7 +438,7 @@ export class LimitExceededException
 export class MalformedCertificateException
   extends /*@__PURE__*/ S.TaggedErrorClass<MalformedCertificateException>()(
     "MalformedCertificateException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "MalformedCertificate", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -448,7 +447,7 @@ export class MalformedCertificateException
 export class MalformedPolicyDocumentException
   extends /*@__PURE__*/ S.TaggedErrorClass<MalformedPolicyDocumentException>()(
     "MalformedPolicyDocumentException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "MalformedPolicyDocument",
@@ -460,7 +459,7 @@ export class MalformedPolicyDocumentException
 export class NoSuchEntityException
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchEntityException>()(
     "NoSuchEntityException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "NoSuchEntity", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -469,7 +468,7 @@ export class NoSuchEntityException
 export class OpenIdIdpCommunicationErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<OpenIdIdpCommunicationErrorException>()(
     "OpenIdIdpCommunicationErrorException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "OpenIdIdpCommunicationError",
@@ -481,19 +480,19 @@ export class OpenIdIdpCommunicationErrorException
 export class OrganizationNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<OrganizationNotFoundException>()(
     "OrganizationNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class OrganizationNotInAllFeaturesModeException
   extends /*@__PURE__*/ S.TaggedErrorClass<OrganizationNotInAllFeaturesModeException>()(
     "OrganizationNotInAllFeaturesModeException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class PasswordPolicyViolationException
   extends /*@__PURE__*/ S.TaggedErrorClass<PasswordPolicyViolationException>()(
     "PasswordPolicyViolationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "PasswordPolicyViolation",
@@ -505,7 +504,7 @@ export class PasswordPolicyViolationException
 export class PolicyEvaluationException
   extends /*@__PURE__*/ S.TaggedErrorClass<PolicyEvaluationException>()(
     "PolicyEvaluationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "PolicyEvaluation", httpResponseCode: 500 }),
       T.HttpError(500),
@@ -514,7 +513,7 @@ export class PolicyEvaluationException
 export class PolicyNotAttachableException
   extends /*@__PURE__*/ S.TaggedErrorClass<PolicyNotAttachableException>()(
     "PolicyNotAttachableException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "PolicyNotAttachable", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -523,7 +522,7 @@ export class PolicyNotAttachableException
 export class ReportGenerationLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ReportGenerationLimitExceededException>()(
     "ReportGenerationLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ReportGenerationLimitExceeded",
@@ -535,18 +534,18 @@ export class ReportGenerationLimitExceededException
 export class RequestLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<RequestLimitExceeded>()(
     "RequestLimitExceeded",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class ServiceAccessNotEnabledException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceAccessNotEnabledException>()(
     "ServiceAccessNotEnabledException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ServiceFailureException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceFailureException>()(
     "ServiceFailureException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ServiceFailure", httpResponseCode: 500 }),
       T.HttpError(500),
@@ -555,7 +554,7 @@ export class ServiceFailureException
 export class ServiceNotSupportedException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceNotSupportedException>()(
     "ServiceNotSupportedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "NotSupportedService", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -564,7 +563,7 @@ export class ServiceNotSupportedException
 export class UnmodifiableEntityException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnmodifiableEntityException>()(
     "UnmodifiableEntityException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "UnmodifiableEntity", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -573,7 +572,7 @@ export class UnmodifiableEntityException
 export class UnrecognizedPublicKeyEncodingException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnrecognizedPublicKeyEncodingException>()(
     "UnrecognizedPublicKeyEncodingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "UnrecognizedPublicKeyEncoding",

--- a/packages/aws/src/services/identitystore.ts
+++ b/packages/aws/src/services/identitystore.ts
@@ -94,7 +94,7 @@ export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       RequestId: S.optional(S.String),
       Reason: S.optional(
         S.suspend(() => ConflictExceptionReason).annotate({
@@ -117,7 +117,7 @@ export class ResourceNotFoundException
           identifier: "ResourceNotFoundExceptionReason",
         }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       RequestId: S.optional(S.String),
     },
     T.HttpError(404),
@@ -125,14 +125,17 @@ export class ResourceNotFoundException
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       RequestId: S.optional(S.String),
       Reason: S.optional(
         S.suspend(() => ValidationExceptionReason).annotate({

--- a/packages/aws/src/services/imagebuilder.ts
+++ b/packages/aws/src/services/imagebuilder.ts
@@ -91,121 +91,121 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class CallRateLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<CallRateLimitExceededException>()(
     "CallRateLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ClientException
   extends /*@__PURE__*/ S.TaggedErrorClass<ClientException>()(
     "ClientException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class DryRunOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<DryRunOperationException>()(
     "DryRunOperationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(412),
   ) {}
 export class ForbiddenException
   extends /*@__PURE__*/ S.TaggedErrorClass<ForbiddenException>()(
     "ForbiddenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class IdempotentParameterMismatchException
   extends /*@__PURE__*/ S.TaggedErrorClass<IdempotentParameterMismatchException>()(
     "IdempotentParameterMismatchException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidPaginationTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPaginationTokenException>()(
     "InvalidPaginationTokenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidParameterCombinationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterCombinationException>()(
     "InvalidParameterCombinationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterException>()(
     "InvalidParameterException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidParameterValueException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterValueException>()(
     "InvalidParameterValueException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidVersionNumberException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidVersionNumberException>()(
     "InvalidVersionNumberException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceAlreadyExistsException>()(
     "ResourceAlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError, C.withAlreadyExistsError) {}
 export class ResourceDependencyException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceDependencyException>()(
     "ResourceDependencyException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUseException>()(
     "ResourceInUseException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceException>()(
     "ServiceException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export type ImageBuildVersionArn = string;

--- a/packages/aws/src/services/inspector-scan.ts
+++ b/packages/aws/src/services/inspector-scan.ts
@@ -87,14 +87,14 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.suspend(() => InternalServerExceptionReason).annotate({
         identifier: "InternalServerExceptionReason",
       }),
@@ -106,7 +106,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.all(T.HttpError(429), T.Retryable({ throttling: true })),
@@ -115,7 +115,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.suspend(() => ValidationExceptionReason).annotate({
         identifier: "ValidationExceptionReason",
       }),

--- a/packages/aws/src/services/inspector.ts
+++ b/packages/aws/src/services/inspector.ts
@@ -89,7 +89,7 @@ export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       errorCode: S.suspend(() => AccessDeniedErrorCode).annotate({
         identifier: "AccessDeniedErrorCode",
       }),
@@ -101,7 +101,7 @@ export class AgentsAlreadyRunningAssessmentException
   extends /*@__PURE__*/ S.TaggedErrorClass<AgentsAlreadyRunningAssessmentException>()(
     "AgentsAlreadyRunningAssessmentException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       agents: S.suspend(() => AgentAlreadyRunningAssessmentList).annotate({
         identifier: "AgentAlreadyRunningAssessmentList",
       }),
@@ -113,7 +113,7 @@ export class AssessmentRunInProgressException
   extends /*@__PURE__*/ S.TaggedErrorClass<AssessmentRunInProgressException>()(
     "AssessmentRunInProgressException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       assessmentRunArns: S.suspend(
         () => AssessmentRunInProgressArnList,
       ).annotate({ identifier: "AssessmentRunInProgressArnList" }),
@@ -124,13 +124,13 @@ export class AssessmentRunInProgressException
 export class InternalException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalException>()(
     "InternalException",
-    { message: S.String, canRetry: S.Boolean },
+    { message: S.String.pipe(T.ErrorMessage()), canRetry: S.Boolean },
   ) {}
 export class InvalidCrossAccountRoleException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCrossAccountRoleException>()(
     "InvalidCrossAccountRoleException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       errorCode: S.suspend(() => InvalidCrossAccountRoleErrorCode).annotate({
         identifier: "InvalidCrossAccountRoleErrorCode",
       }),
@@ -141,7 +141,7 @@ export class InvalidInputException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInputException>()(
     "InvalidInputException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       errorCode: S.suspend(() => InvalidInputErrorCode).annotate({
         identifier: "InvalidInputErrorCode",
       }),
@@ -152,7 +152,7 @@ export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       errorCode: S.suspend(() => LimitExceededErrorCode).annotate({
         identifier: "LimitExceededErrorCode",
       }),
@@ -163,7 +163,7 @@ export class NoSuchEntityException
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchEntityException>()(
     "NoSuchEntityException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       errorCode: S.suspend(() => NoSuchEntityErrorCode).annotate({
         identifier: "NoSuchEntityErrorCode",
       }),
@@ -173,18 +173,18 @@ export class NoSuchEntityException
 export class PreviewGenerationInProgressException
   extends /*@__PURE__*/ S.TaggedErrorClass<PreviewGenerationInProgressException>()(
     "PreviewGenerationInProgressException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
   ) {}
 export class ServiceTemporarilyUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceTemporarilyUnavailableException>()(
     "ServiceTemporarilyUnavailableException",
-    { message: S.String, canRetry: S.Boolean },
+    { message: S.String.pipe(T.ErrorMessage()), canRetry: S.Boolean },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class UnsupportedFeatureException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedFeatureException>()(
     "UnsupportedFeatureException",
-    { message: S.String, canRetry: S.Boolean },
+    { message: S.String.pipe(T.ErrorMessage()), canRetry: S.Boolean },
   ) {}
 export type Arn = string;
 export type AddRemoveAttributesFindingArnList = string[];

--- a/packages/aws/src/services/inspector2.ts
+++ b/packages/aws/src/services/inspector2.ts
@@ -90,26 +90,30 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.all(T.HttpError(500), T.Retryable()),
@@ -117,20 +121,20 @@ export class InternalServerException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.String, resourceId: S.String },
+    { message: S.String.pipe(T.ErrorMessage()), resourceId: S.String },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.all(T.HttpError(429), T.Retryable({ throttling: true })),
@@ -139,7 +143,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.String,
       fields: S.optional(
         S.suspend(() => ValidationExceptionFields).annotate({

--- a/packages/aws/src/services/internetmonitor.ts
+++ b/packages/aws/src/services/internetmonitor.ts
@@ -88,67 +88,67 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerErrorException>()(
     "InternalServerErrorException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError, C.withNotFoundError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(429), T.Retryable({ throttling: true })),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(429), T.Retryable({ throttling: true })),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type ResourceName = string;

--- a/packages/aws/src/services/invoicing.ts
+++ b/packages/aws/src/services/invoicing.ts
@@ -69,7 +69,10 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String), resourceName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      resourceName: S.optional(S.String),
+    },
     T.all(
       T.AwsQueryError({ code: "InvoicingAccessDenied", httpResponseCode: 403 }),
       T.HttpError(403),
@@ -79,7 +82,7 @@ export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceType: S.optional(S.String),
     },
@@ -93,7 +96,7 @@ export class InternalServerException
     "InternalServerException",
     {
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.all(
       T.AwsQueryError({
@@ -106,7 +109,10 @@ export class InternalServerException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String), resourceName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      resourceName: S.optional(S.String),
+    },
     T.all(
       T.AwsQueryError({
         code: "InvoicingResourceNotFound",
@@ -118,7 +124,7 @@ export class ResourceNotFoundException
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvoicingServiceQuotaExceeded",
@@ -130,7 +136,7 @@ export class ServiceQuotaExceededException
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvoicingThrottling", httpResponseCode: 429 }),
       T.HttpError(429),
@@ -140,7 +146,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       resourceName: S.optional(S.String),
       reason: S.optional(
         S.suspend(() => ValidationExceptionReason).annotate({

--- a/packages/aws/src/services/iot-data-plane.ts
+++ b/packages/aws/src/services/iot-data-plane.ts
@@ -121,73 +121,73 @@ const rules = T.EndpointResolver((p, _) => {
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ForbiddenException
   extends /*@__PURE__*/ S.TaggedErrorClass<ForbiddenException>()(
     "ForbiddenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class GatewayTimeoutException
   extends /*@__PURE__*/ S.TaggedErrorClass<GatewayTimeoutException>()(
     "GatewayTimeoutException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(504),
   ).pipe(C.withTimeoutError) {}
 export class InternalFailureException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalFailureException>()(
     "InternalFailureException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class MethodNotAllowedException
   extends /*@__PURE__*/ S.TaggedErrorClass<MethodNotAllowedException>()(
     "MethodNotAllowedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(405),
   ).pipe(C.withBadRequestError) {}
 export class RequestEntityTooLargeException
   extends /*@__PURE__*/ S.TaggedErrorClass<RequestEntityTooLargeException>()(
     "RequestEntityTooLargeException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(413),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class UnauthorizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnauthorizedException>()(
     "UnauthorizedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export class UnsupportedDocumentEncodingException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedDocumentEncodingException>()(
     "UnsupportedDocumentEncodingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(415),
   ).pipe(C.withBadRequestError) {}
 export type ClientId = string;

--- a/packages/aws/src/services/iot-events-data.ts
+++ b/packages/aws/src/services/iot-events-data.ts
@@ -87,31 +87,31 @@ const rules = T.EndpointResolver((p, _) => {
 export class InternalFailureException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalFailureException>()(
     "InternalFailureException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export type RequestId = string;

--- a/packages/aws/src/services/iot-events.ts
+++ b/packages/aws/src/services/iot-events.ts
@@ -87,26 +87,26 @@ const rules = T.EndpointResolver((p, _) => {
 export class InternalFailureException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalFailureException>()(
     "InternalFailureException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(410),
   ).pipe(C.withBadRequestError) {}
 export class ResourceAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceAlreadyExistsException>()(
     "ResourceAlreadyExistsException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceArn: S.optional(S.String),
     },
@@ -115,31 +115,31 @@ export class ResourceAlreadyExistsException
 export class ResourceInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUseException>()(
     "ResourceInUseException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class UnsupportedOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedOperationException>()(
     "UnsupportedOperationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(501),
   ).pipe(C.withServerError) {}
 export type AlarmModelName = string;

--- a/packages/aws/src/services/iot-jobs-data-plane.ts
+++ b/packages/aws/src/services/iot-jobs-data-plane.ts
@@ -87,67 +87,73 @@ const rules = T.EndpointResolver((p, _) => {
 export class CertificateValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<CertificateValidationException>()(
     "CertificateValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String), resourceId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      resourceId: S.optional(S.String),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidStateTransitionException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidStateTransitionException>()(
     "InvalidStateTransitionException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class TerminalStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<TerminalStateException>()(
     "TerminalStateException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(410),
   ).pipe(C.withBadRequestError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String), payload: S.optional(T.Blob) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      payload: S.optional(T.Blob),
+    },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type DescribeJobExecutionJobId = string;

--- a/packages/aws/src/services/iot-managed-integrations.ts
+++ b/packages/aws/src/services/iot-managed-integrations.ts
@@ -57,44 +57,44 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalFailureException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalFailureException>()(
     "InternalFailureException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(410),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       ResourceId: S.optional(S.String),
       ResourceType: S.optional(S.String),
     },
@@ -103,31 +103,31 @@ export class ResourceNotFoundException
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class UnauthorizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnauthorizedException>()(
     "UnauthorizedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type ClientToken = string;

--- a/packages/aws/src/services/iot-wireless.ts
+++ b/packages/aws/src/services/iot-wireless.ts
@@ -90,14 +90,14 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       ResourceId: S.optional(S.String),
       ResourceType: S.optional(S.String),
     },
@@ -106,14 +106,14 @@ export class ConflictException
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       ResourceId: S.optional(S.String),
       ResourceType: S.optional(S.String),
     },
@@ -122,19 +122,22 @@ export class ResourceNotFoundException
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { Message: S.optional(S.String), ResourceName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ResourceName: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type AmazonId = string;

--- a/packages/aws/src/services/iot.ts
+++ b/packages/aws/src/services/iot.ts
@@ -99,122 +99,125 @@ const rules = T.EndpointResolver((p, _) => {
 export class CertificateConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<CertificateConflictException>()(
     "CertificateConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class CertificateStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<CertificateStateException>()(
     "CertificateStateException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(406),
   ).pipe(C.withBadRequestError) {}
 export class CertificateValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<CertificateValidationException>()(
     "CertificateValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String), resourceId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      resourceId: S.optional(S.String),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ConflictingResourceUpdateException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictingResourceUpdateException>()(
     "ConflictingResourceUpdateException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class DeleteConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<DeleteConflictException>()(
     "DeleteConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class IndexNotReadyException
   extends /*@__PURE__*/ S.TaggedErrorClass<IndexNotReadyException>()(
     "IndexNotReadyException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InternalException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalException>()(
     "InternalException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InternalFailureException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalFailureException>()(
     "InternalFailureException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidAggregationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidAggregationException>()(
     "InvalidAggregationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidQueryException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidQueryException>()(
     "InvalidQueryException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidResponseException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidResponseException>()(
     "InvalidResponseException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidStateTransitionException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidStateTransitionException>()(
     "InvalidStateTransitionException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(410),
   ).pipe(C.withBadRequestError) {}
 export class MalformedPolicyException
   extends /*@__PURE__*/ S.TaggedErrorClass<MalformedPolicyException>()(
     "MalformedPolicyException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class NotConfiguredException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotConfiguredException>()(
     "NotConfiguredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class RegistrationCodeValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<RegistrationCodeValidationException>()(
     "RegistrationCodeValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceAlreadyExistsException>()(
     "ResourceAlreadyExistsException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceArn: S.optional(S.String),
     },
@@ -223,49 +226,49 @@ export class ResourceAlreadyExistsException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ResourceRegistrationFailureException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceRegistrationFailureException>()(
     "ResourceRegistrationFailureException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class SqlParseException
   extends /*@__PURE__*/ S.TaggedErrorClass<SqlParseException>()(
     "SqlParseException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TaskAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TaskAlreadyExistsException>()(
     "TaskAlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError, C.withAlreadyExistsError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TopicRuleNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<TopicRuleNotFound>()(
     "TopicRuleNotFound",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "UnauthorizedException",
       message: { includes: "Access to topic rule" },
@@ -274,37 +277,37 @@ export class TopicRuleNotFound
 export class TransferAlreadyCompletedException
   extends /*@__PURE__*/ S.TaggedErrorClass<TransferAlreadyCompletedException>()(
     "TransferAlreadyCompletedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(410),
   ).pipe(C.withBadRequestError) {}
 export class TransferConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<TransferConflictException>()(
     "TransferConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class UnauthorizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnauthorizedException>()(
     "UnauthorizedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class VersionConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<VersionConflictException>()(
     "VersionConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class VersionsLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<VersionsLimitExceededException>()(
     "VersionsLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export type CertificateId = string;

--- a/packages/aws/src/services/iotdeviceadvisor.ts
+++ b/packages/aws/src/services/iotdeviceadvisor.ts
@@ -88,25 +88,25 @@ const rules = T.EndpointResolver((p, _) => {
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type SuiteDefinitionName = string;

--- a/packages/aws/src/services/iotfleetwise.ts
+++ b/packages/aws/src/services/iotfleetwise.ts
@@ -90,13 +90,17 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String, resource: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resource: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class DecoderManifestValidationException
@@ -113,7 +117,7 @@ export class DecoderManifestValidationException
           identifier: "InvalidNetworkInterfaces",
         }),
       ),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
@@ -121,7 +125,7 @@ export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.HttpError(500),
@@ -134,7 +138,7 @@ export class InvalidNodeException
         S.suspend(() => Nodes).annotate({ identifier: "Nodes" }),
       ),
       reason: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
@@ -142,7 +146,7 @@ export class InvalidSignalsException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSignalsException>()(
     "InvalidSignalsException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       invalidSignals: S.optional(
         S.suspend(() => InvalidSignals).annotate({
           identifier: "InvalidSignals",
@@ -154,20 +158,28 @@ export class InvalidSignalsException
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       quotaCode: S.optional(S.String),
       serviceCode: S.optional(S.String),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
@@ -178,7 +190,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.optional(
         S.suspend(() => ValidationExceptionReason).annotate({
           identifier: "ValidationExceptionReason",

--- a/packages/aws/src/services/iotsecuretunneling.ts
+++ b/packages/aws/src/services/iotsecuretunneling.ts
@@ -112,7 +112,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "LimitExceededException",
@@ -124,7 +124,7 @@ export class LimitExceededException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ResourceNotFoundException",

--- a/packages/aws/src/services/iotsitewise.ts
+++ b/packages/aws/src/services/iotsitewise.ts
@@ -90,85 +90,100 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictingOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictingOperationException>()(
     "ConflictingOperationException",
-    { message: S.String, resourceId: S.String, resourceArn: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceArn: S.String,
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalFailureException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalFailureException>()(
     "InternalFailureException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(410),
   ).pipe(C.withBadRequestError) {}
 export class PreconditionFailedException
   extends /*@__PURE__*/ S.TaggedErrorClass<PreconditionFailedException>()(
     "PreconditionFailedException",
-    { message: S.String, resourceId: S.String, resourceArn: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceArn: S.String,
+    },
     T.HttpError(412),
   ) {}
 export class QueryTimeoutException
   extends /*@__PURE__*/ S.TaggedErrorClass<QueryTimeoutException>()(
     "QueryTimeoutException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceAlreadyExistsException>()(
     "ResourceAlreadyExistsException",
-    { message: S.String, resourceId: S.String, resourceArn: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceArn: S.String,
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { message: S.optional(S.String), resourceName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      resourceName: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class UnauthorizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnauthorizedException>()(
     "UnauthorizedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type CustomID = string;

--- a/packages/aws/src/services/iotthingsgraph.ts
+++ b/packages/aws/src/services/iotthingsgraph.ts
@@ -91,43 +91,43 @@ const rules = T.EndpointResolver((p, _) => {
 export class InternalFailureException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalFailureException>()(
     "InternalFailureException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(410),
   ).pipe(C.withBadRequestError) {}
 export class ResourceAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceAlreadyExistsException>()(
     "ResourceAlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class ResourceInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUseException>()(
     "ResourceInUseException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(412),
   ) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export type ThingName = string;

--- a/packages/aws/src/services/iottwinmaker.ts
+++ b/packages/aws/src/services/iottwinmaker.ts
@@ -88,67 +88,67 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ConnectorFailureException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConnectorFailureException>()(
     "ConnectorFailureException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(424),
   ) {}
 export class ConnectorTimeoutException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConnectorTimeoutException>()(
     "ConnectorTimeoutException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(424),
   ) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class QueryTimeoutException
   extends /*@__PURE__*/ S.TaggedErrorClass<QueryTimeoutException>()(
     "QueryTimeoutException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(400), T.Retryable()),
   ).pipe(C.withBadRequestError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type Id = string;

--- a/packages/aws/src/services/ivs-realtime.ts
+++ b/packages/aws/src/services/ivs-realtime.ts
@@ -112,6 +112,7 @@ export class AccessDeniedException
         T.HttpHeader("x-amzn-ErrorType"),
       ),
       exceptionMessage: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
@@ -140,6 +141,7 @@ export class ConflictException
         T.HttpHeader("x-amzn-ErrorType"),
       ),
       exceptionMessage: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
@@ -168,6 +170,7 @@ export class InternalServerException
         T.HttpHeader("x-amzn-ErrorType"),
       ),
       exceptionMessage: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
@@ -196,6 +199,7 @@ export class PendingVerification
         T.HttpHeader("x-amzn-ErrorType"),
       ),
       exceptionMessage: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
@@ -224,6 +228,7 @@ export class ResourceNotFoundException
         T.HttpHeader("x-amzn-ErrorType"),
       ),
       exceptionMessage: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
@@ -252,13 +257,14 @@ export class ServiceQuotaExceededException
         T.HttpHeader("x-amzn-ErrorType"),
       ),
       exceptionMessage: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
@@ -285,6 +291,7 @@ export class ValidationException
         T.HttpHeader("x-amzn-ErrorType"),
       ),
       exceptionMessage: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}

--- a/packages/aws/src/services/ivs.ts
+++ b/packages/aws/src/services/ivs.ts
@@ -112,6 +112,7 @@ export class AccessDeniedException
         T.HttpHeader("x-amzn-ErrorType"),
       ),
       exceptionMessage: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
@@ -140,6 +141,7 @@ export class ChannelNotBroadcasting
         T.HttpHeader("x-amzn-ErrorType"),
       ),
       exceptionMessage: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
@@ -168,6 +170,7 @@ export class ConflictException
         T.HttpHeader("x-amzn-ErrorType"),
       ),
       exceptionMessage: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
@@ -196,6 +199,7 @@ export class InternalServerException
         T.HttpHeader("x-amzn-ErrorType"),
       ),
       exceptionMessage: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
@@ -224,6 +228,7 @@ export class PendingVerification
         T.HttpHeader("x-amzn-ErrorType"),
       ),
       exceptionMessage: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
@@ -252,6 +257,7 @@ export class ResourceNotFoundException
         T.HttpHeader("x-amzn-ErrorType"),
       ),
       exceptionMessage: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
@@ -280,6 +286,7 @@ export class ServiceQuotaExceededException
         T.HttpHeader("x-amzn-ErrorType"),
       ),
       exceptionMessage: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
@@ -308,6 +315,7 @@ export class ServiceUnavailable
         T.HttpHeader("x-amzn-ErrorType"),
       ),
       exceptionMessage: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
@@ -336,6 +344,7 @@ export class StreamUnavailable
         T.HttpHeader("x-amzn-ErrorType"),
       ),
       exceptionMessage: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
@@ -364,6 +373,7 @@ export class ThrottlingException
         T.HttpHeader("x-amzn-ErrorType"),
       ),
       exceptionMessage: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
@@ -392,6 +402,7 @@ export class ValidationException
         T.HttpHeader("x-amzn-ErrorType"),
       ),
       exceptionMessage: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}

--- a/packages/aws/src/services/ivschat.ts
+++ b/packages/aws/src/services/ivschat.ts
@@ -90,38 +90,46 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class PendingVerification
   extends /*@__PURE__*/ S.TaggedErrorClass<PendingVerification>()(
     "PendingVerification",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.String,
       resourceType: S.String,
       limit: S.Number,
@@ -132,7 +140,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.String,
       resourceType: S.String,
       limit: S.Number,
@@ -143,7 +151,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.optional(S.String),
       fieldList: S.optional(
         S.suspend(() => ValidationExceptionFieldList).annotate({

--- a/packages/aws/src/services/kafka.ts
+++ b/packages/aws/src/services/kafka.ts
@@ -148,103 +148,154 @@ const rules = T.EndpointResolver((p, _) => {
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { InvalidParameter: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      InvalidParameter: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ClusterConnectivityException
   extends /*@__PURE__*/ S.TaggedErrorClass<ClusterConnectivityException>()(
     "ClusterConnectivityException",
-    { InvalidParameter: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      InvalidParameter: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { InvalidParameter: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      InvalidParameter: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ControllerMovedException
   extends /*@__PURE__*/ S.TaggedErrorClass<ControllerMovedException>()(
     "ControllerMovedException",
-    { InvalidParameter: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      InvalidParameter: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ForbiddenException
   extends /*@__PURE__*/ S.TaggedErrorClass<ForbiddenException>()(
     "ForbiddenException",
-    { InvalidParameter: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      InvalidParameter: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class GroupSubscribedToTopicException
   extends /*@__PURE__*/ S.TaggedErrorClass<GroupSubscribedToTopicException>()(
     "GroupSubscribedToTopicException",
-    { InvalidParameter: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      InvalidParameter: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerErrorException>()(
     "InternalServerErrorException",
-    { InvalidParameter: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      InvalidParameter: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class KafkaRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<KafkaRequestException>()(
     "KafkaRequestException",
-    { InvalidParameter: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      InvalidParameter: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class KafkaTimeoutException
   extends /*@__PURE__*/ S.TaggedErrorClass<KafkaTimeoutException>()(
     "KafkaTimeoutException",
-    { InvalidParameter: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      InvalidParameter: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class NotControllerException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotControllerException>()(
     "NotControllerException",
-    { InvalidParameter: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      InvalidParameter: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { InvalidParameter: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      InvalidParameter: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ReassignmentInProgressException
   extends /*@__PURE__*/ S.TaggedErrorClass<ReassignmentInProgressException>()(
     "ReassignmentInProgressException",
-    { InvalidParameter: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      InvalidParameter: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { InvalidParameter: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      InvalidParameter: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { InvalidParameter: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      InvalidParameter: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class TopicExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TopicExistsException>()(
     "TopicExistsException",
-    { InvalidParameter: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      InvalidParameter: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class UnauthorizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnauthorizedException>()(
     "UnauthorizedException",
-    { InvalidParameter: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      InvalidParameter: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export class UnknownTopicOrPartitionException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnknownTopicOrPartitionException>()(
     "UnknownTopicOrPartitionException",
-    { InvalidParameter: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      InvalidParameter: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export type __listOf__string = string[];

--- a/packages/aws/src/services/kafkaconnect.ts
+++ b/packages/aws/src/services/kafkaconnect.ts
@@ -108,49 +108,49 @@ const rules = T.EndpointResolver((p, _) => {
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ForbiddenException
   extends /*@__PURE__*/ S.TaggedErrorClass<ForbiddenException>()(
     "ForbiddenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class InternalServerErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerErrorException>()(
     "InternalServerErrorException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class UnauthorizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnauthorizedException>()(
     "UnauthorizedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export type __integerMin1Max8 = number;

--- a/packages/aws/src/services/kendra-ranking.ts
+++ b/packages/aws/src/services/kendra-ranking.ts
@@ -75,49 +75,49 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ResourceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceUnavailableException>()(
     "ResourceUnavailableException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type RescoreExecutionPlanName = string;

--- a/packages/aws/src/services/kendra.ts
+++ b/packages/aws/src/services/kendra.ts
@@ -90,20 +90,20 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class FeaturedResultsConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<FeaturedResultsConflictException>()(
     "FeaturedResultsConflictException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       ConflictingItems: S.optional(
         S.suspend(() => ConflictingItems).annotate({
           identifier: "ConflictingItems",
@@ -115,55 +115,55 @@ export class FeaturedResultsConflictException
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceAlreadyExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceAlreadyExistException>()(
     "ResourceAlreadyExistException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUseException>()(
     "ResourceInUseException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ResourceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceUnavailableException>()(
     "ResourceUnavailableException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type ExperienceId = string;

--- a/packages/aws/src/services/keyspaces.ts
+++ b/packages/aws/src/services/keyspaces.ts
@@ -91,7 +91,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "AccessDeniedException", httpResponseCode: 403 }),
       T.HttpError(403),
@@ -100,7 +100,7 @@ export class AccessDeniedException
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ConflictException", httpResponseCode: 409 }),
       T.HttpError(409),
@@ -109,7 +109,7 @@ export class ConflictException
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InternalServerException",
@@ -121,7 +121,10 @@ export class InternalServerException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String), resourceArn: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      resourceArn: S.optional(S.String),
+    },
     T.all(
       T.AwsQueryError({
         code: "ResourceNotFoundException",
@@ -133,7 +136,7 @@ export class ResourceNotFoundException
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ServiceQuotaExceededException",
@@ -145,7 +148,7 @@ export class ServiceQuotaExceededException
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "ValidationException", httpResponseCode: 400 }),
   ) {}
 export type KeyspaceName = string;

--- a/packages/aws/src/services/keyspacesstreams.ts
+++ b/packages/aws/src/services/keyspacesstreams.ts
@@ -55,7 +55,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "AccessDeniedException", httpResponseCode: 403 }),
       T.HttpError(403),
@@ -64,7 +64,7 @@ export class AccessDeniedException
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InternalServerException",
@@ -76,7 +76,7 @@ export class InternalServerException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ResourceNotFoundException",
@@ -88,7 +88,7 @@ export class ResourceNotFoundException
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ThrottlingException", httpResponseCode: 429 }),
       T.HttpError(429),
@@ -98,7 +98,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       errorCode: S.optional(
         S.suspend(() => ValidationExceptionType).annotate({
           identifier: "ValidationExceptionType",

--- a/packages/aws/src/services/kinesis-analytics-v2.ts
+++ b/packages/aws/src/services/kinesis-analytics-v2.ts
@@ -91,65 +91,65 @@ const rules = T.EndpointResolver((p, _) => {
 export class CodeValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<CodeValidationException>()(
     "CodeValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ConcurrentModificationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentModificationException>()(
     "ConcurrentModificationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InvalidApplicationConfigurationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidApplicationConfigurationException>()(
     "InvalidApplicationConfigurationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidArgumentException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidArgumentException>()(
     "InvalidArgumentException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUseException>()(
     "ResourceInUseException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceProvisionedThroughputExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceProvisionedThroughputExceededException>()(
     "ResourceProvisionedThroughputExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class UnableToDetectSchemaException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnableToDetectSchemaException>()(
     "UnableToDetectSchemaException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       RawInputRecords: S.optional(
         S.suspend(() => RawInputRecords).annotate({
           identifier: "RawInputRecords",
@@ -165,7 +165,7 @@ export class UnableToDetectSchemaException
 export class UnsupportedOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedOperationException>()(
     "UnsupportedOperationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type ApplicationName = string;
 export type ApplicationVersionId = number;

--- a/packages/aws/src/services/kinesis-analytics.ts
+++ b/packages/aws/src/services/kinesis-analytics.ts
@@ -90,60 +90,60 @@ const rules = T.EndpointResolver((p, _) => {
 export class CodeValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<CodeValidationException>()(
     "CodeValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ConcurrentModificationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentModificationException>()(
     "ConcurrentModificationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InvalidApplicationConfigurationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidApplicationConfigurationException>()(
     "InvalidApplicationConfigurationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidArgumentException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidArgumentException>()(
     "InvalidArgumentException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUseException>()(
     "ResourceInUseException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceProvisionedThroughputExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceProvisionedThroughputExceededException>()(
     "ResourceProvisionedThroughputExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class UnableToDetectSchemaException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnableToDetectSchemaException>()(
     "UnableToDetectSchemaException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       RawInputRecords: S.optional(
         S.suspend(() => RawInputRecords).annotate({
           identifier: "RawInputRecords",
@@ -159,7 +159,7 @@ export class UnableToDetectSchemaException
 export class UnsupportedOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedOperationException>()(
     "UnsupportedOperationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type ApplicationName = string;
 export type ApplicationVersionId = number;

--- a/packages/aws/src/services/kinesis-video-archived-media.ts
+++ b/packages/aws/src/services/kinesis-video-archived-media.ts
@@ -88,55 +88,55 @@ const rules = T.EndpointResolver((p, _) => {
 export class ClientLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ClientLimitExceededException>()(
     "ClientLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidArgumentException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidArgumentException>()(
     "InvalidArgumentException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidCodecPrivateDataException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCodecPrivateDataException>()(
     "InvalidCodecPrivateDataException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidMediaFrameException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidMediaFrameException>()(
     "InvalidMediaFrameException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class MissingCodecPrivateDataException
   extends /*@__PURE__*/ S.TaggedErrorClass<MissingCodecPrivateDataException>()(
     "MissingCodecPrivateDataException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class NoDataRetentionException
   extends /*@__PURE__*/ S.TaggedErrorClass<NoDataRetentionException>()(
     "NoDataRetentionException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class NotAuthorizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotAuthorizedException>()(
     "NotAuthorizedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class UnsupportedStreamMediaTypeException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedStreamMediaTypeException>()(
     "UnsupportedStreamMediaTypeException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type StreamName = string;

--- a/packages/aws/src/services/kinesis-video-media.ts
+++ b/packages/aws/src/services/kinesis-video-media.ts
@@ -87,37 +87,37 @@ const rules = T.EndpointResolver((p, _) => {
 export class ClientLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ClientLimitExceededException>()(
     "ClientLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ConnectionLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConnectionLimitExceededException>()(
     "ConnectionLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidArgumentException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidArgumentException>()(
     "InvalidArgumentException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidEndpointException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidEndpointException>()(
     "InvalidEndpointException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class NotAuthorizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotAuthorizedException>()(
     "NotAuthorizedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export type StreamName = string;

--- a/packages/aws/src/services/kinesis-video-signaling.ts
+++ b/packages/aws/src/services/kinesis-video-signaling.ts
@@ -89,37 +89,37 @@ const rules = T.EndpointResolver((p, _) => {
 export class ClientLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ClientLimitExceededException>()(
     "ClientLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidArgumentException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidArgumentException>()(
     "InvalidArgumentException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidClientException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidClientException>()(
     "InvalidClientException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class NotAuthorizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotAuthorizedException>()(
     "NotAuthorizedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class SessionExpiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<SessionExpiredException>()(
     "SessionExpiredException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type ResourceARN = string;

--- a/packages/aws/src/services/kinesis-video-webrtc-storage.ts
+++ b/packages/aws/src/services/kinesis-video-webrtc-storage.ts
@@ -87,25 +87,25 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ClientLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ClientLimitExceededException>()(
     "ClientLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidArgumentException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidArgumentException>()(
     "InvalidArgumentException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export type ChannelArn = string;

--- a/packages/aws/src/services/kinesis-video.ts
+++ b/packages/aws/src/services/kinesis-video.ts
@@ -91,85 +91,85 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export class AccountChannelLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccountChannelLimitExceededException>()(
     "AccountChannelLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class AccountStreamLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccountStreamLimitExceededException>()(
     "AccountStreamLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ClientLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ClientLimitExceededException>()(
     "ClientLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class DeviceStreamLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<DeviceStreamLimitExceededException>()(
     "DeviceStreamLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidArgumentException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidArgumentException>()(
     "InvalidArgumentException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidDeviceException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDeviceException>()(
     "InvalidDeviceException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidResourceFormatException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidResourceFormatException>()(
     "InvalidResourceFormatException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class NoDataRetentionException
   extends /*@__PURE__*/ S.TaggedErrorClass<NoDataRetentionException>()(
     "NoDataRetentionException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class NotAuthorizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotAuthorizedException>()(
     "NotAuthorizedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export class ResourceInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUseException>()(
     "ResourceInUseException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class StreamEdgeConfigurationNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<StreamEdgeConfigurationNotFoundException>()(
     "StreamEdgeConfigurationNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class StreamNotActive
   extends /*@__PURE__*/ S.TaggedErrorClass<StreamNotActive>()(
     "StreamNotActive",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "ResourceNotFoundException",
       message: { includes: "not active" },
@@ -178,13 +178,13 @@ export class StreamNotActive
 export class TagsPerResourceExceededLimitException
   extends /*@__PURE__*/ S.TaggedErrorClass<TagsPerResourceExceededLimitException>()(
     "TagsPerResourceExceededLimitException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class VersionMismatchException
   extends /*@__PURE__*/ S.TaggedErrorClass<VersionMismatchException>()(
     "VersionMismatchException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type ChannelName = string;

--- a/packages/aws/src/services/kinesis.ts
+++ b/packages/aws/src/services/kinesis.ts
@@ -647,82 +647,82 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAuthError) {}
 export class ExpiredIteratorException
   extends /*@__PURE__*/ S.TaggedErrorClass<ExpiredIteratorException>()(
     "ExpiredIteratorException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class ExpiredNextTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<ExpiredNextTokenException>()(
     "ExpiredNextTokenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class InternalFailureException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalFailureException>()(
     "InternalFailureException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class InvalidArgumentException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidArgumentException>()(
     "InvalidArgumentException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class KMSAccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<KMSAccessDeniedException>()(
     "KMSAccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAuthError) {}
 export class KMSDisabledException
   extends /*@__PURE__*/ S.TaggedErrorClass<KMSDisabledException>()(
     "KMSDisabledException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class KMSInvalidStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<KMSInvalidStateException>()(
     "KMSInvalidStateException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class KMSNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<KMSNotFoundException>()(
     "KMSNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class KMSOptInRequired
   extends /*@__PURE__*/ S.TaggedErrorClass<KMSOptInRequired>()(
     "KMSOptInRequired",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class KMSThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<KMSThrottlingException>()(
     "KMSThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withQuotaError, C.withRetryableError) {}
 export class ProvisionedThroughputExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ProvisionedThroughputExceededException>()(
     "ProvisionedThroughputExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class ResourceInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUseException>()(
     "ResourceInUseException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withConflictError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withNotFoundError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export type StreamName = string;
 export type TagKey = string;

--- a/packages/aws/src/services/kms.ts
+++ b/packages/aws/src/services/kms.ts
@@ -88,7 +88,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class AlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<AlreadyExistsException>()(
     "AlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "AlreadyExists", httpResponseCode: 409 }),
       T.HttpError(409),
@@ -97,7 +97,7 @@ export class AlreadyExistsException
 export class CloudHsmClusterInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<CloudHsmClusterInUseException>()(
     "CloudHsmClusterInUseException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CloudHsmClusterInUseException",
@@ -109,7 +109,7 @@ export class CloudHsmClusterInUseException
 export class CloudHsmClusterInvalidConfigurationException
   extends /*@__PURE__*/ S.TaggedErrorClass<CloudHsmClusterInvalidConfigurationException>()(
     "CloudHsmClusterInvalidConfigurationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CloudHsmClusterInvalidConfigurationException",
@@ -121,7 +121,7 @@ export class CloudHsmClusterInvalidConfigurationException
 export class CloudHsmClusterNotActiveException
   extends /*@__PURE__*/ S.TaggedErrorClass<CloudHsmClusterNotActiveException>()(
     "CloudHsmClusterNotActiveException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CloudHsmClusterNotActiveException",
@@ -133,7 +133,7 @@ export class CloudHsmClusterNotActiveException
 export class CloudHsmClusterNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<CloudHsmClusterNotFoundException>()(
     "CloudHsmClusterNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CloudHsmClusterNotFoundException",
@@ -145,7 +145,7 @@ export class CloudHsmClusterNotFoundException
 export class CloudHsmClusterNotRelatedException
   extends /*@__PURE__*/ S.TaggedErrorClass<CloudHsmClusterNotRelatedException>()(
     "CloudHsmClusterNotRelatedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CloudHsmClusterNotRelatedException",
@@ -157,7 +157,7 @@ export class CloudHsmClusterNotRelatedException
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ConflictException", httpResponseCode: 409 }),
       T.HttpError(409),
@@ -166,7 +166,7 @@ export class ConflictException
 export class CustomKeyStoreHasCMKsException
   extends /*@__PURE__*/ S.TaggedErrorClass<CustomKeyStoreHasCMKsException>()(
     "CustomKeyStoreHasCMKsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CustomKeyStoreHasCMKsException",
@@ -178,7 +178,7 @@ export class CustomKeyStoreHasCMKsException
 export class CustomKeyStoreInvalidStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<CustomKeyStoreInvalidStateException>()(
     "CustomKeyStoreInvalidStateException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CustomKeyStoreInvalidStateException",
@@ -190,7 +190,7 @@ export class CustomKeyStoreInvalidStateException
 export class CustomKeyStoreNameInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<CustomKeyStoreNameInUseException>()(
     "CustomKeyStoreNameInUseException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CustomKeyStoreNameInUseException",
@@ -202,7 +202,7 @@ export class CustomKeyStoreNameInUseException
 export class CustomKeyStoreNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<CustomKeyStoreNotFoundException>()(
     "CustomKeyStoreNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CustomKeyStoreNotFoundException",
@@ -214,7 +214,7 @@ export class CustomKeyStoreNotFoundException
 export class DependencyTimeoutException
   extends /*@__PURE__*/ S.TaggedErrorClass<DependencyTimeoutException>()(
     "DependencyTimeoutException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "DependencyTimeout", httpResponseCode: 503 }),
       T.HttpError(503),
@@ -223,7 +223,7 @@ export class DependencyTimeoutException
 export class DisabledException
   extends /*@__PURE__*/ S.TaggedErrorClass<DisabledException>()(
     "DisabledException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "Disabled", httpResponseCode: 409 }),
       T.HttpError(409),
@@ -232,7 +232,7 @@ export class DisabledException
 export class DryRunOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<DryRunOperationException>()(
     "DryRunOperationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "DryRunOperation", httpResponseCode: 412 }),
       T.HttpError(412),
@@ -241,7 +241,7 @@ export class DryRunOperationException
 export class ExpiredImportTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<ExpiredImportTokenException>()(
     "ExpiredImportTokenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ExpiredImportTokenException",
@@ -253,7 +253,7 @@ export class ExpiredImportTokenException
 export class IncorrectKeyException
   extends /*@__PURE__*/ S.TaggedErrorClass<IncorrectKeyException>()(
     "IncorrectKeyException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "IncorrectKeyException", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -262,7 +262,7 @@ export class IncorrectKeyException
 export class IncorrectKeyMaterialException
   extends /*@__PURE__*/ S.TaggedErrorClass<IncorrectKeyMaterialException>()(
     "IncorrectKeyMaterialException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "IncorrectKeyMaterialException",
@@ -274,7 +274,7 @@ export class IncorrectKeyMaterialException
 export class IncorrectTrustAnchorException
   extends /*@__PURE__*/ S.TaggedErrorClass<IncorrectTrustAnchorException>()(
     "IncorrectTrustAnchorException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "IncorrectTrustAnchorException",
@@ -286,7 +286,7 @@ export class IncorrectTrustAnchorException
 export class InvalidAliasNameException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidAliasNameException>()(
     "InvalidAliasNameException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidAliasName", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -295,7 +295,7 @@ export class InvalidAliasNameException
 export class InvalidArnException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidArnException>()(
     "InvalidArnException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidArn", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -304,7 +304,7 @@ export class InvalidArnException
 export class InvalidCiphertextException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCiphertextException>()(
     "InvalidCiphertextException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidCiphertext", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -313,7 +313,7 @@ export class InvalidCiphertextException
 export class InvalidGrantIdException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidGrantIdException>()(
     "InvalidGrantIdException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidGrantId", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -322,7 +322,7 @@ export class InvalidGrantIdException
 export class InvalidGrantTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidGrantTokenException>()(
     "InvalidGrantTokenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidGrantToken", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -331,7 +331,7 @@ export class InvalidGrantTokenException
 export class InvalidImportTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidImportTokenException>()(
     "InvalidImportTokenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidImportTokenException",
@@ -343,7 +343,7 @@ export class InvalidImportTokenException
 export class InvalidKeyUsageException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidKeyUsageException>()(
     "InvalidKeyUsageException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidKeyUsage", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -352,7 +352,7 @@ export class InvalidKeyUsageException
 export class InvalidMarkerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidMarkerException>()(
     "InvalidMarkerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidMarker", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -361,7 +361,7 @@ export class InvalidMarkerException
 export class KeyUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<KeyUnavailableException>()(
     "KeyUnavailableException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "KeyUnavailable", httpResponseCode: 500 }),
       T.HttpError(500),
@@ -370,7 +370,7 @@ export class KeyUnavailableException
 export class KMSInternalException
   extends /*@__PURE__*/ S.TaggedErrorClass<KMSInternalException>()(
     "KMSInternalException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "KMSInternal", httpResponseCode: 500 }),
       T.HttpError(500),
@@ -379,7 +379,7 @@ export class KMSInternalException
 export class KMSInvalidMacException
   extends /*@__PURE__*/ S.TaggedErrorClass<KMSInvalidMacException>()(
     "KMSInvalidMacException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "KMSInvalidMac", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -388,7 +388,7 @@ export class KMSInvalidMacException
 export class KMSInvalidSignatureException
   extends /*@__PURE__*/ S.TaggedErrorClass<KMSInvalidSignatureException>()(
     "KMSInvalidSignatureException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "KMSInvalidSignature", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -397,7 +397,7 @@ export class KMSInvalidSignatureException
 export class KMSInvalidStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<KMSInvalidStateException>()(
     "KMSInvalidStateException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "KMSInvalidStateException",
@@ -409,7 +409,7 @@ export class KMSInvalidStateException
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "LimitExceeded", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -418,7 +418,7 @@ export class LimitExceededException
 export class MalformedPolicyDocumentException
   extends /*@__PURE__*/ S.TaggedErrorClass<MalformedPolicyDocumentException>()(
     "MalformedPolicyDocumentException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "MalformedPolicyDocument",
@@ -430,7 +430,7 @@ export class MalformedPolicyDocumentException
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "NotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -439,7 +439,7 @@ export class NotFoundException
 export class TagException
   extends /*@__PURE__*/ S.TaggedErrorClass<TagException>()(
     "TagException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "TagException", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -448,7 +448,7 @@ export class TagException
 export class UnsupportedOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedOperationException>()(
     "UnsupportedOperationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "UnsupportedOperation", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -457,7 +457,7 @@ export class UnsupportedOperationException
 export class XksKeyAlreadyInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<XksKeyAlreadyInUseException>()(
     "XksKeyAlreadyInUseException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "XksKeyAlreadyInUse", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -466,7 +466,7 @@ export class XksKeyAlreadyInUseException
 export class XksKeyInvalidConfigurationException
   extends /*@__PURE__*/ S.TaggedErrorClass<XksKeyInvalidConfigurationException>()(
     "XksKeyInvalidConfigurationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "XksKeyInvalidConfiguration",
@@ -478,7 +478,7 @@ export class XksKeyInvalidConfigurationException
 export class XksKeyNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<XksKeyNotFoundException>()(
     "XksKeyNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "XksKeyNotFoundException",
@@ -490,7 +490,7 @@ export class XksKeyNotFoundException
 export class XksProxyIncorrectAuthenticationCredentialException
   extends /*@__PURE__*/ S.TaggedErrorClass<XksProxyIncorrectAuthenticationCredentialException>()(
     "XksProxyIncorrectAuthenticationCredentialException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "XksProxyIncorrectAuthenticationCredentialException",
@@ -502,7 +502,7 @@ export class XksProxyIncorrectAuthenticationCredentialException
 export class XksProxyInvalidConfigurationException
   extends /*@__PURE__*/ S.TaggedErrorClass<XksProxyInvalidConfigurationException>()(
     "XksProxyInvalidConfigurationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "XksProxyInvalidConfigurationException",
@@ -514,7 +514,7 @@ export class XksProxyInvalidConfigurationException
 export class XksProxyInvalidResponseException
   extends /*@__PURE__*/ S.TaggedErrorClass<XksProxyInvalidResponseException>()(
     "XksProxyInvalidResponseException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "XksProxyInvalidResponseException",
@@ -526,7 +526,7 @@ export class XksProxyInvalidResponseException
 export class XksProxyUriEndpointInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<XksProxyUriEndpointInUseException>()(
     "XksProxyUriEndpointInUseException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "XksProxyUriEndpointInUseException",
@@ -538,7 +538,7 @@ export class XksProxyUriEndpointInUseException
 export class XksProxyUriInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<XksProxyUriInUseException>()(
     "XksProxyUriInUseException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "XksProxyUriInUseException",
@@ -550,7 +550,7 @@ export class XksProxyUriInUseException
 export class XksProxyUriUnreachableException
   extends /*@__PURE__*/ S.TaggedErrorClass<XksProxyUriUnreachableException>()(
     "XksProxyUriUnreachableException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "XksProxyUriUnreachableException",
@@ -562,7 +562,7 @@ export class XksProxyUriUnreachableException
 export class XksProxyVpcEndpointServiceInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<XksProxyVpcEndpointServiceInUseException>()(
     "XksProxyVpcEndpointServiceInUseException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "XksProxyVpcEndpointServiceInUseException",
@@ -574,7 +574,7 @@ export class XksProxyVpcEndpointServiceInUseException
 export class XksProxyVpcEndpointServiceInvalidConfigurationException
   extends /*@__PURE__*/ S.TaggedErrorClass<XksProxyVpcEndpointServiceInvalidConfigurationException>()(
     "XksProxyVpcEndpointServiceInvalidConfigurationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "XksProxyVpcEndpointServiceInvalidConfigurationException",
@@ -586,7 +586,7 @@ export class XksProxyVpcEndpointServiceInvalidConfigurationException
 export class XksProxyVpcEndpointServiceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<XksProxyVpcEndpointServiceNotFoundException>()(
     "XksProxyVpcEndpointServiceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "XksProxyVpcEndpointServiceNotFoundException",

--- a/packages/aws/src/services/lakeformation.ts
+++ b/packages/aws/src/services/lakeformation.ts
@@ -90,56 +90,56 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class AlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<AlreadyExistsException>()(
     "AlreadyExistsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class ConcurrentModificationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentModificationException>()(
     "ConcurrentModificationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class EntityNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<EntityNotFoundException>()(
     "EntityNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ExpiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<ExpiredException>()(
     "ExpiredException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(410),
   ).pipe(C.withBadRequestError) {}
 export class GlueEncryptionException
   extends /*@__PURE__*/ S.TaggedErrorClass<GlueEncryptionException>()(
     "GlueEncryptionException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InternalServiceException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServiceException>()(
     "InternalServiceException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidInputException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInputException>()(
     "InvalidInputException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidLakeFormationPrincipal
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidLakeFormationPrincipal>()(
     "InvalidLakeFormationPrincipal",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "InvalidInputException",
       message: { includes: "Invalid principal" },
@@ -148,7 +148,7 @@ export class InvalidLakeFormationPrincipal
 export class LastServiceLinkedRoleRegistration
   extends /*@__PURE__*/ S.TaggedErrorClass<LastServiceLinkedRoleRegistration>()(
     "LastServiceLinkedRoleRegistration",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "InvalidInputException",
       message: { includes: "Must manually delete service-linked role" },
@@ -157,58 +157,58 @@ export class LastServiceLinkedRoleRegistration
 export class OperationTimeoutException
   extends /*@__PURE__*/ S.TaggedErrorClass<OperationTimeoutException>()(
     "OperationTimeoutException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class PermissionTypeMismatchException
   extends /*@__PURE__*/ S.TaggedErrorClass<PermissionTypeMismatchException>()(
     "PermissionTypeMismatchException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceNotReadyException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotReadyException>()(
     "ResourceNotReadyException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNumberLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNumberLimitExceededException>()(
     "ResourceNumberLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class StatisticsNotReadyYetException
   extends /*@__PURE__*/ S.TaggedErrorClass<StatisticsNotReadyYetException>()(
     "StatisticsNotReadyYetException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(420),
   ) {}
 export class ThrottledException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottledException>()(
     "ThrottledException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(429), T.Retryable({ throttling: true })),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class TransactionCanceledException
   extends /*@__PURE__*/ S.TaggedErrorClass<TransactionCanceledException>()(
     "TransactionCanceledException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TransactionCommitInProgressException
   extends /*@__PURE__*/ S.TaggedErrorClass<TransactionCommitInProgressException>()(
     "TransactionCommitInProgressException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TransactionCommittedException
   extends /*@__PURE__*/ S.TaggedErrorClass<TransactionCommittedException>()(
     "TransactionCommittedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class WorkUnitsNotReadyYetException
   extends /*@__PURE__*/ S.TaggedErrorClass<WorkUnitsNotReadyYetException>()(
     "WorkUnitsNotReadyYetException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(420),
   ) {}
 export type CatalogIdString = string;

--- a/packages/aws/src/services/lambda-core.ts
+++ b/packages/aws/src/services/lambda-core.ts
@@ -88,31 +88,46 @@ const rules = T.EndpointResolver((p, _) => {
 export class InvalidParameterValueException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterValueException>()(
     "InvalidParameterValueException",
-    { Type: S.optional(S.String), message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class NetworkConnectorLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<NetworkConnectorLimitExceededException>()(
     "NetworkConnectorLimitExceededException",
-    { Type: S.optional(S.String), message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceConflictException>()(
     "ResourceConflictException",
-    { Type: S.optional(S.String), message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceException>()(
     "ServiceException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class TooManyRequestsException
@@ -121,7 +136,7 @@ export class TooManyRequestsException
     {
       retryAfterSeconds: S.optional(S.String).pipe(T.HttpHeader("Retry-After")),
       Type: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => ThrottleReason).annotate({
           identifier: "ThrottleReason",

--- a/packages/aws/src/services/lambda-microvms.ts
+++ b/packages/aws/src/services/lambda-microvms.ts
@@ -90,14 +90,14 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceType: S.optional(S.String),
     },
@@ -107,7 +107,7 @@ export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.all(T.HttpError(500), T.Retryable()),
@@ -115,20 +115,26 @@ export class InternalServerException
 export class InvalidParameterValueException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterValueException>()(
     "InvalidParameterValueException",
-    { Type: S.optional(S.String), message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceConflictException>()(
     "ResourceConflictException",
-    { Type: S.optional(S.String), message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceType: S.optional(S.String),
       resourceId: S.optional(S.String),
     },
@@ -137,14 +143,17 @@ export class ResourceNotFoundException
 export class ServiceException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceException>()(
     "ServiceException",
-    { Type: S.optional(S.String), message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceType: S.optional(S.String),
       serviceCode: S.optional(S.String),
@@ -156,7 +165,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       serviceCode: S.optional(S.String),
       quotaCode: S.optional(S.String),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
@@ -166,13 +175,16 @@ export class ThrottlingException
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { Type: S.optional(S.String), message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type MicrovmIdentifier = string;

--- a/packages/aws/src/services/lambda.ts
+++ b/packages/aws/src/services/lambda.ts
@@ -90,73 +90,109 @@ const rules = T.EndpointResolver((p, _) => {
 export class AliasLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<AliasLimitExceededException>()(
     "AliasLimitExceededException",
-    { Type: S.optional(S.String), message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class CallbackTimeoutException
   extends /*@__PURE__*/ S.TaggedErrorClass<CallbackTimeoutException>()(
     "CallbackTimeoutException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class CapacityProviderLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<CapacityProviderLimitExceededException>()(
     "CapacityProviderLimitExceededException",
-    { Type: S.optional(S.String), message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class CodeArtifactUserDeletedException
   extends /*@__PURE__*/ S.TaggedErrorClass<CodeArtifactUserDeletedException>()(
     "CodeArtifactUserDeletedException",
-    { Type: S.optional(S.String), message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class CodeArtifactUserFailedException
   extends /*@__PURE__*/ S.TaggedErrorClass<CodeArtifactUserFailedException>()(
     "CodeArtifactUserFailedException",
-    { Type: S.optional(S.String), message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class CodeArtifactUserPendingException
   extends /*@__PURE__*/ S.TaggedErrorClass<CodeArtifactUserPendingException>()(
     "CodeArtifactUserPendingException",
-    { Type: S.optional(S.String), message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class CodeSigningConfigNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<CodeSigningConfigNotFoundException>()(
     "CodeSigningConfigNotFoundException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class CodeStorageExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<CodeStorageExceededException>()(
     "CodeStorageExceededException",
-    { Type: S.optional(S.String), message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class CodeVerificationFailedException
   extends /*@__PURE__*/ S.TaggedErrorClass<CodeVerificationFailedException>()(
     "CodeVerificationFailedException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class DurableExecutionAlreadyStartedException
   extends /*@__PURE__*/ S.TaggedErrorClass<DurableExecutionAlreadyStartedException>()(
     "DurableExecutionAlreadyStartedException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class EC2AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<EC2AccessDeniedException>()(
     "EC2AccessDeniedException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(502),
   ).pipe(C.withServerError, C.withAuthError) {}
 export class EC2ThrottledException
   extends /*@__PURE__*/ S.TaggedErrorClass<EC2ThrottledException>()(
     "EC2ThrottledException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(502),
   ).pipe(C.withServerError) {}
 export class EC2UnexpectedException
@@ -164,7 +200,7 @@ export class EC2UnexpectedException
     "EC2UnexpectedException",
     {
       Type: S.optional(S.String),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       EC2ErrorCode: S.optional(S.String),
     },
     T.HttpError(502),
@@ -172,254 +208,379 @@ export class EC2UnexpectedException
 export class EFSIOException
   extends /*@__PURE__*/ S.TaggedErrorClass<EFSIOException>()(
     "EFSIOException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(410),
   ).pipe(C.withBadRequestError) {}
 export class EFSMountConnectivityException
   extends /*@__PURE__*/ S.TaggedErrorClass<EFSMountConnectivityException>()(
     "EFSMountConnectivityException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(408),
   ).pipe(C.withTimeoutError) {}
 export class EFSMountFailureException
   extends /*@__PURE__*/ S.TaggedErrorClass<EFSMountFailureException>()(
     "EFSMountFailureException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class EFSMountTimeoutException
   extends /*@__PURE__*/ S.TaggedErrorClass<EFSMountTimeoutException>()(
     "EFSMountTimeoutException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(408),
   ).pipe(C.withTimeoutError) {}
 export class ENILimitReachedException
   extends /*@__PURE__*/ S.TaggedErrorClass<ENILimitReachedException>()(
     "ENILimitReachedException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(502),
   ).pipe(C.withServerError) {}
 export class ENINotReadyException
   extends /*@__PURE__*/ S.TaggedErrorClass<ENINotReadyException>()(
     "ENINotReadyException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(502),
   ).pipe(C.withServerError) {}
 export class FunctionVersionsPerCapacityProviderLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<FunctionVersionsPerCapacityProviderLimitExceededException>()(
     "FunctionVersionsPerCapacityProviderLimitExceededException",
-    { Type: S.optional(S.String), message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidCodeSignatureException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCodeSignatureException>()(
     "InvalidCodeSignatureException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidParameterValueException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterValueException>()(
     "InvalidParameterValueException",
-    { Type: S.optional(S.String), message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidRequestContentException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestContentException>()(
     "InvalidRequestContentException",
-    { Type: S.optional(S.String), message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidRuntimeException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRuntimeException>()(
     "InvalidRuntimeException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(502),
   ).pipe(C.withServerError) {}
 export class InvalidSecurityGroupIDException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSecurityGroupIDException>()(
     "InvalidSecurityGroupIDException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(502),
   ).pipe(C.withServerError) {}
 export class InvalidSubnetIDException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSubnetIDException>()(
     "InvalidSubnetIDException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(502),
   ).pipe(C.withServerError) {}
 export class InvalidZipFileException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidZipFileException>()(
     "InvalidZipFileException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(502),
   ).pipe(C.withServerError) {}
 export class KMSAccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<KMSAccessDeniedException>()(
     "KMSAccessDeniedException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(502),
   ).pipe(C.withServerError, C.withAuthError) {}
 export class KMSDisabledException
   extends /*@__PURE__*/ S.TaggedErrorClass<KMSDisabledException>()(
     "KMSDisabledException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(502),
   ).pipe(C.withServerError) {}
 export class KMSInvalidStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<KMSInvalidStateException>()(
     "KMSInvalidStateException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(502),
   ).pipe(C.withServerError) {}
 export class KMSNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<KMSNotFoundException>()(
     "KMSNotFoundException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(502),
   ).pipe(C.withServerError) {}
 export class ModeNotSupportedException
   extends /*@__PURE__*/ S.TaggedErrorClass<ModeNotSupportedException>()(
     "ModeNotSupportedException",
-    { Type: S.optional(S.String), message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class NoPublishedVersionException
   extends /*@__PURE__*/ S.TaggedErrorClass<NoPublishedVersionException>()(
     "NoPublishedVersionException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ParseError
-  extends /*@__PURE__*/ S.TaggedErrorClass<ParseError>()("ParseError", {}) {}
+  extends /*@__PURE__*/ S.TaggedErrorClass<ParseError>()("ParseError", {
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
+  }) {}
 export class PolicyLengthExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<PolicyLengthExceededException>()(
     "PolicyLengthExceededException",
-    { Type: S.optional(S.String), message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class PreconditionFailedException
   extends /*@__PURE__*/ S.TaggedErrorClass<PreconditionFailedException>()(
     "PreconditionFailedException",
-    { Type: S.optional(S.String), message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(412),
   ) {}
 export class ProvisionedConcurrencyConfigNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ProvisionedConcurrencyConfigNotFoundException>()(
     "ProvisionedConcurrencyConfigNotFoundException",
-    { Type: S.optional(S.String), message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class PublicPolicyException
   extends /*@__PURE__*/ S.TaggedErrorClass<PublicPolicyException>()(
     "PublicPolicyException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class RecursiveInvocationException
   extends /*@__PURE__*/ S.TaggedErrorClass<RecursiveInvocationException>()(
     "RecursiveInvocationException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class RequestLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<RequestLimitExceeded>()(
     "RequestLimitExceeded",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withThrottlingError) {}
 export class RequestTooLargeException
   extends /*@__PURE__*/ S.TaggedErrorClass<RequestTooLargeException>()(
     "RequestTooLargeException",
-    { Type: S.optional(S.String), message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(413),
   ).pipe(C.withBadRequestError) {}
 export class ResourceConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceConflictException>()(
     "ResourceConflictException",
-    { Type: S.optional(S.String), message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ResourceInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUseException>()(
     "ResourceInUseException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotReadyException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotReadyException>()(
     "ResourceNotReadyException",
-    { Type: S.optional(S.String), message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(502),
   ).pipe(C.withServerError) {}
 export class S3FilesMountConnectivityException
   extends /*@__PURE__*/ S.TaggedErrorClass<S3FilesMountConnectivityException>()(
     "S3FilesMountConnectivityException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(408),
   ).pipe(C.withTimeoutError) {}
 export class S3FilesMountFailureException
   extends /*@__PURE__*/ S.TaggedErrorClass<S3FilesMountFailureException>()(
     "S3FilesMountFailureException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class S3FilesMountTimeoutException
   extends /*@__PURE__*/ S.TaggedErrorClass<S3FilesMountTimeoutException>()(
     "S3FilesMountTimeoutException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(408),
   ).pipe(C.withTimeoutError) {}
 export class SerializedRequestEntityTooLargeException
   extends /*@__PURE__*/ S.TaggedErrorClass<SerializedRequestEntityTooLargeException>()(
     "SerializedRequestEntityTooLargeException",
-    { Type: S.optional(S.String), message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(413),
   ).pipe(C.withBadRequestError) {}
 export class ServiceException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceException>()(
     "ServiceException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class SnapStartException
   extends /*@__PURE__*/ S.TaggedErrorClass<SnapStartException>()(
     "SnapStartException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class SnapStartNotReadyException
   extends /*@__PURE__*/ S.TaggedErrorClass<SnapStartNotReadyException>()(
     "SnapStartNotReadyException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class SnapStartRegenerationFailureException
   extends /*@__PURE__*/ S.TaggedErrorClass<SnapStartRegenerationFailureException>()(
     "SnapStartRegenerationFailureException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class SnapStartTimeoutException
   extends /*@__PURE__*/ S.TaggedErrorClass<SnapStartTimeoutException>()(
     "SnapStartTimeoutException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(408),
   ).pipe(C.withTimeoutError) {}
 export class SubnetIPAddressLimitReachedException
   extends /*@__PURE__*/ S.TaggedErrorClass<SubnetIPAddressLimitReachedException>()(
     "SubnetIPAddressLimitReachedException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(502),
   ).pipe(C.withServerError) {}
 export class TooManyRequestsException
@@ -428,7 +589,7 @@ export class TooManyRequestsException
     {
       retryAfterSeconds: S.optional(S.String).pipe(T.HttpHeader("Retry-After")),
       Type: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => ThrottleReason).annotate({
           identifier: "ThrottleReason",
@@ -440,7 +601,10 @@ export class TooManyRequestsException
 export class UnsupportedMediaTypeException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedMediaTypeException>()(
     "UnsupportedMediaTypeException",
-    { Type: S.optional(S.String), message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(415),
   ).pipe(C.withBadRequestError) {}
 export type LayerName = string;

--- a/packages/aws/src/services/launch-wizard.ts
+++ b/packages/aws/src/services/launch-wizard.ts
@@ -88,25 +88,25 @@ const rules = T.EndpointResolver((p, _) => {
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceLimitException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceLimitException>()(
     "ResourceLimitException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type WorkloadName = string;

--- a/packages/aws/src/services/lex-model-building-service.ts
+++ b/packages/aws/src/services/lex-model-building-service.ts
@@ -100,25 +100,25 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalFailureException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalFailureException>()(
     "InternalFailureException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class LimitExceededException
@@ -126,20 +126,20 @@ export class LimitExceededException
     "LimitExceededException",
     {
       retryAfterSeconds: S.optional(S.String).pipe(T.HttpHeader("Retry-After")),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class PreconditionFailedException
   extends /*@__PURE__*/ S.TaggedErrorClass<PreconditionFailedException>()(
     "PreconditionFailedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(412),
   ) {}
 export class ResourceInUseException
@@ -156,6 +156,7 @@ export class ResourceInUseException
           identifier: "ResourceReference",
         }),
       ),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}

--- a/packages/aws/src/services/lex-models-v2.ts
+++ b/packages/aws/src/services/lex-models-v2.ts
@@ -90,31 +90,31 @@ const rules = T.EndpointResolver((p, _) => {
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class PreconditionFailedException
   extends /*@__PURE__*/ S.TaggedErrorClass<PreconditionFailedException>()(
     "PreconditionFailedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(412),
   ) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
@@ -122,14 +122,14 @@ export class ThrottlingException
     "ThrottlingException",
     {
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type Id = string;

--- a/packages/aws/src/services/lex-runtime-service.ts
+++ b/packages/aws/src/services/lex-runtime-service.ts
@@ -101,31 +101,31 @@ const rules = T.EndpointResolver((p, _) => {
 export class BadGatewayException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadGatewayException>()(
     "BadGatewayException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(502),
   ).pipe(C.withServerError) {}
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class DependencyFailedException
   extends /*@__PURE__*/ S.TaggedErrorClass<DependencyFailedException>()(
     "DependencyFailedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(424),
   ) {}
 export class InternalFailureException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalFailureException>()(
     "InternalFailureException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class LimitExceededException
@@ -133,38 +133,38 @@ export class LimitExceededException
     "LimitExceededException",
     {
       retryAfterSeconds: S.optional(S.String).pipe(T.HttpHeader("Retry-After")),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class LoopDetectedException
   extends /*@__PURE__*/ S.TaggedErrorClass<LoopDetectedException>()(
     "LoopDetectedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(508),
   ).pipe(C.withServerError) {}
 export class NotAcceptableException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotAcceptableException>()(
     "NotAcceptableException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(406),
   ).pipe(C.withBadRequestError) {}
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class RequestTimeoutException
   extends /*@__PURE__*/ S.TaggedErrorClass<RequestTimeoutException>()(
     "RequestTimeoutException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(408),
   ).pipe(C.withTimeoutError) {}
 export class UnsupportedMediaTypeException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedMediaTypeException>()(
     "UnsupportedMediaTypeException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(415),
   ).pipe(C.withBadRequestError) {}
 export type BotName = string;

--- a/packages/aws/src/services/lex-runtime-v2.ts
+++ b/packages/aws/src/services/lex-runtime-v2.ts
@@ -90,49 +90,49 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class BadGatewayException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadGatewayException>()(
     "BadGatewayException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(502),
   ).pipe(C.withServerError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class DependencyFailedException
   extends /*@__PURE__*/ S.TaggedErrorClass<DependencyFailedException>()(
     "DependencyFailedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(424),
   ) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type BotIdentifier = string;

--- a/packages/aws/src/services/license-manager-linux-subscriptions.ts
+++ b/packages/aws/src/services/license-manager-linux-subscriptions.ts
@@ -87,22 +87,22 @@ const rules = T.EndpointResolver((p, _) => {
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type SubscriptionProviderArn = string;
 export interface DeregisterSubscriptionProviderRequest {

--- a/packages/aws/src/services/license-manager-user-subscriptions.ts
+++ b/packages/aws/src/services/license-manager-user-subscriptions.ts
@@ -88,39 +88,39 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type Directory = string;
 export type IpV4 = string;

--- a/packages/aws/src/services/license-manager.ts
+++ b/packages/aws/src/services/license-manager.ts
@@ -92,7 +92,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ServiceAccessDenied", httpResponseCode: 401 }),
       T.HttpError(401),
@@ -101,7 +101,7 @@ export class AccessDeniedException
 export class AuthorizationException
   extends /*@__PURE__*/ S.TaggedErrorClass<AuthorizationException>()(
     "AuthorizationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "AuthorizationFailure", httpResponseCode: 403 }),
       T.HttpError(403),
@@ -110,7 +110,7 @@ export class AuthorizationException
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ConflictException", httpResponseCode: 409 }),
       T.HttpError(409),
@@ -119,13 +119,16 @@ export class ConflictException
 export class EntitlementNotAllowedException
   extends /*@__PURE__*/ S.TaggedErrorClass<EntitlementNotAllowedException>()(
     "EntitlementNotAllowedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class FailedDependencyException
   extends /*@__PURE__*/ S.TaggedErrorClass<FailedDependencyException>()(
     "FailedDependencyException",
-    { Message: S.optional(S.String), ErrorCode: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ErrorCode: S.optional(S.String),
+    },
     T.all(
       T.AwsQueryError({ code: "FailedDependency", httpResponseCode: 424 }),
       T.HttpError(424),
@@ -134,7 +137,7 @@ export class FailedDependencyException
 export class FilterLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<FilterLimitExceededException>()(
     "FilterLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "FilterLimitExceeded", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -143,7 +146,7 @@ export class FilterLimitExceededException
 export class InvalidParameterValueException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterValueException>()(
     "InvalidParameterValueException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidParameterValueProvided",
@@ -155,7 +158,7 @@ export class InvalidParameterValueException
 export class InvalidResourceStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidResourceStateException>()(
     "InvalidResourceStateException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidResourceState", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -164,7 +167,7 @@ export class InvalidResourceStateException
 export class LicenseConfigurationNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<LicenseConfigurationNotFound>()(
     "LicenseConfigurationNotFound",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "InvalidParameterValueException",
       message: { includes: "Invalid license configuration ARN" },
@@ -173,7 +176,7 @@ export class LicenseConfigurationNotFound
 export class LicenseUsageException
   extends /*@__PURE__*/ S.TaggedErrorClass<LicenseUsageException>()(
     "LicenseUsageException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "LicenseUsageFailure", httpResponseCode: 412 }),
       T.HttpError(412),
@@ -182,13 +185,13 @@ export class LicenseUsageException
 export class NoEntitlementsAllowedException
   extends /*@__PURE__*/ S.TaggedErrorClass<NoEntitlementsAllowedException>()(
     "NoEntitlementsAllowedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class RateLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<RateLimitExceededException>()(
     "RateLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "RateLimitExceeded", httpResponseCode: 429 }),
       T.HttpError(429),
@@ -199,14 +202,14 @@ export class RedirectException
     "RedirectException",
     {
       Location: S.optional(S.String).pipe(T.HttpHeader("Location")),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(308),
   ) {}
 export class ResourceLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceLimitExceededException>()(
     "ResourceLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ResourceLimitExceeded", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -215,7 +218,7 @@ export class ResourceLimitExceededException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidResource.NotFound",
@@ -227,7 +230,7 @@ export class ResourceNotFoundException
 export class ServerInternalException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServerInternalException>()(
     "ServerInternalException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InternalError", httpResponseCode: 500 }),
       T.HttpError(500),
@@ -236,13 +239,13 @@ export class ServerInternalException
 export class UnsupportedDigitalSignatureMethodException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedDigitalSignatureMethodException>()(
     "UnsupportedDigitalSignatureMethodException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type Arn = string;

--- a/packages/aws/src/services/lightsail.ts
+++ b/packages/aws/src/services/lightsail.ts
@@ -92,7 +92,7 @@ export class AccessDeniedException
     {
       code: S.optional(S.String),
       docs: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       tip: S.optional(S.String),
     },
     T.HttpError(403),
@@ -103,7 +103,7 @@ export class AccountSetupInProgressException
     {
       code: S.optional(S.String),
       docs: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       tip: S.optional(S.String),
     },
     T.HttpError(428),
@@ -114,7 +114,7 @@ export class InvalidInputException
     {
       code: S.optional(S.String),
       docs: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       tip: S.optional(S.String),
     },
     T.HttpError(400),
@@ -125,7 +125,7 @@ export class NotFoundException
     {
       code: S.optional(S.String),
       docs: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       tip: S.optional(S.String),
     },
     T.HttpError(404),
@@ -136,7 +136,7 @@ export class OperationFailureException
     {
       code: S.optional(S.String),
       docs: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       tip: S.optional(S.String),
     },
     T.HttpError(400),
@@ -147,7 +147,7 @@ export class RegionSetupInProgressException
     {
       code: S.optional(S.String),
       docs: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       tip: S.optional(S.String),
     },
     T.HttpError(428),
@@ -158,7 +158,7 @@ export class ServiceException
     {
       code: S.optional(S.String),
       docs: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       tip: S.optional(S.String),
     },
     T.HttpError(500),
@@ -169,7 +169,7 @@ export class UnauthenticatedException
     {
       code: S.optional(S.String),
       docs: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       tip: S.optional(S.String),
     },
     T.HttpError(401),

--- a/packages/aws/src/services/location.ts
+++ b/packages/aws/src/services/location.ts
@@ -90,44 +90,44 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(429), T.Retryable()),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       Reason: S.String,
       FieldList: S.suspend(() => ValidationExceptionFieldList).annotate({
         identifier: "ValidationExceptionFieldList",

--- a/packages/aws/src/services/lookoutequipment.ts
+++ b/packages/aws/src/services/lookoutequipment.ts
@@ -88,43 +88,43 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type DatasetName = string;

--- a/packages/aws/src/services/m2.ts
+++ b/packages/aws/src/services/m2.ts
@@ -88,14 +88,14 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceType: S.optional(S.String),
     },
@@ -104,14 +104,14 @@ export class ConflictException
 export class ExecutionTimeoutException
   extends /*@__PURE__*/ S.TaggedErrorClass<ExecutionTimeoutException>()(
     "ExecutionTimeoutException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(504), T.Retryable()),
   ).pipe(C.withTimeoutError, C.withRetryableError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.all(T.HttpError(500), T.Retryable()),
@@ -120,7 +120,7 @@ export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceType: S.optional(S.String),
     },
@@ -130,7 +130,7 @@ export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceType: S.optional(S.String),
       serviceCode: S.optional(S.String),
@@ -141,14 +141,14 @@ export class ServiceQuotaExceededException
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(503), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       serviceCode: S.optional(S.String),
       quotaCode: S.optional(S.String),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
@@ -159,7 +159,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.optional(S.String),
       fieldList: S.optional(
         S.suspend(() => ValidationExceptionFieldList).annotate({

--- a/packages/aws/src/services/machine-learning.ts
+++ b/packages/aws/src/services/machine-learning.ts
@@ -93,48 +93,63 @@ const rules = T.EndpointResolver((p, _) => {
 export class IdempotentParameterMismatchException
   extends /*@__PURE__*/ S.TaggedErrorClass<IdempotentParameterMismatchException>()(
     "IdempotentParameterMismatchException",
-    { message: S.optional(S.String), code: S.optional(S.Number) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      code: S.optional(S.Number),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String), code: S.optional(S.Number) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      code: S.optional(S.Number),
+    },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidInputException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInputException>()(
     "InvalidInputException",
-    { message: S.optional(S.String), code: S.optional(S.Number) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      code: S.optional(S.Number),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidTagException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTagException>()(
     "InvalidTagException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String), code: S.optional(S.Number) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      code: S.optional(S.Number),
+    },
     T.HttpError(417),
   ) {}
 export class PredictorNotMountedException
   extends /*@__PURE__*/ S.TaggedErrorClass<PredictorNotMountedException>()(
     "PredictorNotMountedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String), code: S.optional(S.Number) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      code: S.optional(S.Number),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class TagLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<TagLimitExceededException>()(
     "TagLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type TagKey = string;
 export type TagValue = string;

--- a/packages/aws/src/services/macie2.ts
+++ b/packages/aws/src/services/macie2.ts
@@ -87,25 +87,25 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class MacieNotEnabled
   extends /*@__PURE__*/ S.TaggedErrorClass<MacieNotEnabled>()(
     "MacieNotEnabled",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "AccessDeniedException",
       message: { matches: "Macie is(n[’']t| not) enabled" },
@@ -114,31 +114,31 @@ export class MacieNotEnabled
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class UnprocessableEntityException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnprocessableEntityException>()(
     "UnprocessableEntityException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(422),
   ).pipe(C.withBadRequestError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export interface AcceptInvitationRequest {

--- a/packages/aws/src/services/mailmanager.ts
+++ b/packages/aws/src/services/mailmanager.ts
@@ -90,37 +90,37 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type IdempotencyToken = string;

--- a/packages/aws/src/services/managedblockchain-query.ts
+++ b/packages/aws/src/services/managedblockchain-query.ts
@@ -88,14 +88,14 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.all(T.HttpError(500), T.Retryable()),
@@ -103,14 +103,18 @@ export class InternalServerException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.String,
       resourceType: S.String,
       serviceCode: S.String,
@@ -122,7 +126,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       serviceCode: S.String,
       quotaCode: S.String,
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
@@ -133,7 +137,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.String,
       fieldList: S.optional(
         S.suspend(() => ValidationExceptionFieldList).annotate({

--- a/packages/aws/src/services/managedblockchain.ts
+++ b/packages/aws/src/services/managedblockchain.ts
@@ -90,61 +90,67 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class IllegalActionException
   extends /*@__PURE__*/ S.TaggedErrorClass<IllegalActionException>()(
     "IllegalActionException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InternalServiceErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServiceErrorException>()(
     "InternalServiceErrorException",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceAlreadyExistsException>()(
     "ResourceAlreadyExistsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class ResourceLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceLimitExceededException>()(
     "ResourceLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String), ResourceName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ResourceName: S.optional(S.String),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotReadyException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotReadyException>()(
     "ResourceNotReadyException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { Message: S.optional(S.String), ResourceName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ResourceName: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type ClientRequestTokenString = string;

--- a/packages/aws/src/services/marketplace-agreement.ts
+++ b/packages/aws/src/services/marketplace-agreement.ts
@@ -92,7 +92,7 @@ export class AccessDeniedException
     "AccessDeniedException",
     {
       requestId: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       reason: S.optional(
         S.suspend(() => AccessDeniedExceptionReason).annotate({
           identifier: "AccessDeniedExceptionReason",
@@ -106,7 +106,7 @@ export class ConflictException
     "ConflictException",
     {
       requestId: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceType: S.optional(
         S.suspend(() => ResourceType).annotate({ identifier: "ResourceType" }),
@@ -117,7 +117,10 @@ export class ConflictException
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { requestId: S.optional(S.String), message: S.optional(S.String) },
+    {
+      requestId: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
@@ -125,7 +128,7 @@ export class ResourceNotFoundException
     "ResourceNotFoundException",
     {
       requestId: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceType: S.optional(
         S.suspend(() => ResourceType).annotate({ identifier: "ResourceType" }),
@@ -138,7 +141,7 @@ export class ServiceQuotaExceededException
     "ServiceQuotaExceededException",
     {
       requestId: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       quotaCode: S.optional(S.String),
       serviceCode: S.optional(S.String),
       resourceType: S.optional(S.String),
@@ -149,7 +152,10 @@ export class ServiceQuotaExceededException
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { requestId: S.optional(S.String), message: S.optional(S.String) },
+    {
+      requestId: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
@@ -157,7 +163,7 @@ export class ValidationException
     "ValidationException",
     {
       requestId: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       reason: S.optional(
         S.suspend(() => ValidationExceptionReason).annotate({
           identifier: "ValidationExceptionReason",

--- a/packages/aws/src/services/marketplace-catalog.ts
+++ b/packages/aws/src/services/marketplace-catalog.ts
@@ -97,49 +97,49 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class InternalServiceException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServiceException>()(
     "InternalServiceException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUseException>()(
     "ResourceInUseException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(423),
   ) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotSupportedException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotSupportedException>()(
     "ResourceNotSupportedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(415),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(422),
   ).pipe(C.withBadRequestError) {}
 export type Catalog = string;

--- a/packages/aws/src/services/marketplace-commerce-analytics.ts
+++ b/packages/aws/src/services/marketplace-commerce-analytics.ts
@@ -86,7 +86,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class MarketplaceCommerceAnalyticsException
   extends /*@__PURE__*/ S.TaggedErrorClass<MarketplaceCommerceAnalyticsException>()(
     "MarketplaceCommerceAnalyticsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type DataSetType =
   | "customer_subscriber_hourly_monthly_subscriptions"

--- a/packages/aws/src/services/marketplace-deployment.ts
+++ b/packages/aws/src/services/marketplace-deployment.ts
@@ -89,43 +89,43 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String, resourceId: S.String },
+    { message: S.String.pipe(T.ErrorMessage()), resourceId: S.String },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(429), T.Retryable({ throttling: true })),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.String, fieldName: S.String },
+    { message: S.String.pipe(T.ErrorMessage()), fieldName: S.String },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export interface ListTagsForResourceRequest {

--- a/packages/aws/src/services/marketplace-discovery.ts
+++ b/packages/aws/src/services/marketplace-discovery.ts
@@ -55,7 +55,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export type ListingId = string;

--- a/packages/aws/src/services/marketplace-entitlement-service.ts
+++ b/packages/aws/src/services/marketplace-entitlement-service.ts
@@ -121,17 +121,17 @@ const rules = T.EndpointResolver((p, _) => {
 export class InternalServiceErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServiceErrorException>()(
     "InternalServiceErrorException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterException>()(
     "InvalidParameterException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type ProductCode = string;
 export type GetEntitlementFilterName =

--- a/packages/aws/src/services/marketplace-metering.ts
+++ b/packages/aws/src/services/marketplace-metering.ts
@@ -121,98 +121,98 @@ const rules = T.EndpointResolver((p, _) => {
 export class CustomerNotEntitledException
   extends /*@__PURE__*/ S.TaggedErrorClass<CustomerNotEntitledException>()(
     "CustomerNotEntitledException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class DisabledApiException
   extends /*@__PURE__*/ S.TaggedErrorClass<DisabledApiException>()(
     "DisabledApiException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class DuplicateRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicateRequestException>()(
     "DuplicateRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ExpiredTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<ExpiredTokenException>()(
     "ExpiredTokenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class IdempotencyConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<IdempotencyConflictException>()(
     "IdempotencyConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServiceErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServiceErrorException>()(
     "InternalServiceErrorException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidCustomerIdentifierException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCustomerIdentifierException>()(
     "InvalidCustomerIdentifierException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidEndpointRegionException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidEndpointRegionException>()(
     "InvalidEndpointRegionException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidLicenseException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidLicenseException>()(
     "InvalidLicenseException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidProductCodeException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidProductCodeException>()(
     "InvalidProductCodeException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidPublicKeyVersionException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPublicKeyVersionException>()(
     "InvalidPublicKeyVersionException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRegionException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRegionException>()(
     "InvalidRegionException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTagException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTagException>()(
     "InvalidTagException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTokenException>()(
     "InvalidTokenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidUsageAllocationsException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidUsageAllocationsException>()(
     "InvalidUsageAllocationsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidUsageDimensionException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidUsageDimensionException>()(
     "InvalidUsageDimensionException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class PlatformNotSupportedException
   extends /*@__PURE__*/ S.TaggedErrorClass<PlatformNotSupportedException>()(
     "PlatformNotSupportedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TimestampOutOfBoundsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TimestampOutOfBoundsException>()(
     "TimestampOutOfBoundsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type CustomerIdentifier = string;
 export type UsageDimension = string;

--- a/packages/aws/src/services/marketplace-reporting.ts
+++ b/packages/aws/src/services/marketplace-reporting.ts
@@ -87,25 +87,25 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class UnauthorizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnauthorizedException>()(
     "UnauthorizedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export type DashboardIdentifier = string;

--- a/packages/aws/src/services/mediaconnect.ts
+++ b/packages/aws/src/services/mediaconnect.ts
@@ -88,91 +88,91 @@ const rules = T.EndpointResolver((p, _) => {
 export class AddFlowOutputs420Exception
   extends /*@__PURE__*/ S.TaggedErrorClass<AddFlowOutputs420Exception>()(
     "AddFlowOutputs420Exception",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(420),
   ) {}
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(409), T.Retryable()),
   ).pipe(C.withConflictError, C.withRetryableError) {}
 export class CreateBridge420Exception
   extends /*@__PURE__*/ S.TaggedErrorClass<CreateBridge420Exception>()(
     "CreateBridge420Exception",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(420),
   ) {}
 export class CreateFlow420Exception
   extends /*@__PURE__*/ S.TaggedErrorClass<CreateFlow420Exception>()(
     "CreateFlow420Exception",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(420),
   ) {}
 export class CreateGateway420Exception
   extends /*@__PURE__*/ S.TaggedErrorClass<CreateGateway420Exception>()(
     "CreateGateway420Exception",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(420),
   ) {}
 export class ForbiddenException
   extends /*@__PURE__*/ S.TaggedErrorClass<ForbiddenException>()(
     "ForbiddenException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class GrantFlowEntitlements420Exception
   extends /*@__PURE__*/ S.TaggedErrorClass<GrantFlowEntitlements420Exception>()(
     "GrantFlowEntitlements420Exception",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(420),
   ) {}
 export class InternalServerErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerErrorException>()(
     "InternalServerErrorException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class RouterInputServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<RouterInputServiceQuotaExceededException>()(
     "RouterInputServiceQuotaExceededException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(420),
   ) {}
 export class RouterNetworkInterfaceServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<RouterNetworkInterfaceServiceQuotaExceededException>()(
     "RouterNetworkInterfaceServiceQuotaExceededException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(420),
   ) {}
 export class RouterOutputServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<RouterOutputServiceQuotaExceededException>()(
     "RouterOutputServiceQuotaExceededException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(420),
   ) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(503), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(429), T.Retryable()),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export type BridgeArn = string;

--- a/packages/aws/src/services/mediaconvert.ts
+++ b/packages/aws/src/services/mediaconvert.ts
@@ -98,43 +98,43 @@ const rules = T.EndpointResolver((p, _) => {
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ForbiddenException
   extends /*@__PURE__*/ S.TaggedErrorClass<ForbiddenException>()(
     "ForbiddenException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class InternalServerErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerErrorException>()(
     "InternalServerErrorException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export interface AssociateCertificateRequest {

--- a/packages/aws/src/services/medialive.ts
+++ b/packages/aws/src/services/medialive.ts
@@ -90,44 +90,44 @@ const rules = T.EndpointResolver((p, _) => {
 export class BadGatewayException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadGatewayException>()(
     "BadGatewayException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(502),
   ).pipe(C.withServerError) {}
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ForbiddenException
   extends /*@__PURE__*/ S.TaggedErrorClass<ForbiddenException>()(
     "ForbiddenException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class GatewayTimeoutException
   extends /*@__PURE__*/ S.TaggedErrorClass<GatewayTimeoutException>()(
     "GatewayTimeoutException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(504),
   ).pipe(C.withTimeoutError) {}
 export class InternalServerErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerErrorException>()(
     "InternalServerErrorException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class MediaLiveRoleNotYetTrusted
   extends /*@__PURE__*/ S.TaggedErrorClass<MediaLiveRoleNotYetTrusted>()(
     "MediaLiveRoleNotYetTrusted",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       ValidationErrors: S.optional(
         S.suspend(() => __listOfValidationError).annotate({
           identifier: "__listOfValidationError",
@@ -142,20 +142,20 @@ export class MediaLiveRoleNotYetTrusted
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class UnprocessableEntityException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnprocessableEntityException>()(
     "UnprocessableEntityException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       ValidationErrors: S.optional(
         S.suspend(() => __listOfValidationError).annotate({
           identifier: "__listOfValidationError",

--- a/packages/aws/src/services/mediapackage-vod.ts
+++ b/packages/aws/src/services/mediapackage-vod.ts
@@ -88,37 +88,37 @@ const rules = T.EndpointResolver((p, _) => {
 export class ForbiddenException
   extends /*@__PURE__*/ S.TaggedErrorClass<ForbiddenException>()(
     "ForbiddenException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class InternalServerErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerErrorException>()(
     "InternalServerErrorException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class UnprocessableEntityException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnprocessableEntityException>()(
     "UnprocessableEntityException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(422),
   ).pipe(C.withBadRequestError) {}
 export interface EgressAccessLogs {

--- a/packages/aws/src/services/mediapackage.ts
+++ b/packages/aws/src/services/mediapackage.ts
@@ -90,37 +90,37 @@ const rules = T.EndpointResolver((p, _) => {
 export class ForbiddenException
   extends /*@__PURE__*/ S.TaggedErrorClass<ForbiddenException>()(
     "ForbiddenException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class InternalServerErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerErrorException>()(
     "InternalServerErrorException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class UnprocessableEntityException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnprocessableEntityException>()(
     "UnprocessableEntityException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(422),
   ).pipe(C.withBadRequestError) {}
 export interface EgressAccessLogs {

--- a/packages/aws/src/services/mediapackagev2.ts
+++ b/packages/aws/src/services/mediapackagev2.ts
@@ -88,14 +88,14 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       ConflictExceptionType: S.optional(
         S.suspend(() => ConflictExceptionType).annotate({
           identifier: "ConflictExceptionType",
@@ -107,14 +107,14 @@ export class ConflictException
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       ResourceTypeNotFound: S.optional(
         S.suspend(() => ResourceTypeNotFound).annotate({
           identifier: "ResourceTypeNotFound",
@@ -126,20 +126,20 @@ export class ResourceNotFoundException
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       ValidationExceptionType: S.optional(
         S.suspend(() => ValidationExceptionType).annotate({
           identifier: "ValidationExceptionType",

--- a/packages/aws/src/services/mediastore-data.ts
+++ b/packages/aws/src/services/mediastore-data.ts
@@ -91,24 +91,24 @@ const rules = T.EndpointResolver((p, _) => {
 export class ContainerNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ContainerNotFoundException>()(
     "ContainerNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class InternalServerError
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerError>()(
     "InternalServerError",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ObjectNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ObjectNotFoundException>()(
     "ObjectNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class RequestedRangeNotSatisfiableException
   extends /*@__PURE__*/ S.TaggedErrorClass<RequestedRangeNotSatisfiableException>()(
     "RequestedRangeNotSatisfiableException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(416),
   ) {}
 export type PathNaming = string;

--- a/packages/aws/src/services/mediastore.ts
+++ b/packages/aws/src/services/mediastore.ts
@@ -88,32 +88,32 @@ const rules = T.EndpointResolver((p, _) => {
 export class ContainerInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ContainerInUseException>()(
     "ContainerInUseException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ContainerNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ContainerNotFoundException>()(
     "ContainerNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class CorsPolicyNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<CorsPolicyNotFoundException>()(
     "CorsPolicyNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InternalServerError
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerError>()(
     "InternalServerError",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class PolicyNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<PolicyNotFoundException>()(
     "PolicyNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type ContainerName = string;
 export type TagKey = string;

--- a/packages/aws/src/services/mediatailor.ts
+++ b/packages/aws/src/services/mediatailor.ts
@@ -97,19 +97,19 @@ const rules = T.EndpointResolver((p, _) => {
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ChannelNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<ChannelNotFound>()(
     "ChannelNotFound",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({ from: "NotFoundException", message: { matches: ".*" } }),
   ).pipe(C.withNotFoundError) {}
 export class PlaybackConfigurationNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<PlaybackConfigurationNotFound>()(
     "PlaybackConfigurationNotFound",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "NotFoundException",
       message: { includes: "not found" },
@@ -118,13 +118,13 @@ export class PlaybackConfigurationNotFound
 export class PrefetchScheduleNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<PrefetchScheduleNotFound>()(
     "PrefetchScheduleNotFound",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({ from: "NotFoundException", message: { matches: ".*" } }),
   ).pipe(C.withNotFoundError) {}
 export class ProgramNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<ProgramNotFound>()(
     "ProgramNotFound",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({ from: "NotFoundException", message: { matches: ".*" } }),
   ).pipe(C.withNotFoundError) {}
 export type LogType = "AS_RUN" | (string & {});

--- a/packages/aws/src/services/medical-imaging.ts
+++ b/packages/aws/src/services/medical-imaging.ts
@@ -90,55 +90,55 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class NotAcceptableException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotAcceptableException>()(
     "NotAcceptableException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(406),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type DatastoreId = string;

--- a/packages/aws/src/services/memorydb.ts
+++ b/packages/aws/src/services/memorydb.ts
@@ -106,7 +106,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class ACLAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ACLAlreadyExistsFault>()(
     "ACLAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ACLAlreadyExists", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -115,7 +115,7 @@ export class ACLAlreadyExistsFault
 export class ACLNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ACLNotFoundFault>()(
     "ACLNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ACLNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -124,7 +124,7 @@ export class ACLNotFoundFault
 export class ACLQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ACLQuotaExceededFault>()(
     "ACLQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ACLQuotaExceeded", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -133,7 +133,7 @@ export class ACLQuotaExceededFault
 export class APICallRateForCustomerExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<APICallRateForCustomerExceededFault>()(
     "APICallRateForCustomerExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "APICallRateForCustomerExceeded",
@@ -145,7 +145,7 @@ export class APICallRateForCustomerExceededFault
 export class ClusterAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ClusterAlreadyExistsFault>()(
     "ClusterAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ClusterAlreadyExists", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -154,7 +154,7 @@ export class ClusterAlreadyExistsFault
 export class ClusterNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ClusterNotFoundFault>()(
     "ClusterNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ClusterNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -163,7 +163,7 @@ export class ClusterNotFoundFault
 export class ClusterQuotaForCustomerExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ClusterQuotaForCustomerExceededFault>()(
     "ClusterQuotaForCustomerExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ClusterQuotaForCustomerExceeded",
@@ -175,7 +175,7 @@ export class ClusterQuotaForCustomerExceededFault
 export class DefaultUserRequired
   extends /*@__PURE__*/ S.TaggedErrorClass<DefaultUserRequired>()(
     "DefaultUserRequired",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "DefaultUserRequired", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -184,7 +184,7 @@ export class DefaultUserRequired
 export class DuplicateUserNameFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicateUserNameFault>()(
     "DuplicateUserNameFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "DuplicateUserName", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -193,7 +193,7 @@ export class DuplicateUserNameFault
 export class InsufficientClusterCapacityFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InsufficientClusterCapacityFault>()(
     "InsufficientClusterCapacityFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InsufficientClusterCapacity",
@@ -205,7 +205,7 @@ export class InsufficientClusterCapacityFault
 export class InvalidACLStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidACLStateFault>()(
     "InvalidACLStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidACLState", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -214,7 +214,7 @@ export class InvalidACLStateFault
 export class InvalidARNFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidARNFault>()(
     "InvalidARNFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidARN", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -223,7 +223,7 @@ export class InvalidARNFault
 export class InvalidClusterStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidClusterStateFault>()(
     "InvalidClusterStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidClusterState", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -232,7 +232,7 @@ export class InvalidClusterStateFault
 export class InvalidCredentialsException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCredentialsException>()(
     "InvalidCredentialsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidCredentialsException",
@@ -244,7 +244,7 @@ export class InvalidCredentialsException
 export class InvalidKMSKeyFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidKMSKeyFault>()(
     "InvalidKMSKeyFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidKMSKeyFault", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -253,7 +253,7 @@ export class InvalidKMSKeyFault
 export class InvalidMultiRegionClusterStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidMultiRegionClusterStateFault>()(
     "InvalidMultiRegionClusterStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidMultiRegionClusterState",
@@ -265,7 +265,7 @@ export class InvalidMultiRegionClusterStateFault
 export class InvalidNodeStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNodeStateFault>()(
     "InvalidNodeStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidNodeState", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -274,7 +274,7 @@ export class InvalidNodeStateFault
 export class InvalidParameterCombinationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterCombinationException>()(
     "InvalidParameterCombinationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidParameterCombination",
@@ -286,7 +286,7 @@ export class InvalidParameterCombinationException
 export class InvalidParameterGroupStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterGroupStateFault>()(
     "InvalidParameterGroupStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidParameterGroupState",
@@ -298,7 +298,7 @@ export class InvalidParameterGroupStateFault
 export class InvalidParameterValueException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterValueException>()(
     "InvalidParameterValueException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidParameterValue", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -307,7 +307,7 @@ export class InvalidParameterValueException
 export class InvalidSnapshotStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSnapshotStateFault>()(
     "InvalidSnapshotStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidSnapshotState", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -316,7 +316,7 @@ export class InvalidSnapshotStateFault
 export class InvalidSubnet
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSubnet>()(
     "InvalidSubnet",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidSubnet", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -325,7 +325,7 @@ export class InvalidSubnet
 export class InvalidUserStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidUserStateFault>()(
     "InvalidUserStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidUserState", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -334,7 +334,7 @@ export class InvalidUserStateFault
 export class InvalidVPCNetworkStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidVPCNetworkStateFault>()(
     "InvalidVPCNetworkStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidVPCNetworkStateFault",
@@ -346,7 +346,7 @@ export class InvalidVPCNetworkStateFault
 export class MultiRegionClusterAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<MultiRegionClusterAlreadyExistsFault>()(
     "MultiRegionClusterAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "MultiRegionClusterAlreadyExistsFault",
@@ -358,7 +358,7 @@ export class MultiRegionClusterAlreadyExistsFault
 export class MultiRegionClusterNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<MultiRegionClusterNotFoundFault>()(
     "MultiRegionClusterNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "MultiRegionClusterNotFound",
@@ -370,7 +370,7 @@ export class MultiRegionClusterNotFoundFault
 export class MultiRegionParameterGroupNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<MultiRegionParameterGroupNotFoundFault>()(
     "MultiRegionParameterGroupNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "MultiRegionParameterGroupNotFoundFault",
@@ -382,7 +382,7 @@ export class MultiRegionParameterGroupNotFoundFault
 export class NodeQuotaForClusterExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<NodeQuotaForClusterExceededFault>()(
     "NodeQuotaForClusterExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "NodeQuotaForClusterExceeded",
@@ -394,7 +394,7 @@ export class NodeQuotaForClusterExceededFault
 export class NodeQuotaForCustomerExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<NodeQuotaForCustomerExceededFault>()(
     "NodeQuotaForCustomerExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "NodeQuotaForCustomerExceeded",
@@ -406,7 +406,7 @@ export class NodeQuotaForCustomerExceededFault
 export class NoOperationFault
   extends /*@__PURE__*/ S.TaggedErrorClass<NoOperationFault>()(
     "NoOperationFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "NoOperationFault", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -415,7 +415,7 @@ export class NoOperationFault
 export class ParameterGroupAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ParameterGroupAlreadyExistsFault>()(
     "ParameterGroupAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ParameterGroupAlreadyExists",
@@ -427,7 +427,7 @@ export class ParameterGroupAlreadyExistsFault
 export class ParameterGroupNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ParameterGroupNotFoundFault>()(
     "ParameterGroupNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ParameterGroupNotFound",
@@ -439,7 +439,7 @@ export class ParameterGroupNotFoundFault
 export class ParameterGroupQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ParameterGroupQuotaExceededFault>()(
     "ParameterGroupQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ParameterGroupQuotaExceeded",
@@ -451,7 +451,7 @@ export class ParameterGroupQuotaExceededFault
 export class ReservedNodeAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ReservedNodeAlreadyExistsFault>()(
     "ReservedNodeAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ReservedNodeAlreadyExists",
@@ -463,7 +463,7 @@ export class ReservedNodeAlreadyExistsFault
 export class ReservedNodeNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ReservedNodeNotFoundFault>()(
     "ReservedNodeNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ReservedNodeNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -472,7 +472,7 @@ export class ReservedNodeNotFoundFault
 export class ReservedNodeQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ReservedNodeQuotaExceededFault>()(
     "ReservedNodeQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ReservedNodeQuotaExceeded",
@@ -484,7 +484,7 @@ export class ReservedNodeQuotaExceededFault
 export class ReservedNodesOfferingNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ReservedNodesOfferingNotFoundFault>()(
     "ReservedNodesOfferingNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ReservedNodesOfferingNotFound",
@@ -496,7 +496,7 @@ export class ReservedNodesOfferingNotFoundFault
 export class ServiceLinkedRoleNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceLinkedRoleNotFoundFault>()(
     "ServiceLinkedRoleNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ServiceLinkedRoleNotFoundFault",
@@ -508,7 +508,7 @@ export class ServiceLinkedRoleNotFoundFault
 export class ServiceUpdateNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUpdateNotFoundFault>()(
     "ServiceUpdateNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ServiceUpdateNotFoundFault",
@@ -520,7 +520,7 @@ export class ServiceUpdateNotFoundFault
 export class ShardNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ShardNotFoundFault>()(
     "ShardNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ShardNotFoundFault", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -529,7 +529,7 @@ export class ShardNotFoundFault
 export class ShardsPerClusterQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ShardsPerClusterQuotaExceededFault>()(
     "ShardsPerClusterQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ShardsPerClusterQuotaExceeded",
@@ -541,7 +541,7 @@ export class ShardsPerClusterQuotaExceededFault
 export class SnapshotAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SnapshotAlreadyExistsFault>()(
     "SnapshotAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SnapshotAlreadyExistsFault",
@@ -553,7 +553,7 @@ export class SnapshotAlreadyExistsFault
 export class SnapshotNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SnapshotNotFoundFault>()(
     "SnapshotNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SnapshotNotFoundFault", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -562,7 +562,7 @@ export class SnapshotNotFoundFault
 export class SnapshotQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SnapshotQuotaExceededFault>()(
     "SnapshotQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SnapshotQuotaExceededFault",
@@ -574,7 +574,7 @@ export class SnapshotQuotaExceededFault
 export class SubnetGroupAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SubnetGroupAlreadyExistsFault>()(
     "SubnetGroupAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SubnetGroupAlreadyExists",
@@ -586,7 +586,7 @@ export class SubnetGroupAlreadyExistsFault
 export class SubnetGroupInUseFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SubnetGroupInUseFault>()(
     "SubnetGroupInUseFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SubnetGroupInUse", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -595,7 +595,7 @@ export class SubnetGroupInUseFault
 export class SubnetGroupNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SubnetGroupNotFoundFault>()(
     "SubnetGroupNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SubnetGroupNotFoundFault",
@@ -607,7 +607,7 @@ export class SubnetGroupNotFoundFault
 export class SubnetGroupQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SubnetGroupQuotaExceededFault>()(
     "SubnetGroupQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SubnetGroupQuotaExceeded",
@@ -619,7 +619,7 @@ export class SubnetGroupQuotaExceededFault
 export class SubnetInUse
   extends /*@__PURE__*/ S.TaggedErrorClass<SubnetInUse>()(
     "SubnetInUse",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SubnetInUse", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -628,7 +628,7 @@ export class SubnetInUse
 export class SubnetNotAllowedFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SubnetNotAllowedFault>()(
     "SubnetNotAllowedFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SubnetNotAllowedFault", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -637,7 +637,7 @@ export class SubnetNotAllowedFault
 export class SubnetQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SubnetQuotaExceededFault>()(
     "SubnetQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SubnetQuotaExceededFault",
@@ -649,7 +649,7 @@ export class SubnetQuotaExceededFault
 export class TagNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<TagNotFoundFault>()(
     "TagNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "TagNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -658,7 +658,7 @@ export class TagNotFoundFault
 export class TagQuotaPerResourceExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<TagQuotaPerResourceExceeded>()(
     "TagQuotaPerResourceExceeded",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "TagQuotaPerResourceExceeded",
@@ -670,7 +670,7 @@ export class TagQuotaPerResourceExceeded
 export class TestFailoverNotAvailableFault
   extends /*@__PURE__*/ S.TaggedErrorClass<TestFailoverNotAvailableFault>()(
     "TestFailoverNotAvailableFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "TestFailoverNotAvailableFault",
@@ -682,7 +682,7 @@ export class TestFailoverNotAvailableFault
 export class UserAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<UserAlreadyExistsFault>()(
     "UserAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "UserAlreadyExists", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -691,7 +691,7 @@ export class UserAlreadyExistsFault
 export class UserNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<UserNotFoundFault>()(
     "UserNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "UserNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -700,7 +700,7 @@ export class UserNotFoundFault
 export class UserQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<UserQuotaExceededFault>()(
     "UserQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "UserQuotaExceeded", httpResponseCode: 400 }),
       T.HttpError(400),

--- a/packages/aws/src/services/mgn.ts
+++ b/packages/aws/src/services/mgn.ts
@@ -88,14 +88,17 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String), code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      code: S.optional(S.String),
+    },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       code: S.optional(S.String),
       resourceId: S.optional(S.String),
       resourceType: S.optional(S.String),
@@ -111,7 +114,7 @@ export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.HttpError(500),
@@ -120,7 +123,7 @@ export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       code: S.optional(S.String),
       resourceId: S.optional(S.String),
       resourceType: S.optional(S.String),
@@ -131,7 +134,7 @@ export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       code: S.optional(S.String),
       resourceId: S.optional(S.String),
       resourceType: S.optional(S.String),
@@ -145,7 +148,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       serviceCode: S.optional(S.String),
       quotaCode: S.optional(S.String),
       retryAfterSeconds: S.optional(S.String).pipe(T.HttpHeader("Retry-After")),
@@ -155,14 +158,17 @@ export class ThrottlingException
 export class UninitializedAccountException
   extends /*@__PURE__*/ S.TaggedErrorClass<UninitializedAccountException>()(
     "UninitializedAccountException",
-    { message: S.optional(S.String), code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      code: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       code: S.optional(S.String),
       reason: S.optional(S.String),
       fieldList: S.optional(

--- a/packages/aws/src/services/migration-hub-refactor-spaces.ts
+++ b/packages/aws/src/services/migration-hub-refactor-spaces.ts
@@ -88,38 +88,46 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.String, ResourceId: S.String, ResourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      ResourceId: S.String,
+      ResourceType: S.String,
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidResourcePolicyException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidResourcePolicyException>()(
     "InvalidResourcePolicyException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.String, ResourceId: S.String, ResourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      ResourceId: S.String,
+      ResourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       ResourceId: S.String,
       ResourceType: S.String,
       QuotaCode: S.optional(S.String),
@@ -131,7 +139,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       QuotaCode: S.optional(S.String),
       ServiceCode: S.optional(S.String),
       RetryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
@@ -141,7 +149,7 @@ export class ThrottlingException
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type ApplicationName = string;

--- a/packages/aws/src/services/migration-hub.ts
+++ b/packages/aws/src/services/migration-hub.ts
@@ -88,48 +88,48 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAuthError) {}
 export class DryRunOperation
   extends /*@__PURE__*/ S.TaggedErrorClass<DryRunOperation>()(
     "DryRunOperation",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class HomeRegionNotSetException
   extends /*@__PURE__*/ S.TaggedErrorClass<HomeRegionNotSetException>()(
     "HomeRegionNotSetException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InternalServerError
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerError>()(
     "InternalServerError",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidInputException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInputException>()(
     "InvalidInputException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class PolicyErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<PolicyErrorException>()(
     "PolicyErrorException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withServerError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       RetryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.HttpError(429),
@@ -137,7 +137,7 @@ export class ThrottlingException
 export class UnauthorizedOperation
   extends /*@__PURE__*/ S.TaggedErrorClass<UnauthorizedOperation>()(
     "UnauthorizedOperation",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAuthError) {}
 export type ProgressUpdateStream = string;
 export type MigrationTaskName = string;

--- a/packages/aws/src/services/migrationhub-config.ts
+++ b/packages/aws/src/services/migrationhub-config.ts
@@ -88,33 +88,33 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAuthError) {}
 export class DryRunOperation
   extends /*@__PURE__*/ S.TaggedErrorClass<DryRunOperation>()(
     "DryRunOperation",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InternalServerError
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerError>()(
     "InternalServerError",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidInputException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInputException>()(
     "InvalidInputException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withServerError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       RetryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.HttpError(429),

--- a/packages/aws/src/services/migrationhuborchestrator.ts
+++ b/packages/aws/src/services/migrationhuborchestrator.ts
@@ -88,37 +88,37 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(403), T.Retryable()),
   ).pipe(C.withAuthError, C.withRetryableError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(409), T.Retryable()),
   ).pipe(C.withConflictError, C.withRetryableError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(400), T.Retryable()),
   ).pipe(C.withBadRequestError, C.withRetryableError) {}
 export type MigrationWorkflowId = string;

--- a/packages/aws/src/services/migrationhubstrategy.ts
+++ b/packages/aws/src/services/migrationhubstrategy.ts
@@ -90,55 +90,55 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class DependencyException
   extends /*@__PURE__*/ S.TaggedErrorClass<DependencyException>()(
     "DependencyException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceLinkedRoleLockClientException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceLinkedRoleLockClientException>()(
     "ServiceLinkedRoleLockClientException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type ApplicationComponentId = string;

--- a/packages/aws/src/services/mpa.ts
+++ b/packages/aws/src/services/mpa.ts
@@ -57,55 +57,58 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class InvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterException>()(
     "InvalidParameterException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { Message: S.String, ResourceName: S.optional(S.String) },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      ResourceName: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type SessionArn = string;

--- a/packages/aws/src/services/mq.ts
+++ b/packages/aws/src/services/mq.ts
@@ -89,7 +89,7 @@ export class BadRequestException
     "BadRequestException",
     {
       ErrorAttribute: S.optional(S.String),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       ResourceShareErrors: S.optional(
         S.suspend(() => __listOfResourceShareError).annotate({
           identifier: "__listOfResourceShareError",
@@ -103,7 +103,7 @@ export class ConflictException
     "ConflictException",
     {
       ErrorAttribute: S.optional(S.String),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       ResourceShareErrors: S.optional(
         S.suspend(() => __listOfResourceShareError).annotate({
           identifier: "__listOfResourceShareError",
@@ -117,7 +117,7 @@ export class ForbiddenException
     "ForbiddenException",
     {
       ErrorAttribute: S.optional(S.String),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       ResourceShareErrors: S.optional(
         S.suspend(() => __listOfResourceShareError).annotate({
           identifier: "__listOfResourceShareError",
@@ -131,7 +131,7 @@ export class InternalServerErrorException
     "InternalServerErrorException",
     {
       ErrorAttribute: S.optional(S.String),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       ResourceShareErrors: S.optional(
         S.suspend(() => __listOfResourceShareError).annotate({
           identifier: "__listOfResourceShareError",
@@ -145,7 +145,7 @@ export class NotFoundException
     "NotFoundException",
     {
       ErrorAttribute: S.optional(S.String),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       ResourceShareErrors: S.optional(
         S.suspend(() => __listOfResourceShareError).annotate({
           identifier: "__listOfResourceShareError",
@@ -159,7 +159,7 @@ export class UnauthorizedException
     "UnauthorizedException",
     {
       ErrorAttribute: S.optional(S.String),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       ResourceShareErrors: S.optional(
         S.suspend(() => __listOfResourceShareError).annotate({
           identifier: "__listOfResourceShareError",

--- a/packages/aws/src/services/mturk.ts
+++ b/packages/aws/src/services/mturk.ts
@@ -92,7 +92,10 @@ const rules = T.EndpointResolver((p, _) => {
 export class RequestError
   extends /*@__PURE__*/ S.TaggedErrorClass<RequestError>()(
     "RequestError",
-    { Message: S.optional(S.String), TurkErrorCode: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      TurkErrorCode: S.optional(S.String),
+    },
     T.all(
       T.AwsQueryError({ code: "RequestError", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -101,7 +104,10 @@ export class RequestError
 export class ServiceFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceFault>()(
     "ServiceFault",
-    { Message: S.optional(S.String), TurkErrorCode: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      TurkErrorCode: S.optional(S.String),
+    },
     T.all(
       T.AwsQueryError({ code: "ServiceFault", httpResponseCode: 500 }),
       T.HttpError(500),

--- a/packages/aws/src/services/mwaa-serverless.ts
+++ b/packages/aws/src/services/mwaa-serverless.ts
@@ -55,20 +55,24 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.String, ResourceId: S.String, ResourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      ResourceId: S.String,
+      ResourceType: S.String,
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       RetryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.all(T.HttpError(500), T.Retryable()),
@@ -76,20 +80,24 @@ export class InternalServerException
 export class OperationTimeoutException
   extends /*@__PURE__*/ S.TaggedErrorClass<OperationTimeoutException>()(
     "OperationTimeoutException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(504),
   ).pipe(C.withTimeoutError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.String, ResourceId: S.String, ResourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      ResourceId: S.String,
+      ResourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       ResourceId: S.String,
       ResourceType: S.String,
       ServiceCode: S.String,
@@ -101,7 +109,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       ServiceCode: S.String,
       QuotaCode: S.String,
       RetryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
@@ -112,7 +120,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       Reason: S.suspend(() => ValidationExceptionReason).annotate({
         identifier: "ValidationExceptionReason",
       }),

--- a/packages/aws/src/services/mwaa.ts
+++ b/packages/aws/src/services/mwaa.ts
@@ -87,19 +87,19 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class RestApiClientException
@@ -108,6 +108,7 @@ export class RestApiClientException
     {
       RestApiStatusCode: S.optional(S.Number),
       RestApiResponse: S.optional(S.Any),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
@@ -117,19 +118,20 @@ export class RestApiServerException
     {
       RestApiStatusCode: S.optional(S.Number),
       RestApiResponse: S.optional(S.Any),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type EnvironmentName = string;

--- a/packages/aws/src/services/neptune-graph.ts
+++ b/packages/aws/src/services/neptune-graph.ts
@@ -124,14 +124,14 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.optional(
         S.suspend(() => ConflictExceptionReason).annotate({
           identifier: "ConflictExceptionReason",
@@ -143,20 +143,20 @@ export class ConflictException
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceType: S.optional(S.String),
       serviceCode: S.optional(S.String),
@@ -167,14 +167,14 @@ export class ServiceQuotaExceededException
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(429), T.Retryable({ throttling: true })),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class UnprocessableException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnprocessableException>()(
     "UnprocessableException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.suspend(() => UnprocessableExceptionReason).annotate({
         identifier: "UnprocessableExceptionReason",
       }),
@@ -185,7 +185,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.optional(
         S.suspend(() => ValidationExceptionReason).annotate({
           identifier: "ValidationExceptionReason",

--- a/packages/aws/src/services/neptune.ts
+++ b/packages/aws/src/services/neptune.ts
@@ -94,7 +94,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class AuthorizationNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<AuthorizationNotFoundFault>()(
     "AuthorizationNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "AuthorizationNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -103,7 +103,7 @@ export class AuthorizationNotFoundFault
 export class CertificateNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<CertificateNotFoundFault>()(
     "CertificateNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "CertificateNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -112,7 +112,7 @@ export class CertificateNotFoundFault
 export class DBClusterAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBClusterAlreadyExistsFault>()(
     "DBClusterAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBClusterAlreadyExistsFault",
@@ -124,7 +124,7 @@ export class DBClusterAlreadyExistsFault
 export class DBClusterEndpointAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBClusterEndpointAlreadyExistsFault>()(
     "DBClusterEndpointAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBClusterEndpointAlreadyExistsFault",
@@ -136,7 +136,7 @@ export class DBClusterEndpointAlreadyExistsFault
 export class DBClusterEndpointNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBClusterEndpointNotFoundFault>()(
     "DBClusterEndpointNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBClusterEndpointNotFoundFault",
@@ -148,7 +148,7 @@ export class DBClusterEndpointNotFoundFault
 export class DBClusterEndpointQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBClusterEndpointQuotaExceededFault>()(
     "DBClusterEndpointQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBClusterEndpointQuotaExceededFault",
@@ -160,7 +160,7 @@ export class DBClusterEndpointQuotaExceededFault
 export class DBClusterNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBClusterNotFoundFault>()(
     "DBClusterNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBClusterNotFoundFault",
@@ -172,7 +172,7 @@ export class DBClusterNotFoundFault
 export class DBClusterParameterGroupNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBClusterParameterGroupNotFoundFault>()(
     "DBClusterParameterGroupNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBClusterParameterGroupNotFound",
@@ -184,7 +184,7 @@ export class DBClusterParameterGroupNotFoundFault
 export class DBClusterQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBClusterQuotaExceededFault>()(
     "DBClusterQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBClusterQuotaExceededFault",
@@ -196,7 +196,7 @@ export class DBClusterQuotaExceededFault
 export class DBClusterRoleAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBClusterRoleAlreadyExistsFault>()(
     "DBClusterRoleAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBClusterRoleAlreadyExists",
@@ -208,7 +208,7 @@ export class DBClusterRoleAlreadyExistsFault
 export class DBClusterRoleNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBClusterRoleNotFoundFault>()(
     "DBClusterRoleNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "DBClusterRoleNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -217,7 +217,7 @@ export class DBClusterRoleNotFoundFault
 export class DBClusterRoleQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBClusterRoleQuotaExceededFault>()(
     "DBClusterRoleQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBClusterRoleQuotaExceeded",
@@ -229,7 +229,7 @@ export class DBClusterRoleQuotaExceededFault
 export class DBClusterSnapshotAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBClusterSnapshotAlreadyExistsFault>()(
     "DBClusterSnapshotAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBClusterSnapshotAlreadyExistsFault",
@@ -241,7 +241,7 @@ export class DBClusterSnapshotAlreadyExistsFault
 export class DBClusterSnapshotNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBClusterSnapshotNotFoundFault>()(
     "DBClusterSnapshotNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBClusterSnapshotNotFoundFault",
@@ -253,7 +253,7 @@ export class DBClusterSnapshotNotFoundFault
 export class DBInstanceAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBInstanceAlreadyExistsFault>()(
     "DBInstanceAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBInstanceAlreadyExists",
@@ -265,7 +265,7 @@ export class DBInstanceAlreadyExistsFault
 export class DBInstanceNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBInstanceNotFoundFault>()(
     "DBInstanceNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "DBInstanceNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -274,7 +274,7 @@ export class DBInstanceNotFoundFault
 export class DBParameterGroupAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBParameterGroupAlreadyExistsFault>()(
     "DBParameterGroupAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBParameterGroupAlreadyExists",
@@ -286,7 +286,7 @@ export class DBParameterGroupAlreadyExistsFault
 export class DBParameterGroupNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBParameterGroupNotFoundFault>()(
     "DBParameterGroupNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBParameterGroupNotFound",
@@ -298,7 +298,7 @@ export class DBParameterGroupNotFoundFault
 export class DBParameterGroupQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBParameterGroupQuotaExceededFault>()(
     "DBParameterGroupQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBParameterGroupQuotaExceeded",
@@ -310,7 +310,7 @@ export class DBParameterGroupQuotaExceededFault
 export class DBSecurityGroupNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBSecurityGroupNotFoundFault>()(
     "DBSecurityGroupNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBSecurityGroupNotFound",
@@ -322,7 +322,7 @@ export class DBSecurityGroupNotFoundFault
 export class DBSnapshotAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBSnapshotAlreadyExistsFault>()(
     "DBSnapshotAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBSnapshotAlreadyExists",
@@ -334,7 +334,7 @@ export class DBSnapshotAlreadyExistsFault
 export class DBSnapshotNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBSnapshotNotFoundFault>()(
     "DBSnapshotNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "DBSnapshotNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -343,7 +343,7 @@ export class DBSnapshotNotFoundFault
 export class DBSubnetGroupAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBSubnetGroupAlreadyExistsFault>()(
     "DBSubnetGroupAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBSubnetGroupAlreadyExists",
@@ -355,7 +355,7 @@ export class DBSubnetGroupAlreadyExistsFault
 export class DBSubnetGroupDoesNotCoverEnoughAZs
   extends /*@__PURE__*/ S.TaggedErrorClass<DBSubnetGroupDoesNotCoverEnoughAZs>()(
     "DBSubnetGroupDoesNotCoverEnoughAZs",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBSubnetGroupDoesNotCoverEnoughAZs",
@@ -367,7 +367,7 @@ export class DBSubnetGroupDoesNotCoverEnoughAZs
 export class DBSubnetGroupNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBSubnetGroupNotFoundFault>()(
     "DBSubnetGroupNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBSubnetGroupNotFoundFault",
@@ -379,7 +379,7 @@ export class DBSubnetGroupNotFoundFault
 export class DBSubnetGroupQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBSubnetGroupQuotaExceededFault>()(
     "DBSubnetGroupQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBSubnetGroupQuotaExceeded",
@@ -391,7 +391,7 @@ export class DBSubnetGroupQuotaExceededFault
 export class DBSubnetQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBSubnetQuotaExceededFault>()(
     "DBSubnetQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBSubnetQuotaExceededFault",
@@ -403,7 +403,7 @@ export class DBSubnetQuotaExceededFault
 export class DBUpgradeDependencyFailureFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBUpgradeDependencyFailureFault>()(
     "DBUpgradeDependencyFailureFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBUpgradeDependencyFailure",
@@ -415,7 +415,7 @@ export class DBUpgradeDependencyFailureFault
 export class DomainNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DomainNotFoundFault>()(
     "DomainNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "DomainNotFoundFault", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -424,7 +424,7 @@ export class DomainNotFoundFault
 export class EventSubscriptionQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<EventSubscriptionQuotaExceededFault>()(
     "EventSubscriptionQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "EventSubscriptionQuotaExceeded",
@@ -436,7 +436,7 @@ export class EventSubscriptionQuotaExceededFault
 export class GlobalClusterAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<GlobalClusterAlreadyExistsFault>()(
     "GlobalClusterAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "GlobalClusterAlreadyExistsFault",
@@ -448,7 +448,7 @@ export class GlobalClusterAlreadyExistsFault
 export class GlobalClusterNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<GlobalClusterNotFoundFault>()(
     "GlobalClusterNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "GlobalClusterNotFoundFault",
@@ -460,7 +460,7 @@ export class GlobalClusterNotFoundFault
 export class GlobalClusterQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<GlobalClusterQuotaExceededFault>()(
     "GlobalClusterQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "GlobalClusterQuotaExceededFault",
@@ -472,7 +472,7 @@ export class GlobalClusterQuotaExceededFault
 export class InstanceQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InstanceQuotaExceededFault>()(
     "InstanceQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InstanceQuotaExceeded", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -481,7 +481,7 @@ export class InstanceQuotaExceededFault
 export class InsufficientDBClusterCapacityFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InsufficientDBClusterCapacityFault>()(
     "InsufficientDBClusterCapacityFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InsufficientDBClusterCapacityFault",
@@ -493,7 +493,7 @@ export class InsufficientDBClusterCapacityFault
 export class InsufficientDBInstanceCapacityFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InsufficientDBInstanceCapacityFault>()(
     "InsufficientDBInstanceCapacityFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InsufficientDBInstanceCapacity",
@@ -505,7 +505,7 @@ export class InsufficientDBInstanceCapacityFault
 export class InsufficientStorageClusterCapacityFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InsufficientStorageClusterCapacityFault>()(
     "InsufficientStorageClusterCapacityFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InsufficientStorageClusterCapacity",
@@ -517,7 +517,7 @@ export class InsufficientStorageClusterCapacityFault
 export class InvalidDBClusterEndpointStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDBClusterEndpointStateFault>()(
     "InvalidDBClusterEndpointStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidDBClusterEndpointStateFault",
@@ -529,7 +529,7 @@ export class InvalidDBClusterEndpointStateFault
 export class InvalidDBClusterSnapshotStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDBClusterSnapshotStateFault>()(
     "InvalidDBClusterSnapshotStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidDBClusterSnapshotStateFault",
@@ -541,7 +541,7 @@ export class InvalidDBClusterSnapshotStateFault
 export class InvalidDBClusterStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDBClusterStateFault>()(
     "InvalidDBClusterStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidDBClusterStateFault",
@@ -553,7 +553,7 @@ export class InvalidDBClusterStateFault
 export class InvalidDBInstanceStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDBInstanceStateFault>()(
     "InvalidDBInstanceStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidDBInstanceState",
@@ -565,7 +565,7 @@ export class InvalidDBInstanceStateFault
 export class InvalidDBParameterGroupStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDBParameterGroupStateFault>()(
     "InvalidDBParameterGroupStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidDBParameterGroupState",
@@ -577,7 +577,7 @@ export class InvalidDBParameterGroupStateFault
 export class InvalidDBSecurityGroupStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDBSecurityGroupStateFault>()(
     "InvalidDBSecurityGroupStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidDBSecurityGroupState",
@@ -589,7 +589,7 @@ export class InvalidDBSecurityGroupStateFault
 export class InvalidDBSnapshotStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDBSnapshotStateFault>()(
     "InvalidDBSnapshotStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidDBSnapshotState",
@@ -601,7 +601,7 @@ export class InvalidDBSnapshotStateFault
 export class InvalidDBSubnetGroupStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDBSubnetGroupStateFault>()(
     "InvalidDBSubnetGroupStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidDBSubnetGroupStateFault",
@@ -613,7 +613,7 @@ export class InvalidDBSubnetGroupStateFault
 export class InvalidDBSubnetStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDBSubnetStateFault>()(
     "InvalidDBSubnetStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidDBSubnetStateFault",
@@ -625,7 +625,7 @@ export class InvalidDBSubnetStateFault
 export class InvalidEventSubscriptionStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidEventSubscriptionStateFault>()(
     "InvalidEventSubscriptionStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidEventSubscriptionState",
@@ -637,7 +637,7 @@ export class InvalidEventSubscriptionStateFault
 export class InvalidGlobalClusterStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidGlobalClusterStateFault>()(
     "InvalidGlobalClusterStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidGlobalClusterStateFault",
@@ -649,7 +649,7 @@ export class InvalidGlobalClusterStateFault
 export class InvalidRestoreFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRestoreFault>()(
     "InvalidRestoreFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidRestoreFault", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -658,7 +658,7 @@ export class InvalidRestoreFault
 export class InvalidSubnet
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSubnet>()(
     "InvalidSubnet",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidSubnet", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -667,7 +667,7 @@ export class InvalidSubnet
 export class InvalidVPCNetworkStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidVPCNetworkStateFault>()(
     "InvalidVPCNetworkStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidVPCNetworkStateFault",
@@ -679,7 +679,7 @@ export class InvalidVPCNetworkStateFault
 export class KMSKeyNotAccessibleFault
   extends /*@__PURE__*/ S.TaggedErrorClass<KMSKeyNotAccessibleFault>()(
     "KMSKeyNotAccessibleFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "KMSKeyNotAccessibleFault",
@@ -691,7 +691,7 @@ export class KMSKeyNotAccessibleFault
 export class NetworkTypeNotSupportedFault
   extends /*@__PURE__*/ S.TaggedErrorClass<NetworkTypeNotSupportedFault>()(
     "NetworkTypeNotSupportedFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "NetworkTypeNotSupported",
@@ -703,7 +703,7 @@ export class NetworkTypeNotSupportedFault
 export class OptionGroupNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<OptionGroupNotFoundFault>()(
     "OptionGroupNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "OptionGroupNotFoundFault",
@@ -715,7 +715,7 @@ export class OptionGroupNotFoundFault
 export class ProvisionedIopsNotAvailableInAZFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ProvisionedIopsNotAvailableInAZFault>()(
     "ProvisionedIopsNotAvailableInAZFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ProvisionedIopsNotAvailableInAZFault",
@@ -727,7 +727,7 @@ export class ProvisionedIopsNotAvailableInAZFault
 export class ResourceNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundFault>()(
     "ResourceNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ResourceNotFoundFault", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -736,7 +736,7 @@ export class ResourceNotFoundFault
 export class SharedSnapshotQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SharedSnapshotQuotaExceededFault>()(
     "SharedSnapshotQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SharedSnapshotQuotaExceeded",
@@ -748,7 +748,7 @@ export class SharedSnapshotQuotaExceededFault
 export class SnapshotQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SnapshotQuotaExceededFault>()(
     "SnapshotQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SnapshotQuotaExceeded", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -757,7 +757,7 @@ export class SnapshotQuotaExceededFault
 export class SNSInvalidTopicFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SNSInvalidTopicFault>()(
     "SNSInvalidTopicFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SNSInvalidTopic", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -766,7 +766,7 @@ export class SNSInvalidTopicFault
 export class SNSNoAuthorizationFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SNSNoAuthorizationFault>()(
     "SNSNoAuthorizationFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SNSNoAuthorization", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -775,7 +775,7 @@ export class SNSNoAuthorizationFault
 export class SNSTopicArnNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SNSTopicArnNotFoundFault>()(
     "SNSTopicArnNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SNSTopicArnNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -784,7 +784,7 @@ export class SNSTopicArnNotFoundFault
 export class SourceNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SourceNotFoundFault>()(
     "SourceNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SourceNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -793,7 +793,7 @@ export class SourceNotFoundFault
 export class StorageQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<StorageQuotaExceededFault>()(
     "StorageQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "StorageQuotaExceeded", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -802,7 +802,7 @@ export class StorageQuotaExceededFault
 export class StorageTypeNotSupportedFault
   extends /*@__PURE__*/ S.TaggedErrorClass<StorageTypeNotSupportedFault>()(
     "StorageTypeNotSupportedFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "StorageTypeNotSupported",
@@ -814,7 +814,7 @@ export class StorageTypeNotSupportedFault
 export class SubnetAlreadyInUse
   extends /*@__PURE__*/ S.TaggedErrorClass<SubnetAlreadyInUse>()(
     "SubnetAlreadyInUse",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SubnetAlreadyInUse", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -823,7 +823,7 @@ export class SubnetAlreadyInUse
 export class SubscriptionAlreadyExistFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SubscriptionAlreadyExistFault>()(
     "SubscriptionAlreadyExistFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SubscriptionAlreadyExist",
@@ -835,7 +835,7 @@ export class SubscriptionAlreadyExistFault
 export class SubscriptionCategoryNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SubscriptionCategoryNotFoundFault>()(
     "SubscriptionCategoryNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SubscriptionCategoryNotFound",
@@ -847,7 +847,7 @@ export class SubscriptionCategoryNotFoundFault
 export class SubscriptionNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SubscriptionNotFoundFault>()(
     "SubscriptionNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SubscriptionNotFound", httpResponseCode: 404 }),
       T.HttpError(404),

--- a/packages/aws/src/services/neptunedata.ts
+++ b/packages/aws/src/services/neptunedata.ts
@@ -87,205 +87,375 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { detailedMessage: S.String, requestId: S.String, code: S.String },
+    {
+      detailedMessage: S.String,
+      requestId: S.String,
+      code: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { detailedMessage: S.String, requestId: S.String, code: S.String },
+    {
+      detailedMessage: S.String,
+      requestId: S.String,
+      code: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class BulkLoadIdNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<BulkLoadIdNotFoundException>()(
     "BulkLoadIdNotFoundException",
-    { detailedMessage: S.String, requestId: S.String, code: S.String },
+    {
+      detailedMessage: S.String,
+      requestId: S.String,
+      code: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.all(T.HttpError(404), T.Retryable()),
   ).pipe(C.withBadRequestError, C.withRetryableError) {}
 export class CancelledByUserException
   extends /*@__PURE__*/ S.TaggedErrorClass<CancelledByUserException>()(
     "CancelledByUserException",
-    { detailedMessage: S.String, requestId: S.String, code: S.String },
+    {
+      detailedMessage: S.String,
+      requestId: S.String,
+      code: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ClientTimeoutException
   extends /*@__PURE__*/ S.TaggedErrorClass<ClientTimeoutException>()(
     "ClientTimeoutException",
-    { detailedMessage: S.String, requestId: S.String, code: S.String },
+    {
+      detailedMessage: S.String,
+      requestId: S.String,
+      code: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.all(T.HttpError(408), T.Retryable()),
   ).pipe(C.withTimeoutError, C.withRetryableError) {}
 export class ConcurrentModificationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentModificationException>()(
     "ConcurrentModificationException",
-    { detailedMessage: S.String, requestId: S.String, code: S.String },
+    {
+      detailedMessage: S.String,
+      requestId: S.String,
+      code: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ConstraintViolationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConstraintViolationException>()(
     "ConstraintViolationException",
-    { detailedMessage: S.String, requestId: S.String, code: S.String },
+    {
+      detailedMessage: S.String,
+      requestId: S.String,
+      code: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.all(T.HttpError(400), T.Retryable()),
   ).pipe(C.withBadRequestError, C.withRetryableError) {}
 export class ExpiredStreamException
   extends /*@__PURE__*/ S.TaggedErrorClass<ExpiredStreamException>()(
     "ExpiredStreamException",
-    { detailedMessage: S.String, requestId: S.String, code: S.String },
+    {
+      detailedMessage: S.String,
+      requestId: S.String,
+      code: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class FailureByQueryException
   extends /*@__PURE__*/ S.TaggedErrorClass<FailureByQueryException>()(
     "FailureByQueryException",
-    { detailedMessage: S.String, requestId: S.String, code: S.String },
+    {
+      detailedMessage: S.String,
+      requestId: S.String,
+      code: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class IllegalArgumentException
   extends /*@__PURE__*/ S.TaggedErrorClass<IllegalArgumentException>()(
     "IllegalArgumentException",
-    { detailedMessage: S.String, requestId: S.String, code: S.String },
+    {
+      detailedMessage: S.String,
+      requestId: S.String,
+      code: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InternalFailureException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalFailureException>()(
     "InternalFailureException",
-    { detailedMessage: S.String, requestId: S.String, code: S.String },
+    {
+      detailedMessage: S.String,
+      requestId: S.String,
+      code: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidArgumentException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidArgumentException>()(
     "InvalidArgumentException",
-    { detailedMessage: S.String, requestId: S.String, code: S.String },
+    {
+      detailedMessage: S.String,
+      requestId: S.String,
+      code: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidNumericDataException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNumericDataException>()(
     "InvalidNumericDataException",
-    { detailedMessage: S.String, requestId: S.String, code: S.String },
+    {
+      detailedMessage: S.String,
+      requestId: S.String,
+      code: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterException>()(
     "InvalidParameterException",
-    { detailedMessage: S.String, requestId: S.String, code: S.String },
+    {
+      detailedMessage: S.String,
+      requestId: S.String,
+      code: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class LoadUrlAccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<LoadUrlAccessDeniedException>()(
     "LoadUrlAccessDeniedException",
-    { detailedMessage: S.String, requestId: S.String, code: S.String },
+    {
+      detailedMessage: S.String,
+      requestId: S.String,
+      code: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError, C.withAuthError) {}
 export class MalformedQueryException
   extends /*@__PURE__*/ S.TaggedErrorClass<MalformedQueryException>()(
     "MalformedQueryException",
-    { detailedMessage: S.String, requestId: S.String, code: S.String },
+    {
+      detailedMessage: S.String,
+      requestId: S.String,
+      code: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class MemoryLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<MemoryLimitExceededException>()(
     "MemoryLimitExceededException",
-    { detailedMessage: S.String, requestId: S.String, code: S.String },
+    {
+      detailedMessage: S.String,
+      requestId: S.String,
+      code: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class MethodNotAllowedException
   extends /*@__PURE__*/ S.TaggedErrorClass<MethodNotAllowedException>()(
     "MethodNotAllowedException",
-    { detailedMessage: S.String, requestId: S.String, code: S.String },
+    {
+      detailedMessage: S.String,
+      requestId: S.String,
+      code: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(405),
   ).pipe(C.withBadRequestError) {}
 export class MissingParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<MissingParameterException>()(
     "MissingParameterException",
-    { detailedMessage: S.String, requestId: S.String, code: S.String },
+    {
+      detailedMessage: S.String,
+      requestId: S.String,
+      code: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class MLResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<MLResourceNotFoundException>()(
     "MLResourceNotFoundException",
-    { detailedMessage: S.String, requestId: S.String, code: S.String },
+    {
+      detailedMessage: S.String,
+      requestId: S.String,
+      code: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ParsingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ParsingException>()(
     "ParsingException",
-    { detailedMessage: S.String, requestId: S.String, code: S.String },
+    {
+      detailedMessage: S.String,
+      requestId: S.String,
+      code: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class PreconditionsFailedException
   extends /*@__PURE__*/ S.TaggedErrorClass<PreconditionsFailedException>()(
     "PreconditionsFailedException",
-    { detailedMessage: S.String, requestId: S.String, code: S.String },
+    {
+      detailedMessage: S.String,
+      requestId: S.String,
+      code: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class QueryLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<QueryLimitExceededException>()(
     "QueryLimitExceededException",
-    { detailedMessage: S.String, requestId: S.String, code: S.String },
+    {
+      detailedMessage: S.String,
+      requestId: S.String,
+      code: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class QueryLimitException
   extends /*@__PURE__*/ S.TaggedErrorClass<QueryLimitException>()(
     "QueryLimitException",
-    { detailedMessage: S.String, requestId: S.String, code: S.String },
+    {
+      detailedMessage: S.String,
+      requestId: S.String,
+      code: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class QueryTooLargeException
   extends /*@__PURE__*/ S.TaggedErrorClass<QueryTooLargeException>()(
     "QueryTooLargeException",
-    { detailedMessage: S.String, requestId: S.String, code: S.String },
+    {
+      detailedMessage: S.String,
+      requestId: S.String,
+      code: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ReadOnlyViolationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ReadOnlyViolationException>()(
     "ReadOnlyViolationException",
-    { detailedMessage: S.String, requestId: S.String, code: S.String },
+    {
+      detailedMessage: S.String,
+      requestId: S.String,
+      code: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class S3Exception
   extends /*@__PURE__*/ S.TaggedErrorClass<S3Exception>()(
     "S3Exception",
-    { detailedMessage: S.String, requestId: S.String, code: S.String },
+    {
+      detailedMessage: S.String,
+      requestId: S.String,
+      code: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.all(T.HttpError(400), T.Retryable()),
   ).pipe(C.withBadRequestError, C.withRetryableError) {}
 export class ServerShutdownException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServerShutdownException>()(
     "ServerShutdownException",
-    { detailedMessage: S.String, requestId: S.String, code: S.String },
+    {
+      detailedMessage: S.String,
+      requestId: S.String,
+      code: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class StatisticsNotAvailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<StatisticsNotAvailableException>()(
     "StatisticsNotAvailableException",
-    { detailedMessage: S.String, requestId: S.String, code: S.String },
+    {
+      detailedMessage: S.String,
+      requestId: S.String,
+      code: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class StreamRecordsNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<StreamRecordsNotFoundException>()(
     "StreamRecordsNotFoundException",
-    { detailedMessage: S.String, requestId: S.String, code: S.String },
+    {
+      detailedMessage: S.String,
+      requestId: S.String,
+      code: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { detailedMessage: S.String, requestId: S.String, code: S.String },
+    {
+      detailedMessage: S.String,
+      requestId: S.String,
+      code: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class TimeLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<TimeLimitExceededException>()(
     "TimeLimitExceededException",
-    { detailedMessage: S.String, requestId: S.String, code: S.String },
+    {
+      detailedMessage: S.String,
+      requestId: S.String,
+      code: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { detailedMessage: S.String, requestId: S.String, code: S.String },
+    {
+      detailedMessage: S.String,
+      requestId: S.String,
+      code: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.all(T.HttpError(429), T.Retryable()),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class UnsupportedOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedOperationException>()(
     "UnsupportedOperationException",
-    { detailedMessage: S.String, requestId: S.String, code: S.String },
+    {
+      detailedMessage: S.String,
+      requestId: S.String,
+      code: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export interface CancelGremlinQueryInput {

--- a/packages/aws/src/services/network-firewall.ts
+++ b/packages/aws/src/services/network-firewall.ts
@@ -87,62 +87,62 @@ const rules = T.EndpointResolver((p, _) => {
 export class InsufficientCapacityException
   extends /*@__PURE__*/ S.TaggedErrorClass<InsufficientCapacityException>()(
     "InsufficientCapacityException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InternalServerError
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerError>()(
     "InternalServerError",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidOperationException>()(
     "InvalidOperationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidResourcePolicyException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidResourcePolicyException>()(
     "InvalidResourcePolicyException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTokenException>()(
     "InvalidTokenException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LogDestinationPermissionException
   extends /*@__PURE__*/ S.TaggedErrorClass<LogDestinationPermissionException>()(
     "LogDestinationPermissionException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceOwnerCheckException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceOwnerCheckException>()(
     "ResourceOwnerCheckException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class UnsupportedOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedOperationException>()(
     "UnsupportedOperationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type TransitGatewayAttachmentId = string;
 export interface AcceptNetworkFirewallTransitGatewayAttachmentRequest {

--- a/packages/aws/src/services/networkflowmonitor.ts
+++ b/packages/aws/src/services/networkflowmonitor.ts
@@ -55,43 +55,43 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(429), T.Retryable({ throttling: true })),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type ResourceName = string;

--- a/packages/aws/src/services/networkmanager.ts
+++ b/packages/aws/src/services/networkmanager.ts
@@ -160,20 +160,24 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.String, ResourceId: S.String, ResourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      ResourceId: S.String,
+      ResourceType: S.String,
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class CoreNetworkPolicyException
   extends /*@__PURE__*/ S.TaggedErrorClass<CoreNetworkPolicyException>()(
     "CoreNetworkPolicyException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       Errors: S.optional(
         S.suspend(() => CoreNetworkPolicyErrorList).annotate({
           identifier: "CoreNetworkPolicyErrorList",
@@ -186,7 +190,7 @@ export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       RetryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.HttpError(500),
@@ -195,7 +199,7 @@ export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       ResourceId: S.String,
       ResourceType: S.String,
       Context: S.optional(
@@ -210,7 +214,7 @@ export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       ResourceId: S.optional(S.String),
       ResourceType: S.optional(S.String),
       LimitCode: S.String,
@@ -222,7 +226,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       RetryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.HttpError(429),
@@ -231,7 +235,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => ValidationExceptionReason).annotate({
           identifier: "ValidationExceptionReason",

--- a/packages/aws/src/services/networkmonitor.ts
+++ b/packages/aws/src/services/networkmonitor.ts
@@ -88,43 +88,43 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(429), T.Retryable({ throttling: true })),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type ResourceName = string;

--- a/packages/aws/src/services/notifications.ts
+++ b/packages/aws/src/services/notifications.ts
@@ -55,32 +55,32 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String, resourceId: S.String },
+    { message: S.String.pipe(T.ErrorMessage()), resourceId: S.String },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String, resourceId: S.String },
+    { message: S.String.pipe(T.ErrorMessage()), resourceId: S.String },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceType: S.String,
       resourceId: S.optional(S.String),
       serviceCode: S.optional(S.String),
@@ -92,7 +92,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       serviceCode: S.optional(S.String),
       quotaCode: S.optional(S.String),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
@@ -103,7 +103,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.optional(S.String),
       fieldList: S.optional(
         S.suspend(() => ValidationExceptionFieldList).annotate({

--- a/packages/aws/src/services/notificationscontacts.ts
+++ b/packages/aws/src/services/notificationscontacts.ts
@@ -69,32 +69,40 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.String,
       resourceType: S.String,
       serviceCode: S.String,
@@ -106,7 +114,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       serviceCode: S.optional(S.String),
       quotaCode: S.optional(S.String),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
@@ -117,7 +125,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.suspend(() => ValidationExceptionReason).annotate({
         identifier: "ValidationExceptionReason",
       }),

--- a/packages/aws/src/services/nova-act.ts
+++ b/packages/aws/src/services/nova-act.ts
@@ -90,20 +90,24 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
       reason: S.optional(
         S.suspend(() => InternalServerExceptionReason).annotate({
@@ -116,14 +120,18 @@ export class InternalServerException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.String,
       resourceType: S.String,
       serviceCode: S.String,
@@ -135,7 +143,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       serviceCode: S.optional(S.String),
       quotaCode: S.optional(S.String),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
@@ -146,7 +154,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.suspend(() => ValidationExceptionReason).annotate({
         identifier: "ValidationExceptionReason",
       }),

--- a/packages/aws/src/services/oam.ts
+++ b/packages/aws/src/services/oam.ts
@@ -86,7 +86,7 @@ export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       amznErrorType: S.optional(S.String).pipe(
         T.HttpHeader("x-amzn-ErrorType"),
       ),
@@ -97,7 +97,7 @@ export class InternalServiceFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServiceFault>()(
     "InternalServiceFault",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       amznErrorType: S.optional(S.String).pipe(
         T.HttpHeader("x-amzn-ErrorType"),
       ),
@@ -108,7 +108,7 @@ export class InvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterException>()(
     "InvalidParameterException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       amznErrorType: S.optional(S.String).pipe(
         T.HttpHeader("x-amzn-ErrorType"),
       ),
@@ -119,7 +119,7 @@ export class MissingRequiredParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<MissingRequiredParameterException>()(
     "MissingRequiredParameterException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       amznErrorType: S.optional(S.String).pipe(
         T.HttpHeader("x-amzn-ErrorType"),
       ),
@@ -130,7 +130,7 @@ export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       amznErrorType: S.optional(S.String).pipe(
         T.HttpHeader("x-amzn-ErrorType"),
       ),
@@ -141,7 +141,7 @@ export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       amznErrorType: S.optional(S.String).pipe(
         T.HttpHeader("x-amzn-ErrorType"),
       ),
@@ -151,18 +151,18 @@ export class ServiceQuotaExceededException
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type LabelTemplate = string;

--- a/packages/aws/src/services/observabilityadmin.ts
+++ b/packages/aws/src/services/observabilityadmin.ts
@@ -89,7 +89,7 @@ export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       amznErrorType: S.optional(S.String).pipe(
         T.HttpHeader("x-amzn-ErrorType"),
       ),
@@ -100,7 +100,7 @@ export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       ResourceId: S.optional(S.String),
       ResourceType: S.optional(S.String),
     },
@@ -110,7 +110,7 @@ export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       amznErrorType: S.optional(S.String).pipe(
         T.HttpHeader("x-amzn-ErrorType"),
       ),
@@ -121,14 +121,14 @@ export class InternalServerException
 export class InvalidStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidStateException>()(
     "InvalidStateException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       ResourceId: S.optional(S.String),
       ResourceType: S.optional(S.String),
     },
@@ -138,7 +138,7 @@ export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       ResourceId: S.optional(S.String),
       ResourceType: S.optional(S.String),
       ServiceCode: S.optional(S.String),
@@ -152,14 +152,14 @@ export class ServiceQuotaExceededException
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Errors: S.optional(
         S.suspend(() => ValidationErrors).annotate({
           identifier: "ValidationErrors",

--- a/packages/aws/src/services/odb.ts
+++ b/packages/aws/src/services/odb.ts
@@ -87,20 +87,24 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.all(T.HttpError(500), T.Retryable()),
@@ -108,14 +112,18 @@ export class InternalServerException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.String,
       resourceType: S.String,
       quotaCode: S.String,
@@ -126,7 +134,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.HttpError(429),
@@ -135,7 +143,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.suspend(() => ValidationExceptionReason).annotate({
         identifier: "ValidationExceptionReason",
       }),

--- a/packages/aws/src/services/omics.ts
+++ b/packages/aws/src/services/omics.ts
@@ -85,66 +85,66 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class NotSupportedOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotSupportedOperationException>()(
     "NotSupportedOperationException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(405),
   ).pipe(C.withBadRequestError) {}
 export class RangeNotSatisfiableException
   extends /*@__PURE__*/ S.TaggedErrorClass<RangeNotSatisfiableException>()(
     "RangeNotSatisfiableException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(416), T.Retryable()),
   ).pipe(C.withRetryableError) {}
 export class RequestTimeoutException
   extends /*@__PURE__*/ S.TaggedErrorClass<RequestTimeoutException>()(
     "RequestTimeoutException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(408),
   ).pipe(C.withTimeoutError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(429), T.Retryable({ throttling: true })),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type SequenceStoreId = string;

--- a/packages/aws/src/services/opensearch.ts
+++ b/packages/aws/src/services/opensearch.ts
@@ -100,71 +100,71 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class BaseException
   extends /*@__PURE__*/ S.TaggedErrorClass<BaseException>()("BaseException", {
-    message: S.optional(S.String),
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
   }) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class DependencyFailureException
   extends /*@__PURE__*/ S.TaggedErrorClass<DependencyFailureException>()(
     "DependencyFailureException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(424),
   ) {}
 export class DisabledOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<DisabledOperationException>()(
     "DisabledOperationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalException>()(
     "InternalException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidPaginationTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPaginationTokenException>()(
     "InvalidPaginationTokenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidTypeException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTypeException>()(
     "InvalidTypeException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ResourceAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceAlreadyExistsException>()(
     "ResourceAlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class SlotNotAvailableException
@@ -174,20 +174,20 @@ export class SlotNotAvailableException
       SlotSuggestions: S.optional(
         S.suspend(() => SlotList).annotate({ identifier: "SlotList" }),
       ),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type ConnectionId = string;

--- a/packages/aws/src/services/opensearchserverless.ts
+++ b/packages/aws/src/services/opensearchserverless.ts
@@ -88,32 +88,32 @@ const rules = T.EndpointResolver((p, _) => {
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class OcuLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<OcuLimitExceededException>()(
     "OcuLimitExceededException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceType: S.optional(S.String),
       serviceCode: S.String,
@@ -124,7 +124,7 @@ export class ServiceQuotaExceededException
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type CollectionId = string;

--- a/packages/aws/src/services/organizations.ts
+++ b/packages/aws/src/services/organizations.ts
@@ -225,14 +225,14 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class AccessDeniedForDependencyException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedForDependencyException>()(
     "AccessDeniedForDependencyException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => AccessDeniedForDependencyExceptionReason).annotate({
           identifier: "AccessDeniedForDependencyExceptionReason",
@@ -244,68 +244,68 @@ export class AccessDeniedForDependencyException
 export class AccountAlreadyClosedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccountAlreadyClosedException>()(
     "AccountAlreadyClosedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class AccountAlreadyRegisteredException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccountAlreadyRegisteredException>()(
     "AccountAlreadyRegisteredException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class AccountNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccountNotFoundException>()(
     "AccountNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class AccountNotRegisteredException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccountNotRegisteredException>()(
     "AccountNotRegisteredException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class AccountOwnerNotVerifiedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccountOwnerNotVerifiedException>()(
     "AccountOwnerNotVerifiedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class AlreadyInOrganizationException
   extends /*@__PURE__*/ S.TaggedErrorClass<AlreadyInOrganizationException>()(
     "AlreadyInOrganizationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class AWSOrganizationsNotInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<AWSOrganizationsNotInUseException>()(
     "AWSOrganizationsNotInUseException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ChildNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ChildNotFoundException>()(
     "ChildNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ConcurrentModificationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentModificationException>()(
     "ConcurrentModificationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ConstraintViolationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConstraintViolationException>()(
     "ConstraintViolationException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => ConstraintViolationExceptionReason).annotate({
           identifier: "ConstraintViolationExceptionReason",
@@ -317,67 +317,67 @@ export class ConstraintViolationException
 export class CreateAccountStatusNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<CreateAccountStatusNotFoundException>()(
     "CreateAccountStatusNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class DestinationParentNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<DestinationParentNotFoundException>()(
     "DestinationParentNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class DuplicateAccountException
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicateAccountException>()(
     "DuplicateAccountException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class DuplicateHandshakeException
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicateHandshakeException>()(
     "DuplicateHandshakeException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class DuplicateOrganizationalUnitException
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicateOrganizationalUnitException>()(
     "DuplicateOrganizationalUnitException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class DuplicatePolicyAttachmentException
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicatePolicyAttachmentException>()(
     "DuplicatePolicyAttachmentException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class DuplicatePolicyException
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicatePolicyException>()(
     "DuplicatePolicyException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class EffectivePolicyNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<EffectivePolicyNotFoundException>()(
     "EffectivePolicyNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class FinalizingOrganizationException
   extends /*@__PURE__*/ S.TaggedErrorClass<FinalizingOrganizationException>()(
     "FinalizingOrganizationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class HandshakeAlreadyInStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<HandshakeAlreadyInStateException>()(
     "HandshakeAlreadyInStateException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class HandshakeConstraintViolationException
   extends /*@__PURE__*/ S.TaggedErrorClass<HandshakeConstraintViolationException>()(
     "HandshakeConstraintViolationException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => HandshakeConstraintViolationExceptionReason).annotate({
           identifier: "HandshakeConstraintViolationExceptionReason",
@@ -389,20 +389,20 @@ export class HandshakeConstraintViolationException
 export class HandshakeNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<HandshakeNotFoundException>()(
     "HandshakeNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class InvalidHandshakeTransitionException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidHandshakeTransitionException>()(
     "InvalidHandshakeTransitionException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InvalidInputException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInputException>()(
     "InvalidInputException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => InvalidInputExceptionReason).annotate({
           identifier: "InvalidInputExceptionReason",
@@ -414,138 +414,141 @@ export class InvalidInputException
 export class InvalidResponsibilityTransferTransitionException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidResponsibilityTransferTransitionException>()(
     "InvalidResponsibilityTransferTransitionException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class MalformedPolicyDocumentException
   extends /*@__PURE__*/ S.TaggedErrorClass<MalformedPolicyDocumentException>()(
     "MalformedPolicyDocumentException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class MasterCannotLeaveOrganizationException
   extends /*@__PURE__*/ S.TaggedErrorClass<MasterCannotLeaveOrganizationException>()(
     "MasterCannotLeaveOrganizationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class OrganizationalUnitNotEmptyException
   extends /*@__PURE__*/ S.TaggedErrorClass<OrganizationalUnitNotEmptyException>()(
     "OrganizationalUnitNotEmptyException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class OrganizationalUnitNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<OrganizationalUnitNotFoundException>()(
     "OrganizationalUnitNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class OrganizationNotEmptyException
   extends /*@__PURE__*/ S.TaggedErrorClass<OrganizationNotEmptyException>()(
     "OrganizationNotEmptyException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ParentNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ParentNotFoundException>()(
     "ParentNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class PolicyChangesInProgressException
   extends /*@__PURE__*/ S.TaggedErrorClass<PolicyChangesInProgressException>()(
     "PolicyChangesInProgressException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class PolicyInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<PolicyInUseException>()(
     "PolicyInUseException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class PolicyNotAttachedException
   extends /*@__PURE__*/ S.TaggedErrorClass<PolicyNotAttachedException>()(
     "PolicyNotAttachedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class PolicyNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<PolicyNotFoundException>()(
     "PolicyNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class PolicyTypeAlreadyEnabledException
   extends /*@__PURE__*/ S.TaggedErrorClass<PolicyTypeAlreadyEnabledException>()(
     "PolicyTypeAlreadyEnabledException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class PolicyTypeNotAvailableForOrganizationException
   extends /*@__PURE__*/ S.TaggedErrorClass<PolicyTypeNotAvailableForOrganizationException>()(
     "PolicyTypeNotAvailableForOrganizationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class PolicyTypeNotEnabledException
   extends /*@__PURE__*/ S.TaggedErrorClass<PolicyTypeNotEnabledException>()(
     "PolicyTypeNotEnabledException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ResourcePolicyNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourcePolicyNotFoundException>()(
     "ResourcePolicyNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ResponsibilityTransferAlreadyInStatusException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResponsibilityTransferAlreadyInStatusException>()(
     "ResponsibilityTransferAlreadyInStatusException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ResponsibilityTransferNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResponsibilityTransferNotFoundException>()(
     "ResponsibilityTransferNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class RootNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<RootNotFoundException>()(
     "RootNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceException>()(
     "ServiceException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class SourceParentNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<SourceParentNotFoundException>()(
     "SourceParentNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class TargetNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<TargetNotFoundException>()(
     "TargetNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { Type: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Type: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class UnsupportedAPIEndpointException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedAPIEndpointException>()(
     "UnsupportedAPIEndpointException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export type HandshakeId = string;

--- a/packages/aws/src/services/osis.ts
+++ b/packages/aws/src/services/osis.ts
@@ -89,55 +89,55 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class DisabledOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<DisabledOperationException>()(
     "DisabledOperationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalException>()(
     "InternalException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidPaginationTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPaginationTokenException>()(
     "InvalidPaginationTokenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ResourceAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceAlreadyExistsException>()(
     "ResourceAlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type PipelineName = string;

--- a/packages/aws/src/services/outposts.ts
+++ b/packages/aws/src/services/outposts.ts
@@ -93,14 +93,14 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       ResourceId: S.optional(S.String),
       ResourceType: S.optional(
         S.suspend(() => ResourceType).annotate({ identifier: "ResourceType" }),
@@ -111,25 +111,25 @@ export class ConflictException
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type CapacityTaskId = string;

--- a/packages/aws/src/services/panorama.ts
+++ b/packages/aws/src/services/panorama.ts
@@ -90,14 +90,14 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       ResourceId: S.String,
       ResourceType: S.String,
       ErrorId: S.optional(S.String),
@@ -113,7 +113,7 @@ export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       RetryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.HttpError(500),
@@ -121,14 +121,18 @@ export class InternalServerException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.String, ResourceId: S.String, ResourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      ResourceId: S.String,
+      ResourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       ResourceId: S.optional(S.String),
       ResourceType: S.optional(S.String),
       QuotaCode: S.String,
@@ -140,7 +144,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       Reason: S.optional(S.String),
       ErrorId: S.optional(S.String),
       ErrorArguments: S.optional(

--- a/packages/aws/src/services/partnercentral-account.ts
+++ b/packages/aws/src/services/partnercentral-account.ts
@@ -58,7 +58,7 @@ export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       Reason: S.suspend(() => AccessDeniedExceptionReason).annotate({
         identifier: "AccessDeniedExceptionReason",
       }),
@@ -69,7 +69,7 @@ export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       Reason: S.suspend(() => ConflictExceptionReason).annotate({
         identifier: "ConflictExceptionReason",
       }),
@@ -79,14 +79,14 @@ export class ConflictException
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       Reason: S.suspend(() => ResourceNotFoundExceptionReason).annotate({
         identifier: "ResourceNotFoundExceptionReason",
       }),
@@ -97,7 +97,7 @@ export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       Reason: S.suspend(() => ServiceQuotaExceededExceptionReason).annotate({
         identifier: "ServiceQuotaExceededExceptionReason",
       }),
@@ -108,7 +108,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       ServiceCode: S.optional(S.String),
       QuotaCode: S.optional(S.String),
     },
@@ -118,7 +118,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       Reason: S.suspend(() => ValidationExceptionReason).annotate({
         identifier: "ValidationExceptionReason",
       }),

--- a/packages/aws/src/services/partnercentral-benefits.ts
+++ b/packages/aws/src/services/partnercentral-benefits.ts
@@ -57,32 +57,32 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       ResourceId: S.String,
       ResourceType: S.String,
       QuotaCode: S.String,
@@ -92,14 +92,14 @@ export class ServiceQuotaExceededException
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       Reason: S.suspend(() => ValidationExceptionReason).annotate({
         identifier: "ValidationExceptionReason",
       }),

--- a/packages/aws/src/services/partnercentral-channel.ts
+++ b/packages/aws/src/services/partnercentral-channel.ts
@@ -103,26 +103,30 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String, reason: S.optional(S.String) },
+    { message: S.String.pipe(T.ErrorMessage()), reason: S.optional(S.String) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceType: S.optional(S.String),
     },
@@ -132,7 +136,7 @@ export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.String,
       resourceType: S.String,
       quotaCode: S.String,
@@ -143,7 +147,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       serviceCode: S.optional(S.String),
       quotaCode: S.optional(S.String),
     },
@@ -153,7 +157,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.suspend(() => ValidationExceptionReason).annotate({
         identifier: "ValidationExceptionReason",
       }),

--- a/packages/aws/src/services/partnercentral-selling.ts
+++ b/packages/aws/src/services/partnercentral-selling.ts
@@ -58,7 +58,7 @@ export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => AccessDeniedExceptionErrorCode).annotate({
           identifier: "AccessDeniedExceptionErrorCode",
@@ -70,38 +70,38 @@ export class AccessDeniedException
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       Reason: S.suspend(() => ValidationExceptionReason).annotate({
         identifier: "ValidationExceptionReason",
       }),

--- a/packages/aws/src/services/payment-cryptography-data.ts
+++ b/packages/aws/src/services/payment-cryptography-data.ts
@@ -89,32 +89,35 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { ResourceId: S.optional(S.String) },
+    {
+      ResourceId: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       fieldList: S.optional(
         S.suspend(() => ValidationExceptionFieldList).annotate({
           identifier: "ValidationExceptionFieldList",
@@ -125,7 +128,7 @@ export class ValidationException
 export class VerificationFailedException
   extends /*@__PURE__*/ S.TaggedErrorClass<VerificationFailedException>()(
     "VerificationFailedException",
-    { Reason: S.String, Message: S.String },
+    { Reason: S.String, message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type KeyArnOrKeyAliasType = string;

--- a/packages/aws/src/services/payment-cryptography.ts
+++ b/packages/aws/src/services/payment-cryptography.ts
@@ -90,55 +90,58 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class PublicPolicyException
   extends /*@__PURE__*/ S.TaggedErrorClass<PublicPolicyException>()(
     "PublicPolicyException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { ResourceId: S.optional(S.String) },
+    {
+      ResourceId: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type KeyArnOrKeyAliasType = string;

--- a/packages/aws/src/services/pca-connector-ad.ts
+++ b/packages/aws/src/services/pca-connector-ad.ts
@@ -88,32 +88,40 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.String, ResourceId: S.String, ResourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      ResourceId: S.String,
+      ResourceType: S.String,
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.String, ResourceId: S.String, ResourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      ResourceId: S.String,
+      ResourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       ResourceId: S.String,
       ResourceType: S.String,
       ServiceCode: S.String,
@@ -125,7 +133,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       ServiceCode: S.optional(S.String),
       QuotaCode: S.optional(S.String),
     },
@@ -135,7 +143,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => ValidationExceptionReason).annotate({
           identifier: "ValidationExceptionReason",

--- a/packages/aws/src/services/pca-connector-scep.ts
+++ b/packages/aws/src/services/pca-connector-scep.ts
@@ -90,38 +90,46 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.String, ResourceId: S.String, ResourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      ResourceId: S.String,
+      ResourceType: S.String,
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.String, ResourceId: S.String, ResourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      ResourceId: S.String,
+      ResourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       ResourceType: S.String,
       ServiceCode: S.String,
       QuotaCode: S.String,
@@ -131,14 +139,14 @@ export class ServiceQuotaExceededException
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(429), T.Retryable({ throttling: true })),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => ValidationExceptionReason).annotate({
           identifier: "ValidationExceptionReason",

--- a/packages/aws/src/services/pcs.ts
+++ b/packages/aws/src/services/pcs.ts
@@ -90,32 +90,40 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       serviceCode: S.String,
       resourceId: S.optional(S.String),
       resourceType: S.optional(S.String),
@@ -127,7 +135,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.all(T.HttpError(429), T.Retryable()),
@@ -136,7 +144,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.suspend(() => ValidationExceptionReason).annotate({
         identifier: "ValidationExceptionReason",
       }),

--- a/packages/aws/src/services/personalize-events.ts
+++ b/packages/aws/src/services/personalize-events.ts
@@ -89,19 +89,19 @@ const rules = T.EndpointResolver((p, _) => {
 export class InvalidInputException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInputException>()(
     "InvalidInputException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUseException>()(
     "ResourceInUseException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export type StringType = string;

--- a/packages/aws/src/services/personalize-runtime.ts
+++ b/packages/aws/src/services/personalize-runtime.ts
@@ -89,13 +89,13 @@ const rules = T.EndpointResolver((p, _) => {
 export class InvalidInputException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInputException>()(
     "InvalidInputException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export type Arn = string;

--- a/packages/aws/src/services/personalize.ts
+++ b/packages/aws/src/services/personalize.ts
@@ -90,49 +90,49 @@ const rules = T.EndpointResolver((p, _) => {
 export class InvalidInputException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInputException>()(
     "InvalidInputException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidNextTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNextTokenException>()(
     "InvalidNextTokenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ResourceAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceAlreadyExistsException>()(
     "ResourceAlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError, C.withAlreadyExistsError) {}
 export class ResourceInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUseException>()(
     "ResourceInUseException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class TooManyTagKeysException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagKeysException>()(
     "TooManyTagKeysException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type Name = string;

--- a/packages/aws/src/services/pi.ts
+++ b/packages/aws/src/services/pi.ts
@@ -90,17 +90,17 @@ const rules = T.EndpointResolver((p, _) => {
 export class InternalServiceError
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServiceError>()(
     "InternalServiceError",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidArgumentException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidArgumentException>()(
     "InvalidArgumentException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NotAuthorizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotAuthorizedException>()(
     "NotAuthorizedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type ServiceType = "RDS" | "DOCDB" | (string & {});
 export const ServiceType = /*@__PURE__*/ S.String;

--- a/packages/aws/src/services/pinpoint-email.ts
+++ b/packages/aws/src/services/pinpoint-email.ts
@@ -88,61 +88,61 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccountSuspendedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccountSuspendedException>()(
     "AccountSuspendedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class AlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<AlreadyExistsException>()(
     "AlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError, C.withAlreadyExistsError) {}
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ConcurrentModificationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentModificationException>()(
     "ConcurrentModificationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class MailFromDomainNotVerifiedException
   extends /*@__PURE__*/ S.TaggedErrorClass<MailFromDomainNotVerifiedException>()(
     "MailFromDomainNotVerifiedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class MessageRejected
   extends /*@__PURE__*/ S.TaggedErrorClass<MessageRejected>()(
     "MessageRejected",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class SendingPausedException
   extends /*@__PURE__*/ S.TaggedErrorClass<SendingPausedException>()(
     "SendingPausedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export type ConfigurationSetName = string;

--- a/packages/aws/src/services/pinpoint-sms-voice-v2.ts
+++ b/packages/aws/src/services/pinpoint-sms-voice-v2.ts
@@ -88,13 +88,16 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String), Reason: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Reason: S.optional(S.String),
+    },
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Reason: S.optional(S.String),
       ResourceType: S.optional(S.String),
       ResourceId: S.optional(S.String),
@@ -103,14 +106,17 @@ export class ConflictException
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
     T.Retryable(),
   ).pipe(C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       ResourceType: S.optional(S.String),
       ResourceId: S.optional(S.String),
     },
@@ -118,19 +124,22 @@ export class ResourceNotFoundException
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.optional(S.String), Reason: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Reason: S.optional(S.String),
+    },
   ) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.Retryable({ throttling: true }),
   ).pipe(C.withRetryableError, C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Reason: S.optional(S.String),
       Fields: S.optional(
         S.suspend(() => ValidationExceptionFieldList).annotate({

--- a/packages/aws/src/services/pinpoint-sms-voice.ts
+++ b/packages/aws/src/services/pinpoint-sms-voice.ts
@@ -87,37 +87,37 @@ const rules = T.EndpointResolver((p, _) => {
 export class AlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<AlreadyExistsException>()(
     "AlreadyExistsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InternalServiceErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServiceErrorException>()(
     "InternalServiceErrorException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(412),
   ) {}
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export type WordCharactersWithDelimiters = string;

--- a/packages/aws/src/services/pinpoint.ts
+++ b/packages/aws/src/services/pinpoint.ts
@@ -102,49 +102,73 @@ const rules = T.EndpointResolver((p, _) => {
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { Message: S.optional(S.String), RequestID: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestID: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String), RequestID: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestID: S.optional(S.String),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ForbiddenException
   extends /*@__PURE__*/ S.TaggedErrorClass<ForbiddenException>()(
     "ForbiddenException",
-    { Message: S.optional(S.String), RequestID: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestID: S.optional(S.String),
+    },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class InternalServerErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerErrorException>()(
     "InternalServerErrorException",
-    { Message: S.optional(S.String), RequestID: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestID: S.optional(S.String),
+    },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class MethodNotAllowedException
   extends /*@__PURE__*/ S.TaggedErrorClass<MethodNotAllowedException>()(
     "MethodNotAllowedException",
-    { Message: S.optional(S.String), RequestID: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestID: S.optional(S.String),
+    },
     T.HttpError(405),
   ).pipe(C.withBadRequestError) {}
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { Message: S.optional(S.String), RequestID: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestID: S.optional(S.String),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class PayloadTooLargeException
   extends /*@__PURE__*/ S.TaggedErrorClass<PayloadTooLargeException>()(
     "PayloadTooLargeException",
-    { Message: S.optional(S.String), RequestID: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestID: S.optional(S.String),
+    },
     T.HttpError(413),
   ).pipe(C.withBadRequestError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { Message: S.optional(S.String), RequestID: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestID: S.optional(S.String),
+    },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export type MapOf__string = { [key: string]: string | undefined };

--- a/packages/aws/src/services/pipes.ts
+++ b/packages/aws/src/services/pipes.ts
@@ -88,14 +88,18 @@ const rules = T.EndpointResolver((p, _) => {
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalException>()(
     "InternalException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.HttpError(500),
@@ -103,14 +107,14 @@ export class InternalException
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.String,
       resourceType: S.String,
       serviceCode: S.String,
@@ -122,7 +126,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       serviceCode: S.optional(S.String),
       quotaCode: S.optional(S.String),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
@@ -133,7 +137,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       fieldList: S.optional(
         S.suspend(() => ValidationExceptionFieldList).annotate({
           identifier: "ValidationExceptionFieldList",

--- a/packages/aws/src/services/polly.ts
+++ b/packages/aws/src/services/polly.ts
@@ -88,104 +88,104 @@ const rules = T.EndpointResolver((p, _) => {
 export class EngineNotSupportedException
   extends /*@__PURE__*/ S.TaggedErrorClass<EngineNotSupportedException>()(
     "EngineNotSupportedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidLexiconException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidLexiconException>()(
     "InvalidLexiconException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidNextTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNextTokenException>()(
     "InvalidNextTokenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidS3BucketException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidS3BucketException>()(
     "InvalidS3BucketException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidS3KeyException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidS3KeyException>()(
     "InvalidS3KeyException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidSampleRateException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSampleRateException>()(
     "InvalidSampleRateException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidSnsTopicArnException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSnsTopicArnException>()(
     "InvalidSnsTopicArnException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidSsmlException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSsmlException>()(
     "InvalidSsmlException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidTaskIdException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTaskIdException>()(
     "InvalidTaskIdException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class LanguageNotSupportedException
   extends /*@__PURE__*/ S.TaggedErrorClass<LanguageNotSupportedException>()(
     "LanguageNotSupportedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class LexiconNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<LexiconNotFoundException>()(
     "LexiconNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class LexiconSizeExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LexiconSizeExceededException>()(
     "LexiconSizeExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class MarksNotSupportedForFormatException
   extends /*@__PURE__*/ S.TaggedErrorClass<MarksNotSupportedForFormatException>()(
     "MarksNotSupportedForFormatException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class MaxLexemeLengthExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<MaxLexemeLengthExceededException>()(
     "MaxLexemeLengthExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class MaxLexiconsNumberExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<MaxLexiconsNumberExceededException>()(
     "MaxLexiconsNumberExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ServiceFailureException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceFailureException>()(
     "ServiceFailureException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       quotaCode: S.suspend(() => QuotaCode).annotate({
         identifier: "QuotaCode",
       }),
@@ -198,26 +198,26 @@ export class ServiceQuotaExceededException
 export class SsmlMarksNotSupportedForTextTypeException
   extends /*@__PURE__*/ S.TaggedErrorClass<SsmlMarksNotSupportedForTextTypeException>()(
     "SsmlMarksNotSupportedForTextTypeException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class SynthesisTaskNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<SynthesisTaskNotFoundException>()(
     "SynthesisTaskNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TextLengthExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<TextLengthExceededException>()(
     "TextLengthExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       throttlingReasons: S.optional(
         S.suspend(() => ThrottlingReasonList).annotate({
           identifier: "ThrottlingReasonList",
@@ -232,20 +232,20 @@ export class ThrottlingException
 export class UnsupportedPlsAlphabetException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedPlsAlphabetException>()(
     "UnsupportedPlsAlphabetException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class UnsupportedPlsLanguageException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedPlsLanguageException>()(
     "UnsupportedPlsLanguageException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.suspend(() => ValidationExceptionReason).annotate({
         identifier: "ValidationExceptionReason",
       }),

--- a/packages/aws/src/services/pricing.ts
+++ b/packages/aws/src/services/pricing.ts
@@ -91,49 +91,49 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export class ExpiredNextTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<ExpiredNextTokenException>()(
     "ExpiredNextTokenException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InternalErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalErrorException>()(
     "InternalErrorException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class InvalidNextTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNextTokenException>()(
     "InvalidNextTokenException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterException>()(
     "InvalidParameterException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(429), T.Retryable({ throttling: true })),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export type FormatVersion = string;

--- a/packages/aws/src/services/proton.ts
+++ b/packages/aws/src/services/proton.ts
@@ -90,43 +90,43 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: SensitiveString },
+    { message: SensitiveString.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: SensitiveString },
+    { message: SensitiveString.pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: SensitiveString },
+    { message: SensitiveString.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: SensitiveString },
+    { message: SensitiveString.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: SensitiveString },
+    { message: SensitiveString.pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: SensitiveString },
+    { message: SensitiveString.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(429), T.Retryable({ throttling: true })),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: SensitiveString },
+    { message: SensitiveString.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type EnvironmentAccountConnectionId = string;

--- a/packages/aws/src/services/qapps.ts
+++ b/packages/aws/src/services/qapps.ts
@@ -88,26 +88,34 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ContentTooLargeException
   extends /*@__PURE__*/ S.TaggedErrorClass<ContentTooLargeException>()(
     "ContentTooLargeException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(413),
   ).pipe(C.withBadRequestError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.all(T.HttpError(500), T.Retryable()),
@@ -115,14 +123,18 @@ export class InternalServerException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.String,
       resourceType: S.String,
       serviceCode: S.String,
@@ -134,7 +146,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       serviceCode: S.String,
       quotaCode: S.String,
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
@@ -144,13 +156,13 @@ export class ThrottlingException
 export class UnauthorizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnauthorizedException>()(
     "UnauthorizedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type InstanceId = string;

--- a/packages/aws/src/services/qbusiness.ts
+++ b/packages/aws/src/services/qbusiness.ts
@@ -77,62 +77,74 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ExternalResourceException
   extends /*@__PURE__*/ S.TaggedErrorClass<ExternalResourceException>()(
     "ExternalResourceException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(424),
   ) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class LicenseNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<LicenseNotFoundException>()(
     "LicenseNotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class MediaTooLargeException
   extends /*@__PURE__*/ S.TaggedErrorClass<MediaTooLargeException>()(
     "MediaTooLargeException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.suspend(() => ValidationExceptionReason).annotate({
         identifier: "ValidationExceptionReason",
       }),

--- a/packages/aws/src/services/qconnect.ts
+++ b/packages/aws/src/services/qconnect.ts
@@ -90,73 +90,79 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class DependencyFailedException
   extends /*@__PURE__*/ S.TaggedErrorClass<DependencyFailedException>()(
     "DependencyFailedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(424),
   ) {}
 export class PreconditionFailedException
   extends /*@__PURE__*/ S.TaggedErrorClass<PreconditionFailedException>()(
     "PreconditionFailedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(412),
   ) {}
 export class RequestTimeoutException
   extends /*@__PURE__*/ S.TaggedErrorClass<RequestTimeoutException>()(
     "RequestTimeoutException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(408), T.Retryable()),
   ).pipe(C.withTimeoutError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String), resourceName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      resourceName: S.optional(S.String),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(400), T.Retryable()),
   ).pipe(C.withBadRequestError, C.withRetryableError) {}
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { message: S.optional(S.String), resourceName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      resourceName: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class UnauthorizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnauthorizedException>()(
     "UnauthorizedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export class UnprocessableContentException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnprocessableContentException>()(
     "UnprocessableContentException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(422),
   ).pipe(C.withBadRequestError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type UuidOrArn = string;

--- a/packages/aws/src/services/quicksight.ts
+++ b/packages/aws/src/services/quicksight.ts
@@ -90,86 +90,122 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export class ConcurrentUpdatingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentUpdatingException>()(
     "ConcurrentUpdatingException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class CustomerManagedKeyUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<CustomerManagedKeyUnavailableException>()(
     "CustomerManagedKeyUnavailableException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class DomainNotWhitelistedException
   extends /*@__PURE__*/ S.TaggedErrorClass<DomainNotWhitelistedException>()(
     "DomainNotWhitelistedException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class IdentityTypeNotSupportedException
   extends /*@__PURE__*/ S.TaggedErrorClass<IdentityTypeNotSupportedException>()(
     "IdentityTypeNotSupportedException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class InternalFailureException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalFailureException>()(
     "InternalFailureException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidDataSetParameterValueException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDataSetParameterValueException>()(
     "InvalidDataSetParameterValueException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidNextTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNextTokenException>()(
     "InvalidNextTokenException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterException>()(
     "InvalidParameterException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidParameterValueException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterValueException>()(
     "InvalidParameterValueException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       ResourceType: S.optional(
         S.suspend(() => ExceptionResourceType).annotate({
           identifier: "ExceptionResourceType",
@@ -182,14 +218,17 @@ export class LimitExceededException
 export class PreconditionNotMetException
   extends /*@__PURE__*/ S.TaggedErrorClass<PreconditionNotMetException>()(
     "PreconditionNotMetException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class QuickSightSubscriptionRequired
   extends /*@__PURE__*/ S.TaggedErrorClass<QuickSightSubscriptionRequired>()(
     "QuickSightSubscriptionRequired",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       ResourceType: S.optional(
         S.suspend(() => ExceptionResourceType).annotate({
           identifier: "ExceptionResourceType",
@@ -205,14 +244,17 @@ export class QuickSightSubscriptionRequired
 export class QuickSightUserNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<QuickSightUserNotFoundException>()(
     "QuickSightUserNotFoundException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ResourceExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceExistsException>()(
     "ResourceExistsException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       ResourceType: S.optional(
         S.suspend(() => ExceptionResourceType).annotate({
           identifier: "ExceptionResourceType",
@@ -226,7 +268,7 @@ export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       ResourceType: S.optional(
         S.suspend(() => ExceptionResourceType).annotate({
           identifier: "ExceptionResourceType",
@@ -240,7 +282,7 @@ export class ResourceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceUnavailableException>()(
     "ResourceUnavailableException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       ResourceType: S.optional(
         S.suspend(() => ExceptionResourceType).annotate({
           identifier: "ExceptionResourceType",
@@ -253,25 +295,37 @@ export class ResourceUnavailableException
 export class SessionLifetimeInMinutesInvalidException
   extends /*@__PURE__*/ S.TaggedErrorClass<SessionLifetimeInMinutesInvalidException>()(
     "SessionLifetimeInMinutesInvalidException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class UnsupportedPricingPlanException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedPricingPlanException>()(
     "UnsupportedPricingPlanException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class UnsupportedUserEditionException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedUserEditionException>()(
     "UnsupportedUserEditionException",
-    { Message: S.optional(S.String), RequestId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      RequestId: S.optional(S.String),
+    },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export type AwsAccountId = string;

--- a/packages/aws/src/services/ram.ts
+++ b/packages/aws/src/services/ram.ts
@@ -91,7 +91,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class IdempotentParameterMismatchException
   extends /*@__PURE__*/ S.TaggedErrorClass<IdempotentParameterMismatchException>()(
     "IdempotentParameterMismatchException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "IdempotentParameterMismatch",
@@ -103,7 +103,7 @@ export class IdempotentParameterMismatchException
 export class InvalidClientTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidClientTokenException>()(
     "InvalidClientTokenException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidClientToken", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -112,7 +112,7 @@ export class InvalidClientTokenException
 export class InvalidMaxResultsException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidMaxResultsException>()(
     "InvalidMaxResultsException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidMaxResults", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -121,7 +121,7 @@ export class InvalidMaxResultsException
 export class InvalidNextTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNextTokenException>()(
     "InvalidNextTokenException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidNextToken", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -130,7 +130,7 @@ export class InvalidNextTokenException
 export class InvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterException>()(
     "InvalidParameterException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidParameter", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -139,7 +139,7 @@ export class InvalidParameterException
 export class InvalidPolicyException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPolicyException>()(
     "InvalidPolicyException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidPolicy", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -148,7 +148,7 @@ export class InvalidPolicyException
 export class InvalidResourceTypeException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidResourceTypeException>()(
     "InvalidResourceTypeException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidResourceType.Unknown",
@@ -160,7 +160,7 @@ export class InvalidResourceTypeException
 export class InvalidStateTransitionException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidStateTransitionException>()(
     "InvalidStateTransitionException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidStateTransitionException.Unknown",
@@ -172,7 +172,7 @@ export class InvalidStateTransitionException
 export class MalformedArnException
   extends /*@__PURE__*/ S.TaggedErrorClass<MalformedArnException>()(
     "MalformedArnException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidArn.Malformed", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -181,7 +181,7 @@ export class MalformedArnException
 export class MalformedPolicyTemplateException
   extends /*@__PURE__*/ S.TaggedErrorClass<MalformedPolicyTemplateException>()(
     "MalformedPolicyTemplateException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "MalformedPolicyTemplateException",
@@ -193,7 +193,7 @@ export class MalformedPolicyTemplateException
 export class MissingRequiredParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<MissingRequiredParameterException>()(
     "MissingRequiredParameterException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "MissingRequiredParameter",
@@ -205,7 +205,7 @@ export class MissingRequiredParameterException
 export class OperationNotPermittedException
   extends /*@__PURE__*/ S.TaggedErrorClass<OperationNotPermittedException>()(
     "OperationNotPermittedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "OperationNotPermitted", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -214,7 +214,7 @@ export class OperationNotPermittedException
 export class PermissionAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<PermissionAlreadyExistsException>()(
     "PermissionAlreadyExistsException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "PermissionAlreadyExistsException",
@@ -226,7 +226,7 @@ export class PermissionAlreadyExistsException
 export class PermissionLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<PermissionLimitExceededException>()(
     "PermissionLimitExceededException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "PermissionLimitExceededException",
@@ -238,7 +238,7 @@ export class PermissionLimitExceededException
 export class PermissionVersionsLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<PermissionVersionsLimitExceededException>()(
     "PermissionVersionsLimitExceededException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "PermissionVersionsLimitExceededException",
@@ -250,7 +250,7 @@ export class PermissionVersionsLimitExceededException
 export class ResourceArnNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceArnNotFoundException>()(
     "ResourceArnNotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidResourceArn.NotFound",
@@ -262,7 +262,7 @@ export class ResourceArnNotFoundException
 export class ResourceShareInvitationAlreadyAcceptedException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceShareInvitationAlreadyAcceptedException>()(
     "ResourceShareInvitationAlreadyAcceptedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidResourceShareInvitationArn.AlreadyAccepted",
@@ -274,7 +274,7 @@ export class ResourceShareInvitationAlreadyAcceptedException
 export class ResourceShareInvitationAlreadyRejectedException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceShareInvitationAlreadyRejectedException>()(
     "ResourceShareInvitationAlreadyRejectedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidResourceShareInvitationArn.AlreadyRejected",
@@ -286,7 +286,7 @@ export class ResourceShareInvitationAlreadyRejectedException
 export class ResourceShareInvitationArnNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceShareInvitationArnNotFoundException>()(
     "ResourceShareInvitationArnNotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidResourceShareInvitationArn.NotFound",
@@ -298,7 +298,7 @@ export class ResourceShareInvitationArnNotFoundException
 export class ResourceShareInvitationExpiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceShareInvitationExpiredException>()(
     "ResourceShareInvitationExpiredException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidResourceShareInvitationArn.Expired",
@@ -310,7 +310,7 @@ export class ResourceShareInvitationExpiredException
 export class ResourceShareLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceShareLimitExceededException>()(
     "ResourceShareLimitExceededException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ResourceShareLimitExceeded",
@@ -322,7 +322,7 @@ export class ResourceShareLimitExceededException
 export class ServerInternalException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServerInternalException>()(
     "ServerInternalException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InternalError", httpResponseCode: 500 }),
       T.HttpError(500),
@@ -331,7 +331,7 @@ export class ServerInternalException
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "Unavailable", httpResponseCode: 503 }),
       T.HttpError(503),
@@ -340,7 +340,7 @@ export class ServiceUnavailableException
 export class TagLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<TagLimitExceededException>()(
     "TagLimitExceededException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "TagLimitExceeded", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -349,7 +349,7 @@ export class TagLimitExceededException
 export class TagPolicyViolationException
   extends /*@__PURE__*/ S.TaggedErrorClass<TagPolicyViolationException>()(
     "TagPolicyViolationException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "TagPolicyViolation", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -358,7 +358,7 @@ export class TagPolicyViolationException
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ThrottlingException", httpResponseCode: 429 }),
       T.HttpError(429),
@@ -367,7 +367,7 @@ export class ThrottlingException
 export class UnknownResourceException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnknownResourceException>()(
     "UnknownResourceException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidResourceShareArn.NotFound",
@@ -379,7 +379,7 @@ export class UnknownResourceException
 export class UnmatchedPolicyPermissionException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnmatchedPolicyPermissionException>()(
     "UnmatchedPolicyPermissionException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "UnmatchedPolicyPermissionException",

--- a/packages/aws/src/services/rbin.ts
+++ b/packages/aws/src/services/rbin.ts
@@ -89,7 +89,7 @@ export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => ConflictExceptionReason).annotate({
           identifier: "ConflictExceptionReason",
@@ -101,14 +101,14 @@ export class ConflictException
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => ResourceNotFoundExceptionReason).annotate({
           identifier: "ResourceNotFoundExceptionReason",
@@ -121,7 +121,7 @@ export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => ServiceQuotaExceededExceptionReason).annotate({
           identifier: "ServiceQuotaExceededExceptionReason",
@@ -134,7 +134,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => ValidationExceptionReason).annotate({
           identifier: "ValidationExceptionReason",

--- a/packages/aws/src/services/rds-data.ts
+++ b/packages/aws/src/services/rds-data.ts
@@ -87,103 +87,106 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class DatabaseErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<DatabaseErrorException>()(
     "DatabaseErrorException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class DatabaseNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<DatabaseNotFoundException>()(
     "DatabaseNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class DatabaseResumingException
   extends /*@__PURE__*/ S.TaggedErrorClass<DatabaseResumingException>()(
     "DatabaseResumingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class DatabaseUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<DatabaseUnavailableException>()(
     "DatabaseUnavailableException",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(504),
   ).pipe(C.withTimeoutError) {}
 export class ForbiddenException
   extends /*@__PURE__*/ S.TaggedErrorClass<ForbiddenException>()(
     "ForbiddenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class HttpEndpointNotEnabledException
   extends /*@__PURE__*/ S.TaggedErrorClass<HttpEndpointNotEnabledException>()(
     "HttpEndpointNotEnabledException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InternalServerErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerErrorException>()(
     "InternalServerErrorException",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidResourceStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidResourceStateException>()(
     "InvalidResourceStateException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidSecretException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSecretException>()(
     "InvalidSecretException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class SecretsErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<SecretsErrorException>()(
     "SecretsErrorException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ServiceUnavailableError
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableError>()(
     "ServiceUnavailableError",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class StatementTimeoutException
   extends /*@__PURE__*/ S.TaggedErrorClass<StatementTimeoutException>()(
     "StatementTimeoutException",
-    { message: S.optional(S.String), dbConnectionId: S.optional(S.Number) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      dbConnectionId: S.optional(S.Number),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TransactionNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<TransactionNotFoundException>()(
     "TransactionNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class UnsupportedResultException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedResultException>()(
     "UnsupportedResultException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type Arn = string;

--- a/packages/aws/src/services/rds.ts
+++ b/packages/aws/src/services/rds.ts
@@ -91,7 +91,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class AuthorizationAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<AuthorizationAlreadyExistsFault>()(
     "AuthorizationAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "AuthorizationAlreadyExists",
@@ -103,7 +103,7 @@ export class AuthorizationAlreadyExistsFault
 export class AuthorizationNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<AuthorizationNotFoundFault>()(
     "AuthorizationNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "AuthorizationNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -112,7 +112,7 @@ export class AuthorizationNotFoundFault
 export class AuthorizationQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<AuthorizationQuotaExceededFault>()(
     "AuthorizationQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "AuthorizationQuotaExceeded",
@@ -124,7 +124,7 @@ export class AuthorizationQuotaExceededFault
 export class BackupPolicyNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<BackupPolicyNotFoundFault>()(
     "BackupPolicyNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "BackupPolicyNotFoundFault",
@@ -136,7 +136,7 @@ export class BackupPolicyNotFoundFault
 export class BlueGreenDeploymentAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<BlueGreenDeploymentAlreadyExistsFault>()(
     "BlueGreenDeploymentAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "BlueGreenDeploymentAlreadyExistsFault",
@@ -148,7 +148,7 @@ export class BlueGreenDeploymentAlreadyExistsFault
 export class BlueGreenDeploymentNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<BlueGreenDeploymentNotFoundFault>()(
     "BlueGreenDeploymentNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "BlueGreenDeploymentNotFoundFault",
@@ -160,7 +160,7 @@ export class BlueGreenDeploymentNotFoundFault
 export class CertificateNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<CertificateNotFoundFault>()(
     "CertificateNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "CertificateNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -169,7 +169,7 @@ export class CertificateNotFoundFault
 export class CreateCustomDBEngineVersionFault
   extends /*@__PURE__*/ S.TaggedErrorClass<CreateCustomDBEngineVersionFault>()(
     "CreateCustomDBEngineVersionFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CreateCustomDBEngineVersionFault",
@@ -181,7 +181,7 @@ export class CreateCustomDBEngineVersionFault
 export class CustomAvailabilityZoneNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<CustomAvailabilityZoneNotFoundFault>()(
     "CustomAvailabilityZoneNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CustomAvailabilityZoneNotFound",
@@ -193,7 +193,7 @@ export class CustomAvailabilityZoneNotFoundFault
 export class CustomDBEngineVersionAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<CustomDBEngineVersionAlreadyExistsFault>()(
     "CustomDBEngineVersionAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CustomDBEngineVersionAlreadyExistsFault",
@@ -205,7 +205,7 @@ export class CustomDBEngineVersionAlreadyExistsFault
 export class CustomDBEngineVersionNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<CustomDBEngineVersionNotFoundFault>()(
     "CustomDBEngineVersionNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CustomDBEngineVersionNotFoundFault",
@@ -217,7 +217,7 @@ export class CustomDBEngineVersionNotFoundFault
 export class CustomDBEngineVersionQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<CustomDBEngineVersionQuotaExceededFault>()(
     "CustomDBEngineVersionQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CustomDBEngineVersionQuotaExceededFault",
@@ -229,7 +229,7 @@ export class CustomDBEngineVersionQuotaExceededFault
 export class DBClusterAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBClusterAlreadyExistsFault>()(
     "DBClusterAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBClusterAlreadyExistsFault",
@@ -245,7 +245,7 @@ export class DBClusterAlreadyExistsFault
 export class DBClusterAutomatedBackupNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBClusterAutomatedBackupNotFoundFault>()(
     "DBClusterAutomatedBackupNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBClusterAutomatedBackupNotFoundFault",
@@ -257,7 +257,7 @@ export class DBClusterAutomatedBackupNotFoundFault
 export class DBClusterAutomatedBackupQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBClusterAutomatedBackupQuotaExceededFault>()(
     "DBClusterAutomatedBackupQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBClusterAutomatedBackupQuotaExceededFault",
@@ -269,7 +269,7 @@ export class DBClusterAutomatedBackupQuotaExceededFault
 export class DBClusterBacktrackNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBClusterBacktrackNotFoundFault>()(
     "DBClusterBacktrackNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBClusterBacktrackNotFoundFault",
@@ -281,7 +281,7 @@ export class DBClusterBacktrackNotFoundFault
 export class DBClusterEndpointAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBClusterEndpointAlreadyExistsFault>()(
     "DBClusterEndpointAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBClusterEndpointAlreadyExistsFault",
@@ -293,7 +293,7 @@ export class DBClusterEndpointAlreadyExistsFault
 export class DBClusterEndpointNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBClusterEndpointNotFoundFault>()(
     "DBClusterEndpointNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBClusterEndpointNotFoundFault",
@@ -305,7 +305,7 @@ export class DBClusterEndpointNotFoundFault
 export class DBClusterEndpointQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBClusterEndpointQuotaExceededFault>()(
     "DBClusterEndpointQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBClusterEndpointQuotaExceededFault",
@@ -317,7 +317,7 @@ export class DBClusterEndpointQuotaExceededFault
 export class DBClusterNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBClusterNotFoundFault>()(
     "DBClusterNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBClusterNotFoundFault",
@@ -329,7 +329,7 @@ export class DBClusterNotFoundFault
 export class DBClusterParameterGroupNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBClusterParameterGroupNotFoundFault>()(
     "DBClusterParameterGroupNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBClusterParameterGroupNotFound",
@@ -341,7 +341,7 @@ export class DBClusterParameterGroupNotFoundFault
 export class DBClusterQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBClusterQuotaExceededFault>()(
     "DBClusterQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBClusterQuotaExceededFault",
@@ -353,7 +353,7 @@ export class DBClusterQuotaExceededFault
 export class DBClusterRoleAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBClusterRoleAlreadyExistsFault>()(
     "DBClusterRoleAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBClusterRoleAlreadyExists",
@@ -365,7 +365,7 @@ export class DBClusterRoleAlreadyExistsFault
 export class DBClusterRoleNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBClusterRoleNotFoundFault>()(
     "DBClusterRoleNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "DBClusterRoleNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -374,7 +374,7 @@ export class DBClusterRoleNotFoundFault
 export class DBClusterRoleQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBClusterRoleQuotaExceededFault>()(
     "DBClusterRoleQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBClusterRoleQuotaExceeded",
@@ -386,7 +386,7 @@ export class DBClusterRoleQuotaExceededFault
 export class DBClusterSnapshotAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBClusterSnapshotAlreadyExistsFault>()(
     "DBClusterSnapshotAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBClusterSnapshotAlreadyExistsFault",
@@ -398,7 +398,7 @@ export class DBClusterSnapshotAlreadyExistsFault
 export class DBClusterSnapshotNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBClusterSnapshotNotFoundFault>()(
     "DBClusterSnapshotNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBClusterSnapshotNotFoundFault",
@@ -410,7 +410,7 @@ export class DBClusterSnapshotNotFoundFault
 export class DBInstanceAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBInstanceAlreadyExistsFault>()(
     "DBInstanceAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBInstanceAlreadyExists",
@@ -422,7 +422,7 @@ export class DBInstanceAlreadyExistsFault
 export class DBInstanceAutomatedBackupNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBInstanceAutomatedBackupNotFoundFault>()(
     "DBInstanceAutomatedBackupNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBInstanceAutomatedBackupNotFound",
@@ -434,7 +434,7 @@ export class DBInstanceAutomatedBackupNotFoundFault
 export class DBInstanceAutomatedBackupQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBInstanceAutomatedBackupQuotaExceededFault>()(
     "DBInstanceAutomatedBackupQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBInstanceAutomatedBackupQuotaExceeded",
@@ -446,7 +446,7 @@ export class DBInstanceAutomatedBackupQuotaExceededFault
 export class DBInstanceNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBInstanceNotFoundFault>()(
     "DBInstanceNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "DBInstanceNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -455,7 +455,7 @@ export class DBInstanceNotFoundFault
 export class DBInstanceNotReadyFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBInstanceNotReadyFault>()(
     "DBInstanceNotReadyFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "DBInstanceNotReady", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -464,7 +464,7 @@ export class DBInstanceNotReadyFault
 export class DBInstanceRoleAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBInstanceRoleAlreadyExistsFault>()(
     "DBInstanceRoleAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBInstanceRoleAlreadyExists",
@@ -476,7 +476,7 @@ export class DBInstanceRoleAlreadyExistsFault
 export class DBInstanceRoleNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBInstanceRoleNotFoundFault>()(
     "DBInstanceRoleNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBInstanceRoleNotFound",
@@ -488,7 +488,7 @@ export class DBInstanceRoleNotFoundFault
 export class DBInstanceRoleQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBInstanceRoleQuotaExceededFault>()(
     "DBInstanceRoleQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBInstanceRoleQuotaExceeded",
@@ -500,7 +500,7 @@ export class DBInstanceRoleQuotaExceededFault
 export class DBLogFileNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBLogFileNotFoundFault>()(
     "DBLogFileNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBLogFileNotFoundFault",
@@ -512,7 +512,7 @@ export class DBLogFileNotFoundFault
 export class DBParameterGroupAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBParameterGroupAlreadyExistsFault>()(
     "DBParameterGroupAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBParameterGroupAlreadyExists",
@@ -524,7 +524,7 @@ export class DBParameterGroupAlreadyExistsFault
 export class DBParameterGroupNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBParameterGroupNotFoundFault>()(
     "DBParameterGroupNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBParameterGroupNotFound",
@@ -536,7 +536,7 @@ export class DBParameterGroupNotFoundFault
 export class DBParameterGroupQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBParameterGroupQuotaExceededFault>()(
     "DBParameterGroupQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBParameterGroupQuotaExceeded",
@@ -548,7 +548,7 @@ export class DBParameterGroupQuotaExceededFault
 export class DBProxyAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBProxyAlreadyExistsFault>()(
     "DBProxyAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBProxyAlreadyExistsFault",
@@ -560,7 +560,7 @@ export class DBProxyAlreadyExistsFault
 export class DBProxyEndpointAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBProxyEndpointAlreadyExistsFault>()(
     "DBProxyEndpointAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBProxyEndpointAlreadyExistsFault",
@@ -572,7 +572,7 @@ export class DBProxyEndpointAlreadyExistsFault
 export class DBProxyEndpointNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBProxyEndpointNotFoundFault>()(
     "DBProxyEndpointNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBProxyEndpointNotFoundFault",
@@ -584,7 +584,7 @@ export class DBProxyEndpointNotFoundFault
 export class DBProxyEndpointQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBProxyEndpointQuotaExceededFault>()(
     "DBProxyEndpointQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBProxyEndpointQuotaExceededFault",
@@ -596,7 +596,7 @@ export class DBProxyEndpointQuotaExceededFault
 export class DBProxyNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBProxyNotFoundFault>()(
     "DBProxyNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "DBProxyNotFoundFault", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -605,7 +605,7 @@ export class DBProxyNotFoundFault
 export class DBProxyQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBProxyQuotaExceededFault>()(
     "DBProxyQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBProxyQuotaExceededFault",
@@ -617,7 +617,7 @@ export class DBProxyQuotaExceededFault
 export class DBProxyTargetAlreadyRegisteredFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBProxyTargetAlreadyRegisteredFault>()(
     "DBProxyTargetAlreadyRegisteredFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBProxyTargetAlreadyRegisteredFault",
@@ -629,7 +629,7 @@ export class DBProxyTargetAlreadyRegisteredFault
 export class DBProxyTargetGroupNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBProxyTargetGroupNotFoundFault>()(
     "DBProxyTargetGroupNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBProxyTargetGroupNotFoundFault",
@@ -641,7 +641,7 @@ export class DBProxyTargetGroupNotFoundFault
 export class DBProxyTargetNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBProxyTargetNotFoundFault>()(
     "DBProxyTargetNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBProxyTargetNotFoundFault",
@@ -653,7 +653,7 @@ export class DBProxyTargetNotFoundFault
 export class DBSecurityGroupAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBSecurityGroupAlreadyExistsFault>()(
     "DBSecurityGroupAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBSecurityGroupAlreadyExists",
@@ -665,7 +665,7 @@ export class DBSecurityGroupAlreadyExistsFault
 export class DBSecurityGroupNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBSecurityGroupNotFoundFault>()(
     "DBSecurityGroupNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBSecurityGroupNotFound",
@@ -677,7 +677,7 @@ export class DBSecurityGroupNotFoundFault
 export class DBSecurityGroupNotSupportedFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBSecurityGroupNotSupportedFault>()(
     "DBSecurityGroupNotSupportedFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBSecurityGroupNotSupported",
@@ -689,7 +689,7 @@ export class DBSecurityGroupNotSupportedFault
 export class DBSecurityGroupQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBSecurityGroupQuotaExceededFault>()(
     "DBSecurityGroupQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "QuotaExceeded.DBSecurityGroup",
@@ -701,7 +701,7 @@ export class DBSecurityGroupQuotaExceededFault
 export class DBShardGroupAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBShardGroupAlreadyExistsFault>()(
     "DBShardGroupAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBShardGroupAlreadyExists",
@@ -713,7 +713,7 @@ export class DBShardGroupAlreadyExistsFault
 export class DBShardGroupNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBShardGroupNotFoundFault>()(
     "DBShardGroupNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "DBShardGroupNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -722,7 +722,7 @@ export class DBShardGroupNotFoundFault
 export class DBSnapshotAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBSnapshotAlreadyExistsFault>()(
     "DBSnapshotAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBSnapshotAlreadyExists",
@@ -734,7 +734,7 @@ export class DBSnapshotAlreadyExistsFault
 export class DBSnapshotNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBSnapshotNotFoundFault>()(
     "DBSnapshotNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "DBSnapshotNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -743,7 +743,7 @@ export class DBSnapshotNotFoundFault
 export class DBSnapshotTenantDatabaseNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBSnapshotTenantDatabaseNotFoundFault>()(
     "DBSnapshotTenantDatabaseNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBSnapshotTenantDatabaseNotFoundFault",
@@ -755,7 +755,7 @@ export class DBSnapshotTenantDatabaseNotFoundFault
 export class DBSubnetGroupAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBSubnetGroupAlreadyExistsFault>()(
     "DBSubnetGroupAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBSubnetGroupAlreadyExists",
@@ -767,7 +767,7 @@ export class DBSubnetGroupAlreadyExistsFault
 export class DBSubnetGroupDoesNotCoverEnoughAZs
   extends /*@__PURE__*/ S.TaggedErrorClass<DBSubnetGroupDoesNotCoverEnoughAZs>()(
     "DBSubnetGroupDoesNotCoverEnoughAZs",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBSubnetGroupDoesNotCoverEnoughAZs",
@@ -779,7 +779,7 @@ export class DBSubnetGroupDoesNotCoverEnoughAZs
 export class DBSubnetGroupNotAllowedFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBSubnetGroupNotAllowedFault>()(
     "DBSubnetGroupNotAllowedFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBSubnetGroupNotAllowedFault",
@@ -791,7 +791,7 @@ export class DBSubnetGroupNotAllowedFault
 export class DBSubnetGroupNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBSubnetGroupNotFoundFault>()(
     "DBSubnetGroupNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBSubnetGroupNotFoundFault",
@@ -803,7 +803,7 @@ export class DBSubnetGroupNotFoundFault
 export class DBSubnetGroupQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBSubnetGroupQuotaExceededFault>()(
     "DBSubnetGroupQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBSubnetGroupQuotaExceeded",
@@ -815,7 +815,7 @@ export class DBSubnetGroupQuotaExceededFault
 export class DBSubnetQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBSubnetQuotaExceededFault>()(
     "DBSubnetQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBSubnetQuotaExceededFault",
@@ -827,7 +827,7 @@ export class DBSubnetQuotaExceededFault
 export class DBUpgradeDependencyFailureFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DBUpgradeDependencyFailureFault>()(
     "DBUpgradeDependencyFailureFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DBUpgradeDependencyFailure",
@@ -839,7 +839,7 @@ export class DBUpgradeDependencyFailureFault
 export class DomainNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DomainNotFoundFault>()(
     "DomainNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "DomainNotFoundFault", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -848,7 +848,7 @@ export class DomainNotFoundFault
 export class Ec2ImagePropertiesNotSupportedFault
   extends /*@__PURE__*/ S.TaggedErrorClass<Ec2ImagePropertiesNotSupportedFault>()(
     "Ec2ImagePropertiesNotSupportedFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "Ec2ImagePropertiesNotSupportedFault",
@@ -860,7 +860,7 @@ export class Ec2ImagePropertiesNotSupportedFault
 export class EventSubscriptionQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<EventSubscriptionQuotaExceededFault>()(
     "EventSubscriptionQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "EventSubscriptionQuotaExceeded",
@@ -872,7 +872,7 @@ export class EventSubscriptionQuotaExceededFault
 export class ExportTaskAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ExportTaskAlreadyExistsFault>()(
     "ExportTaskAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ExportTaskAlreadyExists",
@@ -884,7 +884,7 @@ export class ExportTaskAlreadyExistsFault
 export class ExportTaskNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ExportTaskNotFoundFault>()(
     "ExportTaskNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ExportTaskNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -893,7 +893,7 @@ export class ExportTaskNotFoundFault
 export class GlobalClusterAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<GlobalClusterAlreadyExistsFault>()(
     "GlobalClusterAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "GlobalClusterAlreadyExistsFault",
@@ -905,7 +905,7 @@ export class GlobalClusterAlreadyExistsFault
 export class GlobalClusterNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<GlobalClusterNotFoundFault>()(
     "GlobalClusterNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "GlobalClusterNotFoundFault",
@@ -917,7 +917,7 @@ export class GlobalClusterNotFoundFault
 export class GlobalClusterQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<GlobalClusterQuotaExceededFault>()(
     "GlobalClusterQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "GlobalClusterQuotaExceededFault",
@@ -929,7 +929,7 @@ export class GlobalClusterQuotaExceededFault
 export class IamRoleMissingPermissionsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<IamRoleMissingPermissionsFault>()(
     "IamRoleMissingPermissionsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "IamRoleMissingPermissions",
@@ -941,7 +941,7 @@ export class IamRoleMissingPermissionsFault
 export class IamRoleNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<IamRoleNotFoundFault>()(
     "IamRoleNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "IamRoleNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -950,7 +950,7 @@ export class IamRoleNotFoundFault
 export class InstanceQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InstanceQuotaExceededFault>()(
     "InstanceQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InstanceQuotaExceeded", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -959,7 +959,7 @@ export class InstanceQuotaExceededFault
 export class InsufficientAvailableIPsInSubnetFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InsufficientAvailableIPsInSubnetFault>()(
     "InsufficientAvailableIPsInSubnetFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InsufficientAvailableIPsInSubnetFault",
@@ -971,7 +971,7 @@ export class InsufficientAvailableIPsInSubnetFault
 export class InsufficientDBClusterCapacityFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InsufficientDBClusterCapacityFault>()(
     "InsufficientDBClusterCapacityFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InsufficientDBClusterCapacityFault",
@@ -983,7 +983,7 @@ export class InsufficientDBClusterCapacityFault
 export class InsufficientDBInstanceCapacityFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InsufficientDBInstanceCapacityFault>()(
     "InsufficientDBInstanceCapacityFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InsufficientDBInstanceCapacity",
@@ -995,7 +995,7 @@ export class InsufficientDBInstanceCapacityFault
 export class InsufficientStorageClusterCapacityFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InsufficientStorageClusterCapacityFault>()(
     "InsufficientStorageClusterCapacityFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InsufficientStorageClusterCapacity",
@@ -1007,7 +1007,7 @@ export class InsufficientStorageClusterCapacityFault
 export class IntegrationAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<IntegrationAlreadyExistsFault>()(
     "IntegrationAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "IntegrationAlreadyExistsFault",
@@ -1019,7 +1019,7 @@ export class IntegrationAlreadyExistsFault
 export class IntegrationConflictOperationFault
   extends /*@__PURE__*/ S.TaggedErrorClass<IntegrationConflictOperationFault>()(
     "IntegrationConflictOperationFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "IntegrationConflictOperationFault",
@@ -1031,7 +1031,7 @@ export class IntegrationConflictOperationFault
 export class IntegrationNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<IntegrationNotFoundFault>()(
     "IntegrationNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "IntegrationNotFoundFault",
@@ -1043,7 +1043,7 @@ export class IntegrationNotFoundFault
 export class IntegrationQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<IntegrationQuotaExceededFault>()(
     "IntegrationQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "IntegrationQuotaExceededFault",
@@ -1055,7 +1055,7 @@ export class IntegrationQuotaExceededFault
 export class InvalidBlueGreenDeploymentStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidBlueGreenDeploymentStateFault>()(
     "InvalidBlueGreenDeploymentStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidBlueGreenDeploymentStateFault",
@@ -1067,7 +1067,7 @@ export class InvalidBlueGreenDeploymentStateFault
 export class InvalidCustomDBEngineVersionStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCustomDBEngineVersionStateFault>()(
     "InvalidCustomDBEngineVersionStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidCustomDBEngineVersionStateFault",
@@ -1079,7 +1079,7 @@ export class InvalidCustomDBEngineVersionStateFault
 export class InvalidDBClusterAutomatedBackupStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDBClusterAutomatedBackupStateFault>()(
     "InvalidDBClusterAutomatedBackupStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidDBClusterAutomatedBackupStateFault",
@@ -1091,7 +1091,7 @@ export class InvalidDBClusterAutomatedBackupStateFault
 export class InvalidDBClusterCapacityFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDBClusterCapacityFault>()(
     "InvalidDBClusterCapacityFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidDBClusterCapacityFault",
@@ -1103,7 +1103,7 @@ export class InvalidDBClusterCapacityFault
 export class InvalidDBClusterEndpointStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDBClusterEndpointStateFault>()(
     "InvalidDBClusterEndpointStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidDBClusterEndpointStateFault",
@@ -1115,7 +1115,7 @@ export class InvalidDBClusterEndpointStateFault
 export class InvalidDBClusterSnapshotStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDBClusterSnapshotStateFault>()(
     "InvalidDBClusterSnapshotStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidDBClusterSnapshotStateFault",
@@ -1127,7 +1127,7 @@ export class InvalidDBClusterSnapshotStateFault
 export class InvalidDBClusterStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDBClusterStateFault>()(
     "InvalidDBClusterStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidDBClusterStateFault",
@@ -1139,7 +1139,7 @@ export class InvalidDBClusterStateFault
 export class InvalidDBInstanceAutomatedBackupStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDBInstanceAutomatedBackupStateFault>()(
     "InvalidDBInstanceAutomatedBackupStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidDBInstanceAutomatedBackupState",
@@ -1151,7 +1151,7 @@ export class InvalidDBInstanceAutomatedBackupStateFault
 export class InvalidDBInstanceStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDBInstanceStateFault>()(
     "InvalidDBInstanceStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidDBInstanceState",
@@ -1163,7 +1163,7 @@ export class InvalidDBInstanceStateFault
 export class InvalidDBParameterGroupStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDBParameterGroupStateFault>()(
     "InvalidDBParameterGroupStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidDBParameterGroupState",
@@ -1175,7 +1175,7 @@ export class InvalidDBParameterGroupStateFault
 export class InvalidDBProxyEndpointStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDBProxyEndpointStateFault>()(
     "InvalidDBProxyEndpointStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidDBProxyEndpointStateFault",
@@ -1187,7 +1187,7 @@ export class InvalidDBProxyEndpointStateFault
 export class InvalidDBProxyStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDBProxyStateFault>()(
     "InvalidDBProxyStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidDBProxyStateFault",
@@ -1199,7 +1199,7 @@ export class InvalidDBProxyStateFault
 export class InvalidDBSecurityGroupStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDBSecurityGroupStateFault>()(
     "InvalidDBSecurityGroupStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidDBSecurityGroupState",
@@ -1211,7 +1211,7 @@ export class InvalidDBSecurityGroupStateFault
 export class InvalidDBShardGroupStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDBShardGroupStateFault>()(
     "InvalidDBShardGroupStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidDBShardGroupState",
@@ -1223,7 +1223,7 @@ export class InvalidDBShardGroupStateFault
 export class InvalidDBSnapshotStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDBSnapshotStateFault>()(
     "InvalidDBSnapshotStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidDBSnapshotState",
@@ -1235,7 +1235,7 @@ export class InvalidDBSnapshotStateFault
 export class InvalidDBSubnetGroupFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDBSubnetGroupFault>()(
     "InvalidDBSubnetGroupFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidDBSubnetGroupFault",
@@ -1247,7 +1247,7 @@ export class InvalidDBSubnetGroupFault
 export class InvalidDBSubnetGroupStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDBSubnetGroupStateFault>()(
     "InvalidDBSubnetGroupStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidDBSubnetGroupStateFault",
@@ -1259,7 +1259,7 @@ export class InvalidDBSubnetGroupStateFault
 export class InvalidDBSubnetStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDBSubnetStateFault>()(
     "InvalidDBSubnetStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidDBSubnetStateFault",
@@ -1271,7 +1271,7 @@ export class InvalidDBSubnetStateFault
 export class InvalidEventSubscriptionStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidEventSubscriptionStateFault>()(
     "InvalidEventSubscriptionStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidEventSubscriptionState",
@@ -1283,7 +1283,7 @@ export class InvalidEventSubscriptionStateFault
 export class InvalidExportOnlyFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidExportOnlyFault>()(
     "InvalidExportOnlyFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidExportOnly", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -1292,7 +1292,7 @@ export class InvalidExportOnlyFault
 export class InvalidExportSourceStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidExportSourceStateFault>()(
     "InvalidExportSourceStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidExportSourceState",
@@ -1304,7 +1304,7 @@ export class InvalidExportSourceStateFault
 export class InvalidExportTaskStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidExportTaskStateFault>()(
     "InvalidExportTaskStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidExportTaskStateFault",
@@ -1316,7 +1316,7 @@ export class InvalidExportTaskStateFault
 export class InvalidGlobalClusterStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidGlobalClusterStateFault>()(
     "InvalidGlobalClusterStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidGlobalClusterStateFault",
@@ -1328,7 +1328,7 @@ export class InvalidGlobalClusterStateFault
 export class InvalidIntegrationStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidIntegrationStateFault>()(
     "InvalidIntegrationStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidIntegrationStateFault",
@@ -1340,7 +1340,7 @@ export class InvalidIntegrationStateFault
 export class InvalidOptionGroupStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidOptionGroupStateFault>()(
     "InvalidOptionGroupStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidOptionGroupStateFault",
@@ -1352,17 +1352,17 @@ export class InvalidOptionGroupStateFault
 export class InvalidParameterCombination
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterCombination>()(
     "InvalidParameterCombination",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class InvalidParameterValue
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterValue>()(
     "InvalidParameterValue",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class InvalidResourceStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidResourceStateFault>()(
     "InvalidResourceStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidResourceStateFault",
@@ -1374,7 +1374,7 @@ export class InvalidResourceStateFault
 export class InvalidRestoreFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRestoreFault>()(
     "InvalidRestoreFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidRestoreFault", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -1383,7 +1383,7 @@ export class InvalidRestoreFault
 export class InvalidS3BucketFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidS3BucketFault>()(
     "InvalidS3BucketFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidS3BucketFault", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -1392,7 +1392,7 @@ export class InvalidS3BucketFault
 export class InvalidSubnet
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSubnet>()(
     "InvalidSubnet",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidSubnet", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -1401,7 +1401,7 @@ export class InvalidSubnet
 export class InvalidVPCNetworkStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidVPCNetworkStateFault>()(
     "InvalidVPCNetworkStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidVPCNetworkStateFault",
@@ -1413,7 +1413,7 @@ export class InvalidVPCNetworkStateFault
 export class KMSKeyNotAccessibleFault
   extends /*@__PURE__*/ S.TaggedErrorClass<KMSKeyNotAccessibleFault>()(
     "KMSKeyNotAccessibleFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "KMSKeyNotAccessibleFault",
@@ -1425,7 +1425,7 @@ export class KMSKeyNotAccessibleFault
 export class MaxDBShardGroupLimitReached
   extends /*@__PURE__*/ S.TaggedErrorClass<MaxDBShardGroupLimitReached>()(
     "MaxDBShardGroupLimitReached",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "MaxDBShardGroupLimitReached",
@@ -1437,7 +1437,7 @@ export class MaxDBShardGroupLimitReached
 export class NetworkTypeNotSupported
   extends /*@__PURE__*/ S.TaggedErrorClass<NetworkTypeNotSupported>()(
     "NetworkTypeNotSupported",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "NetworkTypeNotSupported",
@@ -1449,7 +1449,7 @@ export class NetworkTypeNotSupported
 export class OptionGroupAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<OptionGroupAlreadyExistsFault>()(
     "OptionGroupAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "OptionGroupAlreadyExistsFault",
@@ -1461,7 +1461,7 @@ export class OptionGroupAlreadyExistsFault
 export class OptionGroupNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<OptionGroupNotFoundFault>()(
     "OptionGroupNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "OptionGroupNotFoundFault",
@@ -1473,7 +1473,7 @@ export class OptionGroupNotFoundFault
 export class OptionGroupQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<OptionGroupQuotaExceededFault>()(
     "OptionGroupQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "OptionGroupQuotaExceededFault",
@@ -1485,7 +1485,7 @@ export class OptionGroupQuotaExceededFault
 export class PointInTimeRestoreNotEnabledFault
   extends /*@__PURE__*/ S.TaggedErrorClass<PointInTimeRestoreNotEnabledFault>()(
     "PointInTimeRestoreNotEnabledFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "PointInTimeRestoreNotEnabled",
@@ -1497,7 +1497,7 @@ export class PointInTimeRestoreNotEnabledFault
 export class ProvisionedIopsNotAvailableInAZFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ProvisionedIopsNotAvailableInAZFault>()(
     "ProvisionedIopsNotAvailableInAZFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ProvisionedIopsNotAvailableInAZFault",
@@ -1509,7 +1509,7 @@ export class ProvisionedIopsNotAvailableInAZFault
 export class ReservedDBInstanceAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ReservedDBInstanceAlreadyExistsFault>()(
     "ReservedDBInstanceAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ReservedDBInstanceAlreadyExists",
@@ -1521,7 +1521,7 @@ export class ReservedDBInstanceAlreadyExistsFault
 export class ReservedDBInstanceNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ReservedDBInstanceNotFoundFault>()(
     "ReservedDBInstanceNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ReservedDBInstanceNotFound",
@@ -1533,7 +1533,7 @@ export class ReservedDBInstanceNotFoundFault
 export class ReservedDBInstanceQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ReservedDBInstanceQuotaExceededFault>()(
     "ReservedDBInstanceQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ReservedDBInstanceQuotaExceeded",
@@ -1545,7 +1545,7 @@ export class ReservedDBInstanceQuotaExceededFault
 export class ReservedDBInstancesOfferingNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ReservedDBInstancesOfferingNotFoundFault>()(
     "ReservedDBInstancesOfferingNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ReservedDBInstancesOfferingNotFound",
@@ -1557,7 +1557,7 @@ export class ReservedDBInstancesOfferingNotFoundFault
 export class ResourceNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundFault>()(
     "ResourceNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ResourceNotFoundFault", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -1566,7 +1566,7 @@ export class ResourceNotFoundFault
 export class SharedSnapshotQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SharedSnapshotQuotaExceededFault>()(
     "SharedSnapshotQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SharedSnapshotQuotaExceeded",
@@ -1578,7 +1578,7 @@ export class SharedSnapshotQuotaExceededFault
 export class SnapshotQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SnapshotQuotaExceededFault>()(
     "SnapshotQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SnapshotQuotaExceeded", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -1587,7 +1587,7 @@ export class SnapshotQuotaExceededFault
 export class SNSInvalidTopicFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SNSInvalidTopicFault>()(
     "SNSInvalidTopicFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SNSInvalidTopic", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -1596,7 +1596,7 @@ export class SNSInvalidTopicFault
 export class SNSNoAuthorizationFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SNSNoAuthorizationFault>()(
     "SNSNoAuthorizationFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SNSNoAuthorization", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -1605,7 +1605,7 @@ export class SNSNoAuthorizationFault
 export class SNSTopicArnNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SNSTopicArnNotFoundFault>()(
     "SNSTopicArnNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SNSTopicArnNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -1614,7 +1614,7 @@ export class SNSTopicArnNotFoundFault
 export class SourceClusterNotSupportedFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SourceClusterNotSupportedFault>()(
     "SourceClusterNotSupportedFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SourceClusterNotSupportedFault",
@@ -1626,7 +1626,7 @@ export class SourceClusterNotSupportedFault
 export class SourceDatabaseNotSupportedFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SourceDatabaseNotSupportedFault>()(
     "SourceDatabaseNotSupportedFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SourceDatabaseNotSupportedFault",
@@ -1638,7 +1638,7 @@ export class SourceDatabaseNotSupportedFault
 export class SourceNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SourceNotFoundFault>()(
     "SourceNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SourceNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -1647,7 +1647,7 @@ export class SourceNotFoundFault
 export class StorageQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<StorageQuotaExceededFault>()(
     "StorageQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "StorageQuotaExceeded", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -1656,7 +1656,7 @@ export class StorageQuotaExceededFault
 export class StorageTypeNotAvailableFault
   extends /*@__PURE__*/ S.TaggedErrorClass<StorageTypeNotAvailableFault>()(
     "StorageTypeNotAvailableFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "StorageTypeNotAvailableFault",
@@ -1668,7 +1668,7 @@ export class StorageTypeNotAvailableFault
 export class StorageTypeNotSupportedFault
   extends /*@__PURE__*/ S.TaggedErrorClass<StorageTypeNotSupportedFault>()(
     "StorageTypeNotSupportedFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "StorageTypeNotSupported",
@@ -1680,7 +1680,7 @@ export class StorageTypeNotSupportedFault
 export class SubnetAlreadyInUse
   extends /*@__PURE__*/ S.TaggedErrorClass<SubnetAlreadyInUse>()(
     "SubnetAlreadyInUse",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SubnetAlreadyInUse", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -1689,7 +1689,7 @@ export class SubnetAlreadyInUse
 export class SubscriptionAlreadyExistFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SubscriptionAlreadyExistFault>()(
     "SubscriptionAlreadyExistFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SubscriptionAlreadyExist",
@@ -1701,7 +1701,7 @@ export class SubscriptionAlreadyExistFault
 export class SubscriptionCategoryNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SubscriptionCategoryNotFoundFault>()(
     "SubscriptionCategoryNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SubscriptionCategoryNotFound",
@@ -1713,7 +1713,7 @@ export class SubscriptionCategoryNotFoundFault
 export class SubscriptionNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SubscriptionNotFoundFault>()(
     "SubscriptionNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SubscriptionNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -1722,7 +1722,7 @@ export class SubscriptionNotFoundFault
 export class TenantDatabaseAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<TenantDatabaseAlreadyExistsFault>()(
     "TenantDatabaseAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "TenantDatabaseAlreadyExists",
@@ -1734,7 +1734,7 @@ export class TenantDatabaseAlreadyExistsFault
 export class TenantDatabaseNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<TenantDatabaseNotFoundFault>()(
     "TenantDatabaseNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "TenantDatabaseNotFound",
@@ -1746,7 +1746,7 @@ export class TenantDatabaseNotFoundFault
 export class TenantDatabaseQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<TenantDatabaseQuotaExceededFault>()(
     "TenantDatabaseQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "TenantDatabaseQuotaExceeded",
@@ -1758,7 +1758,7 @@ export class TenantDatabaseQuotaExceededFault
 export class UnsupportedDBEngineVersionFault
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedDBEngineVersionFault>()(
     "UnsupportedDBEngineVersionFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "UnsupportedDBEngineVersion",
@@ -1770,7 +1770,7 @@ export class UnsupportedDBEngineVersionFault
 export class VpcEncryptionControlViolationException
   extends /*@__PURE__*/ S.TaggedErrorClass<VpcEncryptionControlViolationException>()(
     "VpcEncryptionControlViolationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "VpcEncryptionControlViolationException",

--- a/packages/aws/src/services/redshift-data.ts
+++ b/packages/aws/src/services/redshift-data.ts
@@ -88,55 +88,55 @@ const rules = T.EndpointResolver((p, _) => {
 export class ActiveSessionsExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ActiveSessionsExceededException>()(
     "ActiveSessionsExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ActiveStatementsExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ActiveStatementsExceededException>()(
     "ActiveStatementsExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class BatchExecuteStatementException
   extends /*@__PURE__*/ S.TaggedErrorClass<BatchExecuteStatementException>()(
     "BatchExecuteStatementException",
-    { Message: S.String, StatementId: S.String },
+    { message: S.String.pipe(T.ErrorMessage()), StatementId: S.String },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class DatabaseConnectionException
   extends /*@__PURE__*/ S.TaggedErrorClass<DatabaseConnectionException>()(
     "DatabaseConnectionException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ExecuteStatementException
   extends /*@__PURE__*/ S.TaggedErrorClass<ExecuteStatementException>()(
     "ExecuteStatementException",
-    { Message: S.String, StatementId: S.String },
+    { message: S.String.pipe(T.ErrorMessage()), StatementId: S.String },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class QueryTimeoutException
   extends /*@__PURE__*/ S.TaggedErrorClass<QueryTimeoutException>()(
     "QueryTimeoutException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.String, ResourceId: S.String },
+    { message: S.String.pipe(T.ErrorMessage()), ResourceId: S.String },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type StatementString = string;

--- a/packages/aws/src/services/redshift-serverless.ts
+++ b/packages/aws/src/services/redshift-serverless.ts
@@ -90,73 +90,85 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { code: S.optional(S.String), message: S.optional(S.String) },
+    {
+      code: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class DryRunException
   extends /*@__PURE__*/ S.TaggedErrorClass<DryRunException>()(
     "DryRunException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InsufficientCapacityException
   extends /*@__PURE__*/ S.TaggedErrorClass<InsufficientCapacityException>()(
     "InsufficientCapacityException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(400), T.Retryable()),
   ).pipe(C.withBadRequestError, C.withRetryableError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class InvalidPaginationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPaginationException>()(
     "InvalidPaginationException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class Ipv6CidrBlockNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<Ipv6CidrBlockNotFoundException>()(
     "Ipv6CidrBlockNotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String, resourceName: S.optional(S.String) },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceName: S.optional(S.String),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { code: S.optional(S.String), message: S.optional(S.String) },
+    {
+      code: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.all(T.HttpError(429), T.Retryable()),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { message: S.optional(S.String), resourceName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      resourceName: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type TagKey = string;

--- a/packages/aws/src/services/redshift.ts
+++ b/packages/aws/src/services/redshift.ts
@@ -94,7 +94,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessToClusterDeniedFault
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessToClusterDeniedFault>()(
     "AccessToClusterDeniedFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "AccessToClusterDenied", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -103,7 +103,7 @@ export class AccessToClusterDeniedFault
 export class AccessToSnapshotDeniedFault
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessToSnapshotDeniedFault>()(
     "AccessToSnapshotDeniedFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "AccessToSnapshotDenied",
@@ -115,7 +115,7 @@ export class AccessToSnapshotDeniedFault
 export class AuthenticationProfileAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<AuthenticationProfileAlreadyExistsFault>()(
     "AuthenticationProfileAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "AuthenticationProfileAlreadyExistsFault",
@@ -127,7 +127,7 @@ export class AuthenticationProfileAlreadyExistsFault
 export class AuthenticationProfileNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<AuthenticationProfileNotFoundFault>()(
     "AuthenticationProfileNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "AuthenticationProfileNotFoundFault",
@@ -139,7 +139,7 @@ export class AuthenticationProfileNotFoundFault
 export class AuthenticationProfileQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<AuthenticationProfileQuotaExceededFault>()(
     "AuthenticationProfileQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "AuthenticationProfileQuotaExceededFault",
@@ -151,7 +151,7 @@ export class AuthenticationProfileQuotaExceededFault
 export class AuthorizationAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<AuthorizationAlreadyExistsFault>()(
     "AuthorizationAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "AuthorizationAlreadyExists",
@@ -163,7 +163,7 @@ export class AuthorizationAlreadyExistsFault
 export class AuthorizationNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<AuthorizationNotFoundFault>()(
     "AuthorizationNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "AuthorizationNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -172,7 +172,7 @@ export class AuthorizationNotFoundFault
 export class AuthorizationQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<AuthorizationQuotaExceededFault>()(
     "AuthorizationQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "AuthorizationQuotaExceeded",
@@ -184,7 +184,7 @@ export class AuthorizationQuotaExceededFault
 export class BatchDeleteRequestSizeExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<BatchDeleteRequestSizeExceededFault>()(
     "BatchDeleteRequestSizeExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "BatchDeleteRequestSizeExceeded",
@@ -196,7 +196,7 @@ export class BatchDeleteRequestSizeExceededFault
 export class BatchModifyClusterSnapshotsLimitExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<BatchModifyClusterSnapshotsLimitExceededFault>()(
     "BatchModifyClusterSnapshotsLimitExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "BatchModifyClusterSnapshotsLimitExceededFault",
@@ -208,7 +208,7 @@ export class BatchModifyClusterSnapshotsLimitExceededFault
 export class BucketNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<BucketNotFoundFault>()(
     "BucketNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "BucketNotFoundFault", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -217,7 +217,7 @@ export class BucketNotFoundFault
 export class ClusterAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ClusterAlreadyExistsFault>()(
     "ClusterAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ClusterAlreadyExists", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -226,7 +226,7 @@ export class ClusterAlreadyExistsFault
 export class ClusterNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ClusterNotFoundFault>()(
     "ClusterNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ClusterNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -235,7 +235,7 @@ export class ClusterNotFoundFault
 export class ClusterOnLatestRevisionFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ClusterOnLatestRevisionFault>()(
     "ClusterOnLatestRevisionFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ClusterOnLatestRevision",
@@ -247,7 +247,7 @@ export class ClusterOnLatestRevisionFault
 export class ClusterParameterGroupAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ClusterParameterGroupAlreadyExistsFault>()(
     "ClusterParameterGroupAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ClusterParameterGroupAlreadyExists",
@@ -259,7 +259,7 @@ export class ClusterParameterGroupAlreadyExistsFault
 export class ClusterParameterGroupNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ClusterParameterGroupNotFoundFault>()(
     "ClusterParameterGroupNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ClusterParameterGroupNotFound",
@@ -271,7 +271,7 @@ export class ClusterParameterGroupNotFoundFault
 export class ClusterParameterGroupQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ClusterParameterGroupQuotaExceededFault>()(
     "ClusterParameterGroupQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ClusterParameterGroupQuotaExceeded",
@@ -283,7 +283,7 @@ export class ClusterParameterGroupQuotaExceededFault
 export class ClusterQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ClusterQuotaExceededFault>()(
     "ClusterQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ClusterQuotaExceeded", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -292,7 +292,7 @@ export class ClusterQuotaExceededFault
 export class ClusterSecurityGroupAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ClusterSecurityGroupAlreadyExistsFault>()(
     "ClusterSecurityGroupAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ClusterSecurityGroupAlreadyExists",
@@ -304,7 +304,7 @@ export class ClusterSecurityGroupAlreadyExistsFault
 export class ClusterSecurityGroupNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ClusterSecurityGroupNotFoundFault>()(
     "ClusterSecurityGroupNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ClusterSecurityGroupNotFound",
@@ -316,7 +316,7 @@ export class ClusterSecurityGroupNotFoundFault
 export class ClusterSecurityGroupQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ClusterSecurityGroupQuotaExceededFault>()(
     "ClusterSecurityGroupQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "QuotaExceeded.ClusterSecurityGroup",
@@ -328,7 +328,7 @@ export class ClusterSecurityGroupQuotaExceededFault
 export class ClusterSnapshotAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ClusterSnapshotAlreadyExistsFault>()(
     "ClusterSnapshotAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ClusterSnapshotAlreadyExists",
@@ -340,7 +340,7 @@ export class ClusterSnapshotAlreadyExistsFault
 export class ClusterSnapshotNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ClusterSnapshotNotFoundFault>()(
     "ClusterSnapshotNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ClusterSnapshotNotFound",
@@ -352,7 +352,7 @@ export class ClusterSnapshotNotFoundFault
 export class ClusterSnapshotQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ClusterSnapshotQuotaExceededFault>()(
     "ClusterSnapshotQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ClusterSnapshotQuotaExceeded",
@@ -364,7 +364,7 @@ export class ClusterSnapshotQuotaExceededFault
 export class ClusterSubnetGroupAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ClusterSubnetGroupAlreadyExistsFault>()(
     "ClusterSubnetGroupAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ClusterSubnetGroupAlreadyExists",
@@ -376,7 +376,7 @@ export class ClusterSubnetGroupAlreadyExistsFault
 export class ClusterSubnetGroupNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ClusterSubnetGroupNotFoundFault>()(
     "ClusterSubnetGroupNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ClusterSubnetGroupNotFoundFault",
@@ -388,7 +388,7 @@ export class ClusterSubnetGroupNotFoundFault
 export class ClusterSubnetGroupQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ClusterSubnetGroupQuotaExceededFault>()(
     "ClusterSubnetGroupQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ClusterSubnetGroupQuotaExceeded",
@@ -400,7 +400,7 @@ export class ClusterSubnetGroupQuotaExceededFault
 export class ClusterSubnetQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ClusterSubnetQuotaExceededFault>()(
     "ClusterSubnetQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ClusterSubnetQuotaExceededFault",
@@ -412,7 +412,7 @@ export class ClusterSubnetQuotaExceededFault
 export class ConflictPolicyUpdateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictPolicyUpdateFault>()(
     "ConflictPolicyUpdateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ConflictPolicyUpdateFault",
@@ -424,7 +424,7 @@ export class ConflictPolicyUpdateFault
 export class CopyToRegionDisabledFault
   extends /*@__PURE__*/ S.TaggedErrorClass<CopyToRegionDisabledFault>()(
     "CopyToRegionDisabledFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CopyToRegionDisabledFault",
@@ -436,7 +436,7 @@ export class CopyToRegionDisabledFault
 export class CustomCnameAssociationFault
   extends /*@__PURE__*/ S.TaggedErrorClass<CustomCnameAssociationFault>()(
     "CustomCnameAssociationFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CustomCnameAssociationFault",
@@ -448,7 +448,7 @@ export class CustomCnameAssociationFault
 export class CustomDomainAssociationNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<CustomDomainAssociationNotFoundFault>()(
     "CustomDomainAssociationNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CustomDomainAssociationNotFoundFault",
@@ -460,7 +460,7 @@ export class CustomDomainAssociationNotFoundFault
 export class DependentServiceAccessDeniedFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DependentServiceAccessDeniedFault>()(
     "DependentServiceAccessDeniedFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DependentServiceAccessDenied",
@@ -472,7 +472,7 @@ export class DependentServiceAccessDeniedFault
 export class DependentServiceRequestThrottlingFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DependentServiceRequestThrottlingFault>()(
     "DependentServiceRequestThrottlingFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DependentServiceRequestThrottlingFault",
@@ -484,7 +484,7 @@ export class DependentServiceRequestThrottlingFault
 export class DependentServiceUnavailableFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DependentServiceUnavailableFault>()(
     "DependentServiceUnavailableFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "DependentServiceUnavailableFault",
@@ -496,7 +496,7 @@ export class DependentServiceUnavailableFault
 export class EndpointAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<EndpointAlreadyExistsFault>()(
     "EndpointAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "EndpointAlreadyExists", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -505,7 +505,7 @@ export class EndpointAlreadyExistsFault
 export class EndpointAuthorizationAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<EndpointAuthorizationAlreadyExistsFault>()(
     "EndpointAuthorizationAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "EndpointAuthorizationAlreadyExists",
@@ -517,7 +517,7 @@ export class EndpointAuthorizationAlreadyExistsFault
 export class EndpointAuthorizationNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<EndpointAuthorizationNotFoundFault>()(
     "EndpointAuthorizationNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "EndpointAuthorizationNotFound",
@@ -529,7 +529,7 @@ export class EndpointAuthorizationNotFoundFault
 export class EndpointAuthorizationsPerClusterLimitExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<EndpointAuthorizationsPerClusterLimitExceededFault>()(
     "EndpointAuthorizationsPerClusterLimitExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "EndpointAuthorizationsPerClusterLimitExceeded",
@@ -541,7 +541,7 @@ export class EndpointAuthorizationsPerClusterLimitExceededFault
 export class EndpointNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<EndpointNotFoundFault>()(
     "EndpointNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "EndpointNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -550,7 +550,7 @@ export class EndpointNotFoundFault
 export class EndpointsPerAuthorizationLimitExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<EndpointsPerAuthorizationLimitExceededFault>()(
     "EndpointsPerAuthorizationLimitExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "EndpointsPerAuthorizationLimitExceeded",
@@ -562,7 +562,7 @@ export class EndpointsPerAuthorizationLimitExceededFault
 export class EndpointsPerClusterLimitExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<EndpointsPerClusterLimitExceededFault>()(
     "EndpointsPerClusterLimitExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "EndpointsPerClusterLimitExceeded",
@@ -574,7 +574,7 @@ export class EndpointsPerClusterLimitExceededFault
 export class EventSubscriptionQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<EventSubscriptionQuotaExceededFault>()(
     "EventSubscriptionQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "EventSubscriptionQuotaExceeded",
@@ -586,7 +586,7 @@ export class EventSubscriptionQuotaExceededFault
 export class HsmClientCertificateAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<HsmClientCertificateAlreadyExistsFault>()(
     "HsmClientCertificateAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "HsmClientCertificateAlreadyExistsFault",
@@ -598,7 +598,7 @@ export class HsmClientCertificateAlreadyExistsFault
 export class HsmClientCertificateNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<HsmClientCertificateNotFoundFault>()(
     "HsmClientCertificateNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "HsmClientCertificateNotFoundFault",
@@ -610,7 +610,7 @@ export class HsmClientCertificateNotFoundFault
 export class HsmClientCertificateQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<HsmClientCertificateQuotaExceededFault>()(
     "HsmClientCertificateQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "HsmClientCertificateQuotaExceededFault",
@@ -622,7 +622,7 @@ export class HsmClientCertificateQuotaExceededFault
 export class HsmConfigurationAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<HsmConfigurationAlreadyExistsFault>()(
     "HsmConfigurationAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "HsmConfigurationAlreadyExistsFault",
@@ -634,7 +634,7 @@ export class HsmConfigurationAlreadyExistsFault
 export class HsmConfigurationNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<HsmConfigurationNotFoundFault>()(
     "HsmConfigurationNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "HsmConfigurationNotFoundFault",
@@ -646,7 +646,7 @@ export class HsmConfigurationNotFoundFault
 export class HsmConfigurationQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<HsmConfigurationQuotaExceededFault>()(
     "HsmConfigurationQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "HsmConfigurationQuotaExceededFault",
@@ -658,7 +658,7 @@ export class HsmConfigurationQuotaExceededFault
 export class IncompatibleOrderableOptions
   extends /*@__PURE__*/ S.TaggedErrorClass<IncompatibleOrderableOptions>()(
     "IncompatibleOrderableOptions",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "IncompatibleOrderableOptions",
@@ -670,7 +670,7 @@ export class IncompatibleOrderableOptions
 export class InProgressTableRestoreQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InProgressTableRestoreQuotaExceededFault>()(
     "InProgressTableRestoreQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InProgressTableRestoreQuotaExceededFault",
@@ -682,7 +682,7 @@ export class InProgressTableRestoreQuotaExceededFault
 export class InsufficientClusterCapacityFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InsufficientClusterCapacityFault>()(
     "InsufficientClusterCapacityFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InsufficientClusterCapacity",
@@ -694,7 +694,7 @@ export class InsufficientClusterCapacityFault
 export class InsufficientS3BucketPolicyFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InsufficientS3BucketPolicyFault>()(
     "InsufficientS3BucketPolicyFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InsufficientS3BucketPolicyFault",
@@ -706,7 +706,7 @@ export class InsufficientS3BucketPolicyFault
 export class IntegrationAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<IntegrationAlreadyExistsFault>()(
     "IntegrationAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "IntegrationAlreadyExistsFault",
@@ -718,7 +718,7 @@ export class IntegrationAlreadyExistsFault
 export class IntegrationConflictOperationFault
   extends /*@__PURE__*/ S.TaggedErrorClass<IntegrationConflictOperationFault>()(
     "IntegrationConflictOperationFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "IntegrationConflictOperationFault",
@@ -730,7 +730,7 @@ export class IntegrationConflictOperationFault
 export class IntegrationConflictStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<IntegrationConflictStateFault>()(
     "IntegrationConflictStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "IntegrationConflictStateFault",
@@ -742,7 +742,7 @@ export class IntegrationConflictStateFault
 export class IntegrationNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<IntegrationNotFoundFault>()(
     "IntegrationNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "IntegrationNotFoundFault",
@@ -754,7 +754,7 @@ export class IntegrationNotFoundFault
 export class IntegrationQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<IntegrationQuotaExceededFault>()(
     "IntegrationQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "IntegrationQuotaExceededFault",
@@ -766,7 +766,7 @@ export class IntegrationQuotaExceededFault
 export class IntegrationSourceNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<IntegrationSourceNotFoundFault>()(
     "IntegrationSourceNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "IntegrationSourceNotFoundFault",
@@ -778,7 +778,7 @@ export class IntegrationSourceNotFoundFault
 export class IntegrationTargetNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<IntegrationTargetNotFoundFault>()(
     "IntegrationTargetNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "IntegrationTargetNotFoundFault",
@@ -790,7 +790,7 @@ export class IntegrationTargetNotFoundFault
 export class InvalidAuthenticationProfileRequestFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidAuthenticationProfileRequestFault>()(
     "InvalidAuthenticationProfileRequestFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidAuthenticationProfileRequestFault",
@@ -802,7 +802,7 @@ export class InvalidAuthenticationProfileRequestFault
 export class InvalidAuthorizationStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidAuthorizationStateFault>()(
     "InvalidAuthorizationStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidAuthorizationState",
@@ -814,7 +814,7 @@ export class InvalidAuthorizationStateFault
 export class InvalidClusterParameterGroupStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidClusterParameterGroupStateFault>()(
     "InvalidClusterParameterGroupStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidClusterParameterGroupState",
@@ -826,7 +826,7 @@ export class InvalidClusterParameterGroupStateFault
 export class InvalidClusterSecurityGroupStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidClusterSecurityGroupStateFault>()(
     "InvalidClusterSecurityGroupStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidClusterSecurityGroupState",
@@ -838,7 +838,7 @@ export class InvalidClusterSecurityGroupStateFault
 export class InvalidClusterSnapshotScheduleStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidClusterSnapshotScheduleStateFault>()(
     "InvalidClusterSnapshotScheduleStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidClusterSnapshotScheduleState",
@@ -850,7 +850,7 @@ export class InvalidClusterSnapshotScheduleStateFault
 export class InvalidClusterSnapshotStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidClusterSnapshotStateFault>()(
     "InvalidClusterSnapshotStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidClusterSnapshotState",
@@ -862,7 +862,7 @@ export class InvalidClusterSnapshotStateFault
 export class InvalidClusterStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidClusterStateFault>()(
     "InvalidClusterStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidClusterState", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -871,7 +871,7 @@ export class InvalidClusterStateFault
 export class InvalidClusterSubnetGroupStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidClusterSubnetGroupStateFault>()(
     "InvalidClusterSubnetGroupStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidClusterSubnetGroupStateFault",
@@ -883,7 +883,7 @@ export class InvalidClusterSubnetGroupStateFault
 export class InvalidClusterSubnetStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidClusterSubnetStateFault>()(
     "InvalidClusterSubnetStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidClusterSubnetStateFault",
@@ -895,7 +895,7 @@ export class InvalidClusterSubnetStateFault
 export class InvalidClusterTrackFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidClusterTrackFault>()(
     "InvalidClusterTrackFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidClusterTrack", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -904,7 +904,7 @@ export class InvalidClusterTrackFault
 export class InvalidDataShareFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDataShareFault>()(
     "InvalidDataShareFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidDataShareFault", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -913,7 +913,7 @@ export class InvalidDataShareFault
 export class InvalidElasticIpFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidElasticIpFault>()(
     "InvalidElasticIpFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidElasticIpFault", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -922,7 +922,7 @@ export class InvalidElasticIpFault
 export class InvalidEndpointStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidEndpointStateFault>()(
     "InvalidEndpointStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidEndpointState", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -931,7 +931,7 @@ export class InvalidEndpointStateFault
 export class InvalidHsmClientCertificateStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidHsmClientCertificateStateFault>()(
     "InvalidHsmClientCertificateStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidHsmClientCertificateStateFault",
@@ -943,7 +943,7 @@ export class InvalidHsmClientCertificateStateFault
 export class InvalidHsmConfigurationStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidHsmConfigurationStateFault>()(
     "InvalidHsmConfigurationStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidHsmConfigurationStateFault",
@@ -955,7 +955,7 @@ export class InvalidHsmConfigurationStateFault
 export class InvalidNamespaceFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNamespaceFault>()(
     "InvalidNamespaceFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidNamespaceFault", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -964,7 +964,7 @@ export class InvalidNamespaceFault
 export class InvalidPolicyFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPolicyFault>()(
     "InvalidPolicyFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidPolicyFault", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -973,7 +973,7 @@ export class InvalidPolicyFault
 export class InvalidReservedNodeStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidReservedNodeStateFault>()(
     "InvalidReservedNodeStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidReservedNodeState",
@@ -985,7 +985,7 @@ export class InvalidReservedNodeStateFault
 export class InvalidRestoreFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRestoreFault>()(
     "InvalidRestoreFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidRestore", httpResponseCode: 406 }),
       T.HttpError(406),
@@ -994,7 +994,7 @@ export class InvalidRestoreFault
 export class InvalidRetentionPeriodFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRetentionPeriodFault>()(
     "InvalidRetentionPeriodFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidRetentionPeriodFault",
@@ -1006,7 +1006,7 @@ export class InvalidRetentionPeriodFault
 export class InvalidS3BucketNameFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidS3BucketNameFault>()(
     "InvalidS3BucketNameFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidS3BucketNameFault",
@@ -1018,7 +1018,7 @@ export class InvalidS3BucketNameFault
 export class InvalidS3KeyPrefixFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidS3KeyPrefixFault>()(
     "InvalidS3KeyPrefixFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidS3KeyPrefixFault",
@@ -1030,7 +1030,7 @@ export class InvalidS3KeyPrefixFault
 export class InvalidScheduledActionFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidScheduledActionFault>()(
     "InvalidScheduledActionFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidScheduledAction",
@@ -1042,7 +1042,7 @@ export class InvalidScheduledActionFault
 export class InvalidScheduleFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidScheduleFault>()(
     "InvalidScheduleFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidSchedule", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -1051,7 +1051,7 @@ export class InvalidScheduleFault
 export class InvalidSnapshotCopyGrantStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSnapshotCopyGrantStateFault>()(
     "InvalidSnapshotCopyGrantStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidSnapshotCopyGrantStateFault",
@@ -1063,7 +1063,7 @@ export class InvalidSnapshotCopyGrantStateFault
 export class InvalidSubnet
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSubnet>()(
     "InvalidSubnet",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidSubnet", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -1072,7 +1072,7 @@ export class InvalidSubnet
 export class InvalidSubscriptionStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSubscriptionStateFault>()(
     "InvalidSubscriptionStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidSubscriptionStateFault",
@@ -1084,7 +1084,7 @@ export class InvalidSubscriptionStateFault
 export class InvalidTableRestoreArgumentFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTableRestoreArgumentFault>()(
     "InvalidTableRestoreArgumentFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidTableRestoreArgument",
@@ -1096,7 +1096,7 @@ export class InvalidTableRestoreArgumentFault
 export class InvalidTagFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTagFault>()(
     "InvalidTagFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidTagFault", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -1105,7 +1105,7 @@ export class InvalidTagFault
 export class InvalidUsageLimitFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidUsageLimitFault>()(
     "InvalidUsageLimitFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidUsageLimit", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -1114,7 +1114,7 @@ export class InvalidUsageLimitFault
 export class InvalidVPCNetworkStateFault
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidVPCNetworkStateFault>()(
     "InvalidVPCNetworkStateFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidVPCNetworkStateFault",
@@ -1126,7 +1126,7 @@ export class InvalidVPCNetworkStateFault
 export class Ipv6CidrBlockNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<Ipv6CidrBlockNotFoundFault>()(
     "Ipv6CidrBlockNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "Ipv6CidrBlockNotFoundFault",
@@ -1138,7 +1138,7 @@ export class Ipv6CidrBlockNotFoundFault
 export class LimitExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededFault>()(
     "LimitExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "LimitExceededFault", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -1147,7 +1147,7 @@ export class LimitExceededFault
 export class NumberOfNodesPerClusterLimitExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<NumberOfNodesPerClusterLimitExceededFault>()(
     "NumberOfNodesPerClusterLimitExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "NumberOfNodesPerClusterLimitExceeded",
@@ -1159,7 +1159,7 @@ export class NumberOfNodesPerClusterLimitExceededFault
 export class NumberOfNodesQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<NumberOfNodesQuotaExceededFault>()(
     "NumberOfNodesQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "NumberOfNodesQuotaExceeded",
@@ -1171,7 +1171,7 @@ export class NumberOfNodesQuotaExceededFault
 export class PartnerNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<PartnerNotFoundFault>()(
     "PartnerNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "PartnerNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -1180,7 +1180,7 @@ export class PartnerNotFoundFault
 export class RedshiftIdcApplicationAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<RedshiftIdcApplicationAlreadyExistsFault>()(
     "RedshiftIdcApplicationAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "RedshiftIdcApplicationAlreadyExists",
@@ -1192,7 +1192,7 @@ export class RedshiftIdcApplicationAlreadyExistsFault
 export class RedshiftIdcApplicationNotExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<RedshiftIdcApplicationNotExistsFault>()(
     "RedshiftIdcApplicationNotExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "RedshiftIdcApplicationNotExists",
@@ -1204,7 +1204,7 @@ export class RedshiftIdcApplicationNotExistsFault
 export class RedshiftIdcApplicationQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<RedshiftIdcApplicationQuotaExceededFault>()(
     "RedshiftIdcApplicationQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "RedshiftIdcApplicationQuotaExceeded",
@@ -1216,7 +1216,7 @@ export class RedshiftIdcApplicationQuotaExceededFault
 export class RedshiftInvalidParameterFault
   extends /*@__PURE__*/ S.TaggedErrorClass<RedshiftInvalidParameterFault>()(
     "RedshiftInvalidParameterFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "RedshiftInvalidParameter",
@@ -1228,7 +1228,7 @@ export class RedshiftInvalidParameterFault
 export class ReservedNodeAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ReservedNodeAlreadyExistsFault>()(
     "ReservedNodeAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ReservedNodeAlreadyExists",
@@ -1240,7 +1240,7 @@ export class ReservedNodeAlreadyExistsFault
 export class ReservedNodeAlreadyMigratedFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ReservedNodeAlreadyMigratedFault>()(
     "ReservedNodeAlreadyMigratedFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ReservedNodeAlreadyMigrated",
@@ -1252,7 +1252,7 @@ export class ReservedNodeAlreadyMigratedFault
 export class ReservedNodeExchangeNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ReservedNodeExchangeNotFoundFault>()(
     "ReservedNodeExchangeNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ReservedNodeExchangeNotFond",
@@ -1264,7 +1264,7 @@ export class ReservedNodeExchangeNotFoundFault
 export class ReservedNodeNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ReservedNodeNotFoundFault>()(
     "ReservedNodeNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ReservedNodeNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -1273,7 +1273,7 @@ export class ReservedNodeNotFoundFault
 export class ReservedNodeOfferingNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ReservedNodeOfferingNotFoundFault>()(
     "ReservedNodeOfferingNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ReservedNodeOfferingNotFound",
@@ -1285,7 +1285,7 @@ export class ReservedNodeOfferingNotFoundFault
 export class ReservedNodeQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ReservedNodeQuotaExceededFault>()(
     "ReservedNodeQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ReservedNodeQuotaExceeded",
@@ -1297,7 +1297,7 @@ export class ReservedNodeQuotaExceededFault
 export class ResizeNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ResizeNotFoundFault>()(
     "ResizeNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ResizeNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -1306,7 +1306,7 @@ export class ResizeNotFoundFault
 export class ResourceNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundFault>()(
     "ResourceNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ResourceNotFoundFault", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -1315,7 +1315,7 @@ export class ResourceNotFoundFault
 export class ScheduledActionAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ScheduledActionAlreadyExistsFault>()(
     "ScheduledActionAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ScheduledActionAlreadyExists",
@@ -1327,7 +1327,7 @@ export class ScheduledActionAlreadyExistsFault
 export class ScheduledActionNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ScheduledActionNotFoundFault>()(
     "ScheduledActionNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ScheduledActionNotFound",
@@ -1339,7 +1339,7 @@ export class ScheduledActionNotFoundFault
 export class ScheduledActionQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ScheduledActionQuotaExceededFault>()(
     "ScheduledActionQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ScheduledActionQuotaExceeded",
@@ -1351,7 +1351,7 @@ export class ScheduledActionQuotaExceededFault
 export class ScheduledActionTypeUnsupportedFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ScheduledActionTypeUnsupportedFault>()(
     "ScheduledActionTypeUnsupportedFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ScheduledActionTypeUnsupported",
@@ -1363,7 +1363,7 @@ export class ScheduledActionTypeUnsupportedFault
 export class ScheduleDefinitionTypeUnsupportedFault
   extends /*@__PURE__*/ S.TaggedErrorClass<ScheduleDefinitionTypeUnsupportedFault>()(
     "ScheduleDefinitionTypeUnsupportedFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ScheduleDefinitionTypeUnsupported",
@@ -1375,7 +1375,7 @@ export class ScheduleDefinitionTypeUnsupportedFault
 export class SnapshotCopyAlreadyDisabledFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SnapshotCopyAlreadyDisabledFault>()(
     "SnapshotCopyAlreadyDisabledFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SnapshotCopyAlreadyDisabledFault",
@@ -1387,7 +1387,7 @@ export class SnapshotCopyAlreadyDisabledFault
 export class SnapshotCopyAlreadyEnabledFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SnapshotCopyAlreadyEnabledFault>()(
     "SnapshotCopyAlreadyEnabledFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SnapshotCopyAlreadyEnabledFault",
@@ -1399,7 +1399,7 @@ export class SnapshotCopyAlreadyEnabledFault
 export class SnapshotCopyDisabledFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SnapshotCopyDisabledFault>()(
     "SnapshotCopyDisabledFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SnapshotCopyDisabledFault",
@@ -1411,7 +1411,7 @@ export class SnapshotCopyDisabledFault
 export class SnapshotCopyGrantAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SnapshotCopyGrantAlreadyExistsFault>()(
     "SnapshotCopyGrantAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SnapshotCopyGrantAlreadyExistsFault",
@@ -1423,7 +1423,7 @@ export class SnapshotCopyGrantAlreadyExistsFault
 export class SnapshotCopyGrantNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SnapshotCopyGrantNotFoundFault>()(
     "SnapshotCopyGrantNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SnapshotCopyGrantNotFoundFault",
@@ -1435,7 +1435,7 @@ export class SnapshotCopyGrantNotFoundFault
 export class SnapshotCopyGrantQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SnapshotCopyGrantQuotaExceededFault>()(
     "SnapshotCopyGrantQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SnapshotCopyGrantQuotaExceededFault",
@@ -1447,7 +1447,7 @@ export class SnapshotCopyGrantQuotaExceededFault
 export class SnapshotScheduleAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SnapshotScheduleAlreadyExistsFault>()(
     "SnapshotScheduleAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SnapshotScheduleAlreadyExists",
@@ -1459,7 +1459,7 @@ export class SnapshotScheduleAlreadyExistsFault
 export class SnapshotScheduleNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SnapshotScheduleNotFoundFault>()(
     "SnapshotScheduleNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SnapshotScheduleNotFound",
@@ -1471,7 +1471,7 @@ export class SnapshotScheduleNotFoundFault
 export class SnapshotScheduleQuotaExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SnapshotScheduleQuotaExceededFault>()(
     "SnapshotScheduleQuotaExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SnapshotScheduleQuotaExceeded",
@@ -1483,7 +1483,7 @@ export class SnapshotScheduleQuotaExceededFault
 export class SnapshotScheduleUpdateInProgressFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SnapshotScheduleUpdateInProgressFault>()(
     "SnapshotScheduleUpdateInProgressFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SnapshotScheduleUpdateInProgress",
@@ -1495,7 +1495,7 @@ export class SnapshotScheduleUpdateInProgressFault
 export class SNSInvalidTopicFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SNSInvalidTopicFault>()(
     "SNSInvalidTopicFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SNSInvalidTopic", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -1504,7 +1504,7 @@ export class SNSInvalidTopicFault
 export class SNSNoAuthorizationFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SNSNoAuthorizationFault>()(
     "SNSNoAuthorizationFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SNSNoAuthorization", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -1513,7 +1513,7 @@ export class SNSNoAuthorizationFault
 export class SNSTopicArnNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SNSTopicArnNotFoundFault>()(
     "SNSTopicArnNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SNSTopicArnNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -1522,7 +1522,7 @@ export class SNSTopicArnNotFoundFault
 export class SourceNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SourceNotFoundFault>()(
     "SourceNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SourceNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -1531,7 +1531,7 @@ export class SourceNotFoundFault
 export class SubnetAlreadyInUse
   extends /*@__PURE__*/ S.TaggedErrorClass<SubnetAlreadyInUse>()(
     "SubnetAlreadyInUse",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SubnetAlreadyInUse", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -1540,7 +1540,7 @@ export class SubnetAlreadyInUse
 export class SubscriptionAlreadyExistFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SubscriptionAlreadyExistFault>()(
     "SubscriptionAlreadyExistFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SubscriptionAlreadyExist",
@@ -1552,7 +1552,7 @@ export class SubscriptionAlreadyExistFault
 export class SubscriptionCategoryNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SubscriptionCategoryNotFoundFault>()(
     "SubscriptionCategoryNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SubscriptionCategoryNotFound",
@@ -1564,7 +1564,7 @@ export class SubscriptionCategoryNotFoundFault
 export class SubscriptionEventIdNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SubscriptionEventIdNotFoundFault>()(
     "SubscriptionEventIdNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SubscriptionEventIdNotFound",
@@ -1576,7 +1576,7 @@ export class SubscriptionEventIdNotFoundFault
 export class SubscriptionNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SubscriptionNotFoundFault>()(
     "SubscriptionNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "SubscriptionNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -1585,7 +1585,7 @@ export class SubscriptionNotFoundFault
 export class SubscriptionSeverityNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<SubscriptionSeverityNotFoundFault>()(
     "SubscriptionSeverityNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SubscriptionSeverityNotFound",
@@ -1597,7 +1597,7 @@ export class SubscriptionSeverityNotFoundFault
 export class TableLimitExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<TableLimitExceededFault>()(
     "TableLimitExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "TableLimitExceeded", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -1606,7 +1606,7 @@ export class TableLimitExceededFault
 export class TableRestoreNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<TableRestoreNotFoundFault>()(
     "TableRestoreNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "TableRestoreNotFoundFault",
@@ -1618,7 +1618,7 @@ export class TableRestoreNotFoundFault
 export class TagLimitExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<TagLimitExceededFault>()(
     "TagLimitExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "TagLimitExceededFault", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -1627,7 +1627,7 @@ export class TagLimitExceededFault
 export class UnauthorizedOperation
   extends /*@__PURE__*/ S.TaggedErrorClass<UnauthorizedOperation>()(
     "UnauthorizedOperation",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "UnauthorizedOperation", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -1636,7 +1636,7 @@ export class UnauthorizedOperation
 export class UnauthorizedPartnerIntegrationFault
   extends /*@__PURE__*/ S.TaggedErrorClass<UnauthorizedPartnerIntegrationFault>()(
     "UnauthorizedPartnerIntegrationFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "UnauthorizedPartnerIntegration",
@@ -1648,7 +1648,7 @@ export class UnauthorizedPartnerIntegrationFault
 export class UnknownSnapshotCopyRegionFault
   extends /*@__PURE__*/ S.TaggedErrorClass<UnknownSnapshotCopyRegionFault>()(
     "UnknownSnapshotCopyRegionFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "UnknownSnapshotCopyRegionFault",
@@ -1660,7 +1660,7 @@ export class UnknownSnapshotCopyRegionFault
 export class UnsupportedOperationFault
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedOperationFault>()(
     "UnsupportedOperationFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "UnsupportedOperation", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -1669,7 +1669,7 @@ export class UnsupportedOperationFault
 export class UnsupportedOptionFault
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedOptionFault>()(
     "UnsupportedOptionFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "UnsupportedOptionFault",
@@ -1681,7 +1681,7 @@ export class UnsupportedOptionFault
 export class UsageLimitAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<UsageLimitAlreadyExistsFault>()(
     "UsageLimitAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "UsageLimitAlreadyExists",
@@ -1693,7 +1693,7 @@ export class UsageLimitAlreadyExistsFault
 export class UsageLimitNotFoundFault
   extends /*@__PURE__*/ S.TaggedErrorClass<UsageLimitNotFoundFault>()(
     "UsageLimitNotFoundFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "UsageLimitNotFound", httpResponseCode: 404 }),
       T.HttpError(404),

--- a/packages/aws/src/services/rekognition.ts
+++ b/packages/aws/src/services/rekognition.ts
@@ -91,7 +91,7 @@ export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Code: S.optional(S.String),
       Logref: S.optional(S.String),
     },
@@ -100,7 +100,7 @@ export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Code: S.optional(S.String),
       Logref: S.optional(S.String),
     },
@@ -112,7 +112,7 @@ export class HumanLoopQuotaExceededException
       ResourceType: S.optional(S.String),
       QuotaCode: S.optional(S.String),
       ServiceCode: S.optional(S.String),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Code: S.optional(S.String),
       Logref: S.optional(S.String),
     },
@@ -122,7 +122,7 @@ export class IdempotentParameterMismatchException
   extends /*@__PURE__*/ S.TaggedErrorClass<IdempotentParameterMismatchException>()(
     "IdempotentParameterMismatchException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Code: S.optional(S.String),
       Logref: S.optional(S.String),
     },
@@ -131,7 +131,7 @@ export class ImageTooLargeException
   extends /*@__PURE__*/ S.TaggedErrorClass<ImageTooLargeException>()(
     "ImageTooLargeException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Code: S.optional(S.String),
       Logref: S.optional(S.String),
     },
@@ -140,7 +140,7 @@ export class InternalServerError
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerError>()(
     "InternalServerError",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Code: S.optional(S.String),
       Logref: S.optional(S.String),
     },
@@ -149,7 +149,7 @@ export class InvalidImageFormatException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidImageFormatException>()(
     "InvalidImageFormatException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Code: S.optional(S.String),
       Logref: S.optional(S.String),
     },
@@ -158,7 +158,7 @@ export class InvalidManifestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidManifestException>()(
     "InvalidManifestException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Code: S.optional(S.String),
       Logref: S.optional(S.String),
     },
@@ -167,7 +167,7 @@ export class InvalidPaginationTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPaginationTokenException>()(
     "InvalidPaginationTokenException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Code: S.optional(S.String),
       Logref: S.optional(S.String),
     },
@@ -176,7 +176,7 @@ export class InvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterException>()(
     "InvalidParameterException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Code: S.optional(S.String),
       Logref: S.optional(S.String),
     },
@@ -185,7 +185,7 @@ export class InvalidPolicyRevisionIdException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPolicyRevisionIdException>()(
     "InvalidPolicyRevisionIdException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Code: S.optional(S.String),
       Logref: S.optional(S.String),
     },
@@ -194,7 +194,7 @@ export class InvalidS3ObjectException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidS3ObjectException>()(
     "InvalidS3ObjectException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Code: S.optional(S.String),
       Logref: S.optional(S.String),
     },
@@ -203,7 +203,7 @@ export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Code: S.optional(S.String),
       Logref: S.optional(S.String),
     },
@@ -212,7 +212,7 @@ export class MalformedPolicyDocumentException
   extends /*@__PURE__*/ S.TaggedErrorClass<MalformedPolicyDocumentException>()(
     "MalformedPolicyDocumentException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Code: S.optional(S.String),
       Logref: S.optional(S.String),
     },
@@ -221,7 +221,7 @@ export class ProvisionedThroughputExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ProvisionedThroughputExceededException>()(
     "ProvisionedThroughputExceededException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Code: S.optional(S.String),
       Logref: S.optional(S.String),
     },
@@ -230,7 +230,7 @@ export class ResourceAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceAlreadyExistsException>()(
     "ResourceAlreadyExistsException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Code: S.optional(S.String),
       Logref: S.optional(S.String),
     },
@@ -239,7 +239,7 @@ export class ResourceInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUseException>()(
     "ResourceInUseException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Code: S.optional(S.String),
       Logref: S.optional(S.String),
     },
@@ -248,7 +248,7 @@ export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Code: S.optional(S.String),
       Logref: S.optional(S.String),
     },
@@ -257,7 +257,7 @@ export class ResourceNotReadyException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotReadyException>()(
     "ResourceNotReadyException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Code: S.optional(S.String),
       Logref: S.optional(S.String),
     },
@@ -266,7 +266,7 @@ export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Code: S.optional(S.String),
       Logref: S.optional(S.String),
     },
@@ -275,7 +275,7 @@ export class SessionNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<SessionNotFoundException>()(
     "SessionNotFoundException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Code: S.optional(S.String),
       Logref: S.optional(S.String),
     },
@@ -284,7 +284,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Code: S.optional(S.String),
       Logref: S.optional(S.String),
     },
@@ -293,7 +293,7 @@ export class VideoTooLargeException
   extends /*@__PURE__*/ S.TaggedErrorClass<VideoTooLargeException>()(
     "VideoTooLargeException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Code: S.optional(S.String),
       Logref: S.optional(S.String),
     },

--- a/packages/aws/src/services/repostspace.ts
+++ b/packages/aws/src/services/repostspace.ts
@@ -90,20 +90,24 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.all(T.HttpError(500), T.Retryable()),
@@ -111,14 +115,18 @@ export class InternalServerException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.String,
       resourceType: S.String,
       serviceCode: S.String,
@@ -130,7 +138,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       serviceCode: S.optional(S.String),
       quotaCode: S.optional(S.String),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
@@ -141,7 +149,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.suspend(() => ValidationExceptionReason).annotate({
         identifier: "ValidationExceptionReason",
       }),

--- a/packages/aws/src/services/resiliencehub.ts
+++ b/packages/aws/src/services/resiliencehub.ts
@@ -88,14 +88,14 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceType: S.optional(S.String),
     },
@@ -104,14 +104,14 @@ export class ConflictException
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceType: S.optional(S.String),
     },
@@ -120,19 +120,22 @@ export class ResourceNotFoundException
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String), retryAfterSeconds: S.optional(S.Number) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      retryAfterSeconds: S.optional(S.Number),
+    },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type Arn = string;

--- a/packages/aws/src/services/resiliencehubv2.ts
+++ b/packages/aws/src/services/resiliencehubv2.ts
@@ -88,26 +88,26 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceType: S.optional(S.String),
     },
@@ -116,20 +116,23 @@ export class ResourceNotFoundException
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.String, retryAfterSeconds: S.optional(S.Number) },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      retryAfterSeconds: S.optional(S.Number),
+    },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.optional(
         S.suspend(() => ValidationExceptionReason).annotate({
           identifier: "ValidationExceptionReason",

--- a/packages/aws/src/services/resource-explorer-2.ts
+++ b/packages/aws/src/services/resource-explorer-2.ts
@@ -90,50 +90,54 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.String, Name: S.String, Value: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      Name: S.String,
+      Value: S.String,
+    },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class UnauthorizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnauthorizedException>()(
     "UnauthorizedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       FieldList: S.optional(
         S.suspend(() => ValidationExceptionFieldList).annotate({
           identifier: "ValidationExceptionFieldList",

--- a/packages/aws/src/services/resource-groups-tagging-api.ts
+++ b/packages/aws/src/services/resource-groups-tagging-api.ts
@@ -87,32 +87,32 @@ const rules = T.EndpointResolver((p, _) => {
 export class ConcurrentModificationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentModificationException>()(
     "ConcurrentModificationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ConstraintViolationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConstraintViolationException>()(
     "ConstraintViolationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InternalServiceException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServiceException>()(
     "InternalServiceException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterException>()(
     "InvalidParameterException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class PaginationTokenExpiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<PaginationTokenExpiredException>()(
     "PaginationTokenExpiredException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ThrottledException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottledException>()(
     "ThrottledException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export interface DescribeReportCreationInput {}
 export const DescribeReportCreationInput = /*@__PURE__*/ S.suspend(() =>

--- a/packages/aws/src/services/resource-groups.ts
+++ b/packages/aws/src/services/resource-groups.ts
@@ -91,19 +91,19 @@ const rules = T.EndpointResolver((p, _) => {
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ForbiddenException
   extends /*@__PURE__*/ S.TaggedErrorClass<ForbiddenException>()(
     "ForbiddenException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class GroupAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<GroupAlreadyExists>()(
     "GroupAlreadyExists",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "BadRequestException",
       message: { includes: "group already exists" },
@@ -112,31 +112,31 @@ export class GroupAlreadyExists
 export class InternalServerErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerErrorException>()(
     "InternalServerErrorException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class MethodNotAllowedException
   extends /*@__PURE__*/ S.TaggedErrorClass<MethodNotAllowedException>()(
     "MethodNotAllowedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(405),
   ).pipe(C.withBadRequestError) {}
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class UnauthorizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnauthorizedException>()(
     "UnauthorizedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export type TagSyncTaskArn = string;

--- a/packages/aws/src/services/rolesanywhere.ts
+++ b/packages/aws/src/services/rolesanywhere.ts
@@ -90,25 +90,25 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type ResourceName = string;

--- a/packages/aws/src/services/route-53-domains.ts
+++ b/packages/aws/src/services/route-53-domains.ts
@@ -93,19 +93,19 @@ const rules = T.EndpointResolver((p, _) => {
 export class DnssecLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<DnssecLimitExceeded>()(
     "DnssecLimitExceeded",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError, C.withThrottlingError) {}
 export class DomainLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<DomainLimitExceeded>()(
     "DomainLimitExceeded",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError, C.withThrottlingError) {}
 export class DomainNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<DomainNotFound>()(
     "DomainNotFound",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "InvalidInput",
       message: { includes: "not found in account" },
@@ -114,37 +114,43 @@ export class DomainNotFound
 export class DuplicateRequest
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicateRequest>()(
     "DuplicateRequest",
-    { requestId: S.optional(S.String), message: S.optional(S.String) },
+    {
+      requestId: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidInput
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInput>()(
     "InvalidInput",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class OperationLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<OperationLimitExceeded>()(
     "OperationLimitExceeded",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError, C.withThrottlingError) {}
 export class TLDInMaintenance
   extends /*@__PURE__*/ S.TaggedErrorClass<TLDInMaintenance>()(
     "TLDInMaintenance",
-    { message: S.optional(S.String), tld: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      tld: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TLDRulesViolation
   extends /*@__PURE__*/ S.TaggedErrorClass<TLDRulesViolation>()(
     "TLDRulesViolation",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class UnsupportedTLD
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedTLD>()(
     "UnsupportedTLD",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type DomainName = string;

--- a/packages/aws/src/services/route-53.ts
+++ b/packages/aws/src/services/route-53.ts
@@ -263,135 +263,135 @@ const rules = T.EndpointResolver((p, _) => {
 export class CidrBlockInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<CidrBlockInUseException>()(
     "CidrBlockInUseException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class CidrCollectionAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<CidrCollectionAlreadyExistsException>()(
     "CidrCollectionAlreadyExistsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class CidrCollectionInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<CidrCollectionInUseException>()(
     "CidrCollectionInUseException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class CidrCollectionVersionMismatchException
   extends /*@__PURE__*/ S.TaggedErrorClass<CidrCollectionVersionMismatchException>()(
     "CidrCollectionVersionMismatchException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ConcurrentModification
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentModification>()(
     "ConcurrentModification",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ConflictingDomainExists
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictingDomainExists>()(
     "ConflictingDomainExists",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ConflictingTypes
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictingTypes>()(
     "ConflictingTypes",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class DelegationSetAlreadyCreated
   extends /*@__PURE__*/ S.TaggedErrorClass<DelegationSetAlreadyCreated>()(
     "DelegationSetAlreadyCreated",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class DelegationSetAlreadyReusable
   extends /*@__PURE__*/ S.TaggedErrorClass<DelegationSetAlreadyReusable>()(
     "DelegationSetAlreadyReusable",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class DelegationSetInUse
   extends /*@__PURE__*/ S.TaggedErrorClass<DelegationSetInUse>()(
     "DelegationSetInUse",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withDependencyViolationError) {}
 export class DelegationSetNotAvailable
   extends /*@__PURE__*/ S.TaggedErrorClass<DelegationSetNotAvailable>()(
     "DelegationSetNotAvailable",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class DelegationSetNotReusable
   extends /*@__PURE__*/ S.TaggedErrorClass<DelegationSetNotReusable>()(
     "DelegationSetNotReusable",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class DNSSECNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<DNSSECNotFound>()(
     "DNSSECNotFound",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class HealthCheckAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<HealthCheckAlreadyExists>()(
     "HealthCheckAlreadyExists",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class HealthCheckInUse
   extends /*@__PURE__*/ S.TaggedErrorClass<HealthCheckInUse>()(
     "HealthCheckInUse",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError, C.withDependencyViolationError) {}
 export class HealthCheckVersionMismatch
   extends /*@__PURE__*/ S.TaggedErrorClass<HealthCheckVersionMismatch>()(
     "HealthCheckVersionMismatch",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class HostedZoneAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<HostedZoneAlreadyExists>()(
     "HostedZoneAlreadyExists",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class HostedZoneNotEmpty
   extends /*@__PURE__*/ S.TaggedErrorClass<HostedZoneNotEmpty>()(
     "HostedZoneNotEmpty",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class HostedZoneNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<HostedZoneNotFound>()(
     "HostedZoneNotFound",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class HostedZoneNotPrivate
   extends /*@__PURE__*/ S.TaggedErrorClass<HostedZoneNotPrivate>()(
     "HostedZoneNotPrivate",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class HostedZonePartiallyDelegated
   extends /*@__PURE__*/ S.TaggedErrorClass<HostedZonePartiallyDelegated>()(
     "HostedZonePartiallyDelegated",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class IncompatibleVersion
   extends /*@__PURE__*/ S.TaggedErrorClass<IncompatibleVersion>()(
     "IncompatibleVersion",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InsufficientCloudWatchLogsResourcePolicy
   extends /*@__PURE__*/ S.TaggedErrorClass<InsufficientCloudWatchLogsResourcePolicy>()(
     "InsufficientCloudWatchLogsResourcePolicy",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidArgument
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidArgument>()(
     "InvalidArgument",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidChangeBatch
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidChangeBatch>()(
@@ -402,261 +402,261 @@ export class InvalidChangeBatch
           identifier: "ErrorMessages",
         }),
       ),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
   ) {}
 export class InvalidDomainName
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDomainName>()(
     "InvalidDomainName",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidInput
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInput>()(
     "InvalidInput",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidKeySigningKeyName
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidKeySigningKeyName>()(
     "InvalidKeySigningKeyName",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidKeySigningKeyStatus
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidKeySigningKeyStatus>()(
     "InvalidKeySigningKeyStatus",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidKMSArn
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidKMSArn>()("InvalidKMSArn", {
-    message: S.optional(S.String),
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
   }) {}
 export class InvalidPaginationToken
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPaginationToken>()(
     "InvalidPaginationToken",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidSigningStatus
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSigningStatus>()(
     "InvalidSigningStatus",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTrafficPolicyDocument
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTrafficPolicyDocument>()(
     "InvalidTrafficPolicyDocument",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidVPCId
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidVPCId>()(
     "InvalidVPCId",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class KeySigningKeyAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<KeySigningKeyAlreadyExists>()(
     "KeySigningKeyAlreadyExists",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class KeySigningKeyInParentDSRecord
   extends /*@__PURE__*/ S.TaggedErrorClass<KeySigningKeyInParentDSRecord>()(
     "KeySigningKeyInParentDSRecord",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class KeySigningKeyInUse
   extends /*@__PURE__*/ S.TaggedErrorClass<KeySigningKeyInUse>()(
     "KeySigningKeyInUse",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withDependencyViolationError) {}
 export class KeySigningKeyWithActiveStatusNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<KeySigningKeyWithActiveStatusNotFound>()(
     "KeySigningKeyWithActiveStatusNotFound",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LastVPCAssociation
   extends /*@__PURE__*/ S.TaggedErrorClass<LastVPCAssociation>()(
     "LastVPCAssociation",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class LimitsExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitsExceeded>()("LimitsExceeded", {
-    message: S.optional(S.String),
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
   }) {}
 export class NoSuchChange
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchChange>()(
     "NoSuchChange",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class NoSuchCidrCollectionException
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchCidrCollectionException>()(
     "NoSuchCidrCollectionException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class NoSuchCidrLocationException
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchCidrLocationException>()(
     "NoSuchCidrLocationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class NoSuchCloudWatchLogsLogGroup
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchCloudWatchLogsLogGroup>()(
     "NoSuchCloudWatchLogsLogGroup",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class NoSuchDelegationSet
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchDelegationSet>()(
     "NoSuchDelegationSet",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NoSuchGeoLocation
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchGeoLocation>()(
     "NoSuchGeoLocation",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class NoSuchHealthCheck
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchHealthCheck>()(
     "NoSuchHealthCheck",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class NoSuchHostedZone
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchHostedZone>()(
     "NoSuchHostedZone",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class NoSuchKeySigningKey
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchKeySigningKey>()(
     "NoSuchKeySigningKey",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class NoSuchQueryLoggingConfig
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchQueryLoggingConfig>()(
     "NoSuchQueryLoggingConfig",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class NoSuchTrafficPolicy
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchTrafficPolicy>()(
     "NoSuchTrafficPolicy",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class NoSuchTrafficPolicyInstance
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchTrafficPolicyInstance>()(
     "NoSuchTrafficPolicyInstance",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class NotAuthorizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotAuthorizedException>()(
     "NotAuthorizedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export class PriorRequestNotComplete
   extends /*@__PURE__*/ S.TaggedErrorClass<PriorRequestNotComplete>()(
     "PriorRequestNotComplete",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError, C.withConflictError, C.withRetryableError) {}
 export class PublicZoneVPCAssociation
   extends /*@__PURE__*/ S.TaggedErrorClass<PublicZoneVPCAssociation>()(
     "PublicZoneVPCAssociation",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class QueryLoggingConfigAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<QueryLoggingConfigAlreadyExists>()(
     "QueryLoggingConfigAlreadyExists",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError, C.withThrottlingError, C.withRetryableError) {}
 export class TooManyHealthChecks
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyHealthChecks>()(
     "TooManyHealthChecks",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TooManyHostedZones
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyHostedZones>()(
     "TooManyHostedZones",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyKeySigningKeys
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyKeySigningKeys>()(
     "TooManyKeySigningKeys",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TooManyTrafficPolicies
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTrafficPolicies>()(
     "TooManyTrafficPolicies",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyTrafficPolicyInstances
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTrafficPolicyInstances>()(
     "TooManyTrafficPolicyInstances",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyTrafficPolicyVersionsForCurrentPolicy
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTrafficPolicyVersionsForCurrentPolicy>()(
     "TooManyTrafficPolicyVersionsForCurrentPolicy",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyVPCAssociationAuthorizations
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyVPCAssociationAuthorizations>()(
     "TooManyVPCAssociationAuthorizations",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TrafficPolicyAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<TrafficPolicyAlreadyExists>()(
     "TrafficPolicyAlreadyExists",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class TrafficPolicyInstanceAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<TrafficPolicyInstanceAlreadyExists>()(
     "TrafficPolicyInstanceAlreadyExists",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class TrafficPolicyInUse
   extends /*@__PURE__*/ S.TaggedErrorClass<TrafficPolicyInUse>()(
     "TrafficPolicyInUse",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError, C.withDependencyViolationError) {}
 export class VPCAssociationAuthorizationNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<VPCAssociationAuthorizationNotFound>()(
     "VPCAssociationAuthorizationNotFound",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class VPCAssociationNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<VPCAssociationNotFound>()(
     "VPCAssociationNotFound",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export type ResourceId = string;

--- a/packages/aws/src/services/route53-recovery-cluster.ts
+++ b/packages/aws/src/services/route53-recovery-cluster.ts
@@ -88,26 +88,30 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class EndpointTemporarilyUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<EndpointTemporarilyUnavailableException>()(
     "EndpointTemporarilyUnavailableException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.HttpError(500),
@@ -115,14 +119,18 @@ export class InternalServerException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceLimitExceededException>()(
     "ServiceLimitExceededException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceType: S.optional(S.String),
       limitCode: S.String,
@@ -134,7 +142,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.HttpError(429),
@@ -143,7 +151,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.optional(
         S.suspend(() => ValidationExceptionReason).annotate({
           identifier: "ValidationExceptionReason",

--- a/packages/aws/src/services/route53-recovery-control-config.ts
+++ b/packages/aws/src/services/route53-recovery-control-config.ts
@@ -129,43 +129,43 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type __stringMin1Max64PatternS = string;

--- a/packages/aws/src/services/route53-recovery-readiness.ts
+++ b/packages/aws/src/services/route53-recovery-readiness.ts
@@ -88,37 +88,37 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type __listOf__string = string[];

--- a/packages/aws/src/services/route53globalresolver.ts
+++ b/packages/aws/src/services/route53globalresolver.ts
@@ -57,14 +57,14 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceType: S.String,
     },
@@ -74,7 +74,7 @@ export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.all(T.HttpError(500), T.Retryable()),
@@ -83,7 +83,7 @@ export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceType: S.String,
     },
@@ -93,7 +93,7 @@ export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceType: S.String,
       serviceCode: S.optional(S.String),
@@ -105,7 +105,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       serviceCode: S.optional(S.String),
       quotaCode: S.optional(S.String),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
@@ -116,7 +116,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.suspend(() => ValidationExceptionReason).annotate({
         identifier: "ValidationExceptionReason",
       }),

--- a/packages/aws/src/services/route53profiles.ts
+++ b/packages/aws/src/services/route53profiles.ts
@@ -88,52 +88,64 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InternalServiceErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServiceErrorException>()(
     "InternalServiceErrorException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidNextTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNextTokenException>()(
     "InvalidNextTokenException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterException>()(
     "InvalidParameterException",
-    { Message: S.String, FieldName: S.optional(S.String) },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      FieldName: S.optional(S.String),
+    },
   ) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { Message: S.optional(S.String), ResourceType: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ResourceType: S.optional(S.String),
+    },
   ) {}
 export class ResourceExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceExistsException>()(
     "ResourceExistsException",
-    { Message: S.optional(S.String), ResourceType: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ResourceType: S.optional(S.String),
+    },
   ) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String), ResourceType: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ResourceType: S.optional(S.String),
+    },
   ) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type ResourceId = string;
 export type Name = string;

--- a/packages/aws/src/services/route53resolver.ts
+++ b/packages/aws/src/services/route53resolver.ts
@@ -94,87 +94,105 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InternalServiceErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServiceErrorException>()(
     "InternalServiceErrorException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidNextTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNextTokenException>()(
     "InvalidNextTokenException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterException>()(
     "InvalidParameterException",
-    { Message: S.String, FieldName: S.optional(S.String) },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      FieldName: S.optional(S.String),
+    },
   ) {}
 export class InvalidPolicyDocument
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPolicyDocument>()(
     "InvalidPolicyDocument",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidTagException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTagException>()(
     "InvalidTagException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { Message: S.optional(S.String), ResourceType: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ResourceType: S.optional(S.String),
+    },
   ) {}
 export class ResourceExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceExistsException>()(
     "ResourceExistsException",
-    { Message: S.optional(S.String), ResourceType: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ResourceType: S.optional(S.String),
+    },
   ) {}
 export class ResourceInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUseException>()(
     "ResourceInUseException",
-    { Message: S.optional(S.String), ResourceType: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ResourceType: S.optional(S.String),
+    },
   ) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String), ResourceType: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ResourceType: S.optional(S.String),
+    },
   ) {}
 export class ResourceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceUnavailableException>()(
     "ResourceUnavailableException",
-    { Message: S.optional(S.String), ResourceType: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ResourceType: S.optional(S.String),
+    },
   ) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class UnknownResourceException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnknownResourceException>()(
     "UnknownResourceException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type CreatorRequestId = string;
 export type ResourceId = string;

--- a/packages/aws/src/services/rtbfabric.ts
+++ b/packages/aws/src/services/rtbfabric.ts
@@ -90,43 +90,43 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(429), T.Retryable()),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type GatewayId = string;

--- a/packages/aws/src/services/rum.ts
+++ b/packages/aws/src/services/rum.ts
@@ -85,14 +85,14 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceName: S.String,
       resourceType: S.optional(S.String),
     },
@@ -102,7 +102,7 @@ export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.all(T.HttpError(500), T.Retryable()),
@@ -110,32 +110,32 @@ export class InternalServerException
 export class InvalidPolicyRevisionIdException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPolicyRevisionIdException>()(
     "InvalidPolicyRevisionIdException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class MalformedPolicyDocumentException
   extends /*@__PURE__*/ S.TaggedErrorClass<MalformedPolicyDocumentException>()(
     "MalformedPolicyDocumentException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class PolicyNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<PolicyNotFoundException>()(
     "PolicyNotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class PolicySizeLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<PolicySizeLimitExceededException>()(
     "PolicySizeLimitExceededException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceName: S.String,
       resourceType: S.optional(S.String),
     },
@@ -144,14 +144,14 @@ export class ResourceNotFoundException
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       serviceCode: S.optional(S.String),
       quotaCode: S.optional(S.String),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
@@ -161,7 +161,7 @@ export class ThrottlingException
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type AppMonitorName = string;

--- a/packages/aws/src/services/s3-control.ts
+++ b/packages/aws/src/services/s3-control.ts
@@ -1053,57 +1053,56 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessPointAlreadyOwnedByYou
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessPointAlreadyOwnedByYou>()(
     "AccessPointAlreadyOwnedByYou",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class BucketAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<BucketAlreadyExists>()(
     "BucketAlreadyExists",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class BucketAlreadyOwnedByYou
   extends /*@__PURE__*/ S.TaggedErrorClass<BucketAlreadyOwnedByYou>()(
     "BucketAlreadyOwnedByYou",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class IdempotencyException
   extends /*@__PURE__*/ S.TaggedErrorClass<IdempotencyException>()(
     "IdempotencyException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InternalServiceException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServiceException>()(
     "InternalServiceException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidNextTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNextTokenException>()(
     "InvalidNextTokenException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidRequest
-  extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequest>()(
-    "InvalidRequest",
-    {},
-  ).pipe(C.withBadRequestError) {}
+  extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequest>()("InvalidRequest", {
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
+  }).pipe(C.withBadRequestError) {}
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class JobStatusException
   extends /*@__PURE__*/ S.TaggedErrorClass<JobStatusException>()(
     "JobStatusException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class JobStatusTransitionForbidden
   extends /*@__PURE__*/ S.TaggedErrorClass<JobStatusTransitionForbidden>()(
     "JobStatusTransitionForbidden",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "InvalidRequest",
       message: { includes: "job status forbidden" },
@@ -1112,48 +1111,48 @@ export class JobStatusTransitionForbidden
 export class MalformedPolicy
   extends /*@__PURE__*/ S.TaggedErrorClass<MalformedPolicy>()(
     "MalformedPolicy",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class MissingBucketLevelActivityMetrics
   extends /*@__PURE__*/ S.TaggedErrorClass<MissingBucketLevelActivityMetrics>()(
     "MissingBucketLevelActivityMetrics",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class NoSuchAccessPoint
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchAccessPoint>()(
     "NoSuchAccessPoint",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withNotFoundError) {}
 export class NoSuchAccessPointPolicy
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchAccessPointPolicy>()(
     "NoSuchAccessPointPolicy",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withNotFoundError) {}
 export class NoSuchConfiguration
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchConfiguration>()(
     "NoSuchConfiguration",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withNotFoundError) {}
 export class NoSuchMultiRegionAccessPoint
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchMultiRegionAccessPoint>()(
     "NoSuchMultiRegionAccessPoint",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withNotFoundError) {}
 export class NoSuchPublicAccessBlockConfiguration
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchPublicAccessBlockConfiguration>()(
     "NoSuchPublicAccessBlockConfiguration",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ObjectLambdaNotAvailable
   extends /*@__PURE__*/ S.TaggedErrorClass<ObjectLambdaNotAvailable>()(
     "ObjectLambdaNotAvailable",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "AccessDenied",
       message: {
@@ -1164,12 +1163,12 @@ export class ObjectLambdaNotAvailable
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type AccountId = string;
 export type IdentityCenterArn = string;

--- a/packages/aws/src/services/s3.ts
+++ b/packages/aws/src/services/s3.ts
@@ -3022,95 +3022,93 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDenied
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDenied>()(
     "AccessDenied",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class AnnotationLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<AnnotationLimitExceeded>()(
     "AnnotationLimitExceeded",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError, C.withThrottlingError) {}
 export class AnnotationNameTooLong
   extends /*@__PURE__*/ S.TaggedErrorClass<AnnotationNameTooLong>()(
     "AnnotationNameTooLong",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class BucketAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<BucketAlreadyExists>()(
     "BucketAlreadyExists",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class BucketAlreadyOwnedByYou
   extends /*@__PURE__*/ S.TaggedErrorClass<BucketAlreadyOwnedByYou>()(
     "BucketAlreadyOwnedByYou",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class BucketHasAccessPointsAttached
   extends /*@__PURE__*/ S.TaggedErrorClass<BucketHasAccessPointsAttached>()(
     "BucketHasAccessPointsAttached",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withConflictError) {}
 export class BucketNotEmpty
-  extends /*@__PURE__*/ S.TaggedErrorClass<BucketNotEmpty>()(
-    "BucketNotEmpty",
-    {},
-  ).pipe(C.withConflictError) {}
+  extends /*@__PURE__*/ S.TaggedErrorClass<BucketNotEmpty>()("BucketNotEmpty", {
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
+  }).pipe(C.withConflictError) {}
 export class ConditionalRequestConflict
   extends /*@__PURE__*/ S.TaggedErrorClass<ConditionalRequestConflict>()(
     "ConditionalRequestConflict",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withConflictError, C.withRetryableError) {}
 export class EncryptionTypeMismatch
   extends /*@__PURE__*/ S.TaggedErrorClass<EncryptionTypeMismatch>()(
     "EncryptionTypeMismatch",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class IdempotencyParameterMismatch
   extends /*@__PURE__*/ S.TaggedErrorClass<IdempotencyParameterMismatch>()(
     "IdempotencyParameterMismatch",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class IllegalLocationConstraintException
   extends /*@__PURE__*/ S.TaggedErrorClass<IllegalLocationConstraintException>()(
     "IllegalLocationConstraintException",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class InvalidAnnotationName
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidAnnotationName>()(
     "InvalidAnnotationName",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidArgument
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidArgument>()(
     "InvalidArgument",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class InvalidBucketName
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidBucketName>()(
     "InvalidBucketName",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class InvalidBucketState
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidBucketState>()(
     "InvalidBucketState",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withConflictError) {}
 export class InvalidDigest
-  extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDigest>()(
-    "InvalidDigest",
-    {},
-  ).pipe(C.withBadRequestError) {}
+  extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDigest>()("InvalidDigest", {
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
+  }).pipe(C.withBadRequestError) {}
 export class InvalidLocationConstraint
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidLocationConstraint>()(
     "InvalidLocationConstraint",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class InvalidObjectState
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidObjectState>()(
@@ -3124,122 +3122,128 @@ export class InvalidObjectState
           identifier: "IntelligentTieringAccessTier",
         }),
       ),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class InvalidPrefix
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPrefix>()(
     "InvalidPrefix",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidRequest
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequest>()(
     "InvalidRequest",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidWriteOffset
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidWriteOffset>()(
     "InvalidWriteOffset",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class MalformedPolicy
   extends /*@__PURE__*/ S.TaggedErrorClass<MalformedPolicy>()(
     "MalformedPolicy",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class MalformedXML
-  extends /*@__PURE__*/ S.TaggedErrorClass<MalformedXML>()(
-    "MalformedXML",
-    {},
-  ).pipe(C.withBadRequestError) {}
+  extends /*@__PURE__*/ S.TaggedErrorClass<MalformedXML>()("MalformedXML", {
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
+  }).pipe(C.withBadRequestError) {}
 export class NoSuchAnnotation
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchAnnotation>()(
     "NoSuchAnnotation",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class NoSuchBucket
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchBucket>()(
     "NoSuchBucket",
-    { Message: S.optional(S.String), BucketName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      BucketName: S.optional(S.String),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class NoSuchBucketPolicy
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchBucketPolicy>()(
     "NoSuchBucketPolicy",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NoSuchConfiguration
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchConfiguration>()(
     "NoSuchConfiguration",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NoSuchCORSConfiguration
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchCORSConfiguration>()(
     "NoSuchCORSConfiguration",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NoSuchKey
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchKey>()(
     "NoSuchKey",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class NoSuchLifecycleConfiguration
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchLifecycleConfiguration>()(
     "NoSuchLifecycleConfiguration",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NoSuchPublicAccessBlockConfiguration
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchPublicAccessBlockConfiguration>()(
     "NoSuchPublicAccessBlockConfiguration",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NoSuchTagSet
-  extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchTagSet>()(
-    "NoSuchTagSet",
-    {},
-  ) {}
+  extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchTagSet>()("NoSuchTagSet", {
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
+  }) {}
 export class NoSuchUpload
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchUpload>()(
     "NoSuchUpload",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class NoSuchWebsiteConfiguration
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchWebsiteConfiguration>()(
     "NoSuchWebsiteConfiguration",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NotFound
-  extends /*@__PURE__*/ S.TaggedErrorClass<NotFound>()("NotFound", {}) {}
+  extends /*@__PURE__*/ S.TaggedErrorClass<NotFound>()("NotFound", {
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
+  }) {}
 export class ObjectAlreadyInActiveTierError
   extends /*@__PURE__*/ S.TaggedErrorClass<ObjectAlreadyInActiveTierError>()(
     "ObjectAlreadyInActiveTierError",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ObjectLockConfigurationNotFoundError
   extends /*@__PURE__*/ S.TaggedErrorClass<ObjectLockConfigurationNotFoundError>()(
     "ObjectLockConfigurationNotFoundError",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ObjectNotInActiveTierError
   extends /*@__PURE__*/ S.TaggedErrorClass<ObjectNotInActiveTierError>()(
     "ObjectNotInActiveTierError",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class OwnershipControlsNotFoundError
   extends /*@__PURE__*/ S.TaggedErrorClass<OwnershipControlsNotFoundError>()(
     "OwnershipControlsNotFoundError",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ParseError
-  extends /*@__PURE__*/ S.TaggedErrorClass<ParseError>()("ParseError", {}) {}
+  extends /*@__PURE__*/ S.TaggedErrorClass<ParseError>()("ParseError", {
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
+  }) {}
 export class PermanentRedirect
   extends /*@__PURE__*/ S.TaggedErrorClass<PermanentRedirect>()(
     "PermanentRedirect",
@@ -3249,49 +3253,47 @@ export class PermanentRedirect
       ),
       Endpoint: S.optional(S.String),
       Bucket: S.optional(S.String),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
   ) {}
 export class PreconditionFailed
   extends /*@__PURE__*/ S.TaggedErrorClass<PreconditionFailed>()(
     "PreconditionFailed",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withConflictError) {}
 export class ReplicationConfigurationNotFoundError
   extends /*@__PURE__*/ S.TaggedErrorClass<ReplicationConfigurationNotFoundError>()(
     "ReplicationConfigurationNotFoundError",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class RequestError
-  extends /*@__PURE__*/ S.TaggedErrorClass<RequestError>()(
-    "RequestError",
-    {},
-  ) {}
+  extends /*@__PURE__*/ S.TaggedErrorClass<RequestError>()("RequestError", {
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
+  }) {}
 export class RequestLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<RequestLimitExceeded>()(
     "RequestLimitExceeded",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withThrottlingError) {}
 export class SignatureDoesNotMatch
   extends /*@__PURE__*/ S.TaggedErrorClass<SignatureDoesNotMatch>()(
     "SignatureDoesNotMatch",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAuthError) {}
 export class SlowDown
-  extends /*@__PURE__*/ S.TaggedErrorClass<SlowDown>()("SlowDown", {}).pipe(
-    C.withThrottlingError,
-    C.withRetryableError,
-  ) {}
+  extends /*@__PURE__*/ S.TaggedErrorClass<SlowDown>()("SlowDown", {
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
+  }).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class TooManyParts
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyParts>()(
     "TooManyParts",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class UnsupportedMediaType
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedMediaType>()(
     "UnsupportedMediaType",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(415),
   ).pipe(C.withBadRequestError) {}
 export type BucketName = string;

--- a/packages/aws/src/services/s3files.ts
+++ b/packages/aws/src/services/s3files.ts
@@ -55,7 +55,7 @@ export class ConflictException
     "ConflictException",
     {
       errorCode: S.String,
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceType: S.optional(S.String),
     },
@@ -64,25 +64,37 @@ export class ConflictException
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { errorCode: S.String, message: S.optional(S.String) },
+    {
+      errorCode: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { errorCode: S.String, message: S.optional(S.String) },
+    {
+      errorCode: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { errorCode: S.String, message: S.optional(S.String) },
+    {
+      errorCode: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { errorCode: S.String, message: S.optional(S.String) },
+    {
+      errorCode: S.String,
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type ClientToken = string;

--- a/packages/aws/src/services/s3outposts.ts
+++ b/packages/aws/src/services/s3outposts.ts
@@ -88,43 +88,43 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class OutpostOfflineException
   extends /*@__PURE__*/ S.TaggedErrorClass<OutpostOfflineException>()(
     "OutpostOfflineException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type OutpostId = string;

--- a/packages/aws/src/services/s3tables.ts
+++ b/packages/aws/src/services/s3tables.ts
@@ -88,49 +88,49 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ForbiddenException
   extends /*@__PURE__*/ S.TaggedErrorClass<ForbiddenException>()(
     "ForbiddenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class InternalServerErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerErrorException>()(
     "InternalServerErrorException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class MethodNotAllowedException
   extends /*@__PURE__*/ S.TaggedErrorClass<MethodNotAllowedException>()(
     "MethodNotAllowedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(405),
   ).pipe(C.withBadRequestError) {}
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export type TableBucketARN = string;

--- a/packages/aws/src/services/s3vectors.ts
+++ b/packages/aws/src/services/s3vectors.ts
@@ -55,55 +55,55 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class KmsDisabledException
   extends /*@__PURE__*/ S.TaggedErrorClass<KmsDisabledException>()(
     "KmsDisabledException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class KmsInvalidKeyUsageException
   extends /*@__PURE__*/ S.TaggedErrorClass<KmsInvalidKeyUsageException>()(
     "KmsInvalidKeyUsageException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class KmsInvalidStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<KmsInvalidStateException>()(
     "KmsInvalidStateException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class KmsNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<KmsNotFoundException>()(
     "KmsNotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(503), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export type VectorBucketName = string;

--- a/packages/aws/src/services/sagemaker-a2i-runtime.ts
+++ b/packages/aws/src/services/sagemaker-a2i-runtime.ts
@@ -88,37 +88,37 @@ const rules = T.EndpointResolver((p, _) => {
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type HumanLoopName = string;

--- a/packages/aws/src/services/sagemaker-edge.ts
+++ b/packages/aws/src/services/sagemaker-edge.ts
@@ -86,7 +86,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class InternalServiceException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServiceException>()(
     "InternalServiceException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type DeviceName = string;
 export type DeviceFleetName = string;

--- a/packages/aws/src/services/sagemaker-featurestore-runtime.ts
+++ b/packages/aws/src/services/sagemaker-featurestore-runtime.ts
@@ -88,13 +88,13 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessForbidden
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessForbidden>()(
     "AccessForbidden",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class FeatureGroupNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<FeatureGroupNotFound>()(
     "FeatureGroupNotFound",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "ValidationError",
       message: { includes: "Resource Not Found" },
@@ -103,25 +103,25 @@ export class FeatureGroupNotFound
 export class InternalFailure
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalFailure>()(
     "InternalFailure",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFound>()(
     "ResourceNotFound",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceUnavailable
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailable>()(
     "ServiceUnavailable",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class ValidationError
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationError>()(
     "ValidationError",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type FeatureGroupNameOrArn = string;

--- a/packages/aws/src/services/sagemaker-geospatial.ts
+++ b/packages/aws/src/services/sagemaker-geospatial.ts
@@ -90,43 +90,61 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.String, ResourceId: S.optional(S.String) },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      ResourceId: S.optional(S.String),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.String, ResourceId: S.optional(S.String) },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      ResourceId: S.optional(S.String),
+    },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.String, ResourceId: S.optional(S.String) },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      ResourceId: S.optional(S.String),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.String, ResourceId: S.optional(S.String) },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      ResourceId: S.optional(S.String),
+    },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.String, ResourceId: S.optional(S.String) },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      ResourceId: S.optional(S.String),
+    },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.String, ResourceId: S.optional(S.String) },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      ResourceId: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type EarthObservationJobArn = string;

--- a/packages/aws/src/services/sagemaker-runtime-http2.ts
+++ b/packages/aws/src/services/sagemaker-runtime-http2.ts
@@ -342,25 +342,31 @@ const rules = T.EndpointResolver((p, _) => {
 export class InputValidationError
   extends /*@__PURE__*/ S.TaggedErrorClass<InputValidationError>()(
     "InputValidationError",
-    { Message: S.optional(S.String), ErrorCode: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ErrorCode: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InternalServerError
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerError>()(
     "InternalServerError",
-    { Message: S.optional(S.String), ErrorCode: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ErrorCode: S.optional(S.String),
+    },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InternalStreamFailure
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalStreamFailure>()(
     "InternalStreamFailure",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ModelError
   extends /*@__PURE__*/ S.TaggedErrorClass<ModelError>()(
     "ModelError",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       OriginalStatusCode: S.optional(S.Number),
       OriginalMessage: S.optional(S.String),
       LogStreamArn: S.optional(S.String),
@@ -371,12 +377,18 @@ export class ModelError
 export class ModelStreamError
   extends /*@__PURE__*/ S.TaggedErrorClass<ModelStreamError>()(
     "ModelStreamError",
-    { Message: S.optional(S.String), ErrorCode: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ErrorCode: S.optional(S.String),
+    },
   ) {}
 export class ServiceUnavailableError
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableError>()(
     "ServiceUnavailableError",
-    { Message: S.optional(S.String), ErrorCode: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ErrorCode: S.optional(S.String),
+    },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export type SensitiveBlob = Uint8Array | redacted.Redacted<Uint8Array>;

--- a/packages/aws/src/services/sagemaker-runtime.ts
+++ b/packages/aws/src/services/sagemaker-runtime.ts
@@ -98,25 +98,25 @@ const rules = T.EndpointResolver((p, _) => {
 export class InternalDependencyException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalDependencyException>()(
     "InternalDependencyException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(530),
   ).pipe(C.withServerError) {}
 export class InternalFailure
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalFailure>()(
     "InternalFailure",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InternalStreamFailure
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalStreamFailure>()(
     "InternalStreamFailure",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ModelError
   extends /*@__PURE__*/ S.TaggedErrorClass<ModelError>()(
     "ModelError",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       OriginalStatusCode: S.optional(S.Number),
       OriginalMessage: S.optional(S.String),
       LogStreamArn: S.optional(S.String),
@@ -126,7 +126,7 @@ export class ModelError
 export class ModelNotReadyException
   extends /*@__PURE__*/ S.TaggedErrorClass<ModelNotReadyException>()(
     "ModelNotReadyException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ModelNotReadyException",
@@ -138,18 +138,21 @@ export class ModelNotReadyException
 export class ModelStreamError
   extends /*@__PURE__*/ S.TaggedErrorClass<ModelStreamError>()(
     "ModelStreamError",
-    { Message: S.optional(S.String), ErrorCode: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ErrorCode: S.optional(S.String),
+    },
   ) {}
 export class ServiceUnavailable
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailable>()(
     "ServiceUnavailable",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class ValidationError
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationError>()(
     "ValidationError",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type EndpointName = string;

--- a/packages/aws/src/services/sagemaker.ts
+++ b/packages/aws/src/services/sagemaker.ts
@@ -97,12 +97,12 @@ const rules = T.EndpointResolver((p, _) => {
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class EndpointAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<EndpointAlreadyExists>()(
     "EndpointAlreadyExists",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "ValidationException",
       message: { includes: "Cannot create already existing endpoint" },
@@ -111,7 +111,7 @@ export class EndpointAlreadyExists
 export class EndpointConfigAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<EndpointConfigAlreadyExists>()(
     "EndpointConfigAlreadyExists",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "ValidationException",
       message: {
@@ -122,7 +122,7 @@ export class EndpointConfigAlreadyExists
 export class EndpointConfigNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<EndpointConfigNotFound>()(
     "EndpointConfigNotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "ValidationException",
       message: { includes: "Could not find endpoint configuration" },
@@ -131,7 +131,7 @@ export class EndpointConfigNotFound
 export class EndpointNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<EndpointNotFound>()(
     "EndpointNotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "ValidationException",
       message: { includes: 'Could not find endpoint "' },
@@ -140,7 +140,7 @@ export class EndpointNotFound
 export class ModelAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<ModelAlreadyExists>()(
     "ModelAlreadyExists",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "ValidationException",
       message: { includes: "Cannot create already existing model" },
@@ -149,7 +149,7 @@ export class ModelAlreadyExists
 export class ModelNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<ModelNotFound>()(
     "ModelNotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "ValidationException",
       message: { includes: "Could not find model" },
@@ -157,17 +157,17 @@ export class ModelNotFound
   ).pipe(C.withNotFoundError) {}
 export class ResourceInUse
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUse>()("ResourceInUse", {
-    Message: S.optional(S.String),
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
   }).pipe(C.withDependencyViolationError) {}
 export class ResourceLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceLimitExceeded>()(
     "ResourceLimitExceeded",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withThrottlingError) {}
 export class ResourceNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFound>()(
     "ResourceNotFound",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type AssociationEntityArn = string;
 export type AssociationEdgeType =

--- a/packages/aws/src/services/sagemakerjobruntime.ts
+++ b/packages/aws/src/services/sagemakerjobruntime.ts
@@ -75,43 +75,43 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServiceError
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServiceError>()(
     "InternalServiceError",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(429), T.Retryable()),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type JobArn = string;

--- a/packages/aws/src/services/savingsplans.ts
+++ b/packages/aws/src/services/savingsplans.ts
@@ -128,7 +128,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InternalServerException",
@@ -140,7 +140,7 @@ export class InternalServerException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ResourceNotFoundException",
@@ -152,7 +152,7 @@ export class ResourceNotFoundException
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ServiceQuotaExceededException",
@@ -164,7 +164,7 @@ export class ServiceQuotaExceededException
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ValidationException", httpResponseCode: 400 }),
       T.HttpError(400),

--- a/packages/aws/src/services/scheduler.ts
+++ b/packages/aws/src/services/scheduler.ts
@@ -88,37 +88,37 @@ const rules = T.EndpointResolver((p, _) => {
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withRetryableError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type Name = string;

--- a/packages/aws/src/services/schemas.ts
+++ b/packages/aws/src/services/schemas.ts
@@ -85,61 +85,91 @@ const rules = T.EndpointResolver((p, _) => {
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { Code: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Code: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Code: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Code: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ForbiddenException
   extends /*@__PURE__*/ S.TaggedErrorClass<ForbiddenException>()(
     "ForbiddenException",
-    { Code: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Code: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class GoneException
   extends /*@__PURE__*/ S.TaggedErrorClass<GoneException>()(
     "GoneException",
-    { Code: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Code: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(410),
   ).pipe(C.withBadRequestError) {}
 export class InternalServerErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerErrorException>()(
     "InternalServerErrorException",
-    { Code: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Code: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { Code: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Code: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class PreconditionFailedException
   extends /*@__PURE__*/ S.TaggedErrorClass<PreconditionFailedException>()(
     "PreconditionFailedException",
-    { Code: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Code: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(412),
   ) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { Code: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Code: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { Code: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Code: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class UnauthorizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnauthorizedException>()(
     "UnauthorizedException",
-    { Code: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      Code: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export type __stringMin0Max256 = string;

--- a/packages/aws/src/services/secrets-manager.ts
+++ b/packages/aws/src/services/secrets-manager.ts
@@ -105,62 +105,62 @@ const rules = T.EndpointResolver((p, _) => {
 export class DecryptionFailure
   extends /*@__PURE__*/ S.TaggedErrorClass<DecryptionFailure>()(
     "DecryptionFailure",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withServerError) {}
 export class EncryptionFailure
   extends /*@__PURE__*/ S.TaggedErrorClass<EncryptionFailure>()(
     "EncryptionFailure",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withServerError) {}
 export class InternalServiceError
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServiceError>()(
     "InternalServiceError",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class InvalidNextTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNextTokenException>()(
     "InvalidNextTokenException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class InvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterException>()(
     "InvalidParameterException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withQuotaError) {}
 export class MalformedPolicyDocumentException
   extends /*@__PURE__*/ S.TaggedErrorClass<MalformedPolicyDocumentException>()(
     "MalformedPolicyDocumentException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class PreconditionNotMetException
   extends /*@__PURE__*/ S.TaggedErrorClass<PreconditionNotMetException>()(
     "PreconditionNotMetException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withConflictError) {}
 export class PublicPolicyException
   extends /*@__PURE__*/ S.TaggedErrorClass<PublicPolicyException>()(
     "PublicPolicyException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class ResourceExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceExistsException>()(
     "ResourceExistsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withNotFoundError) {}
 export type SecretIdType = string;
 export type SecretIdListType = string[];

--- a/packages/aws/src/services/security-ir.ts
+++ b/packages/aws/src/services/security-ir.ts
@@ -57,20 +57,20 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.suspend(() => ValidationExceptionReason).annotate({
         identifier: "ValidationExceptionReason",
       }),

--- a/packages/aws/src/services/securityagent.ts
+++ b/packages/aws/src/services/securityagent.ts
@@ -57,38 +57,38 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       serviceCode: S.optional(S.String),
       quotaCode: S.optional(S.String),
     },
@@ -98,7 +98,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       fieldList: S.optional(
         S.suspend(() => ValidationExceptionFieldList).annotate({
           identifier: "ValidationExceptionFieldList",

--- a/packages/aws/src/services/securityhub.ts
+++ b/packages/aws/src/services/securityhub.ts
@@ -88,91 +88,136 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String), Code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Code: S.optional(S.String),
+    },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String), Code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Code: S.optional(S.String),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalException>()(
     "InternalException",
-    { Message: S.optional(S.String), Code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Code: S.optional(S.String),
+    },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String), Code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Code: S.optional(S.String),
+    },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidAccessException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidAccessException>()(
     "InvalidAccessException",
-    { Message: S.optional(S.String), Code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Code: S.optional(S.String),
+    },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export class InvalidInputException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInputException>()(
     "InvalidInputException",
-    { Message: S.optional(S.String), Code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Code: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { Message: S.optional(S.String), Code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Code: S.optional(S.String),
+    },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class OrganizationalUnitNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<OrganizationalUnitNotFoundException>()(
     "OrganizationalUnitNotFoundException",
-    { Message: S.optional(S.String), Code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Code: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class OrganizationNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<OrganizationNotFoundException>()(
     "OrganizationNotFoundException",
-    { Message: S.optional(S.String), Code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Code: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceConflictException>()(
     "ResourceConflictException",
-    { Message: S.optional(S.String), Code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Code: S.optional(S.String),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ResourceInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUseException>()(
     "ResourceInUseException",
-    { Message: S.optional(S.String), Code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Code: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String), Code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Code: S.optional(S.String),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.optional(S.String), Code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Code: S.optional(S.String),
+    },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String), Code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Code: S.optional(S.String),
+    },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String), Code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Code: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type NonEmptyString = string;

--- a/packages/aws/src/services/securitylake.ts
+++ b/packages/aws/src/services/securitylake.ts
@@ -90,20 +90,23 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String), errorCode: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      errorCode: S.optional(S.String),
+    },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       resourceName: S.optional(S.String),
       resourceType: S.optional(S.String),
     },
@@ -112,14 +115,14 @@ export class ConflictException
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       resourceName: S.optional(S.String),
       resourceType: S.optional(S.String),
     },
@@ -129,7 +132,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       serviceCode: S.optional(S.String),
       quotaCode: S.optional(S.String),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
@@ -139,7 +142,7 @@ export class ThrottlingException
 export class UnauthorizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnauthorizedException>()(
     "UnauthorizedException",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAuthError) {}
 export type AwsAccountId = string;
 export type AccountList = string[];

--- a/packages/aws/src/services/serverlessapplicationrepository.ts
+++ b/packages/aws/src/services/serverlessapplicationrepository.ts
@@ -91,37 +91,55 @@ const rules = T.EndpointResolver((p, _) => {
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { ErrorCode: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      ErrorCode: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { ErrorCode: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      ErrorCode: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ForbiddenException
   extends /*@__PURE__*/ S.TaggedErrorClass<ForbiddenException>()(
     "ForbiddenException",
-    { ErrorCode: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      ErrorCode: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class InternalServerErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerErrorException>()(
     "InternalServerErrorException",
-    { ErrorCode: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      ErrorCode: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { ErrorCode: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      ErrorCode: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { ErrorCode: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      ErrorCode: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export type __listOf__string = string[];

--- a/packages/aws/src/services/service-catalog-appregistry.ts
+++ b/packages/aws/src/services/service-catalog-appregistry.ts
@@ -93,37 +93,40 @@ const rules = T.EndpointResolver((p, _) => {
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String), serviceCode: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      serviceCode: S.optional(S.String),
+    },
     T.HttpError(429),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type ApplicationSpecifier = string;

--- a/packages/aws/src/services/service-catalog.ts
+++ b/packages/aws/src/services/service-catalog.ts
@@ -87,32 +87,32 @@ const rules = T.EndpointResolver((p, _) => {
 export class DuplicateResourceException
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicateResourceException>()(
     "DuplicateResourceException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidParametersException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParametersException>()(
     "InvalidParametersException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidStateException>()(
     "InvalidStateException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class OperationNotSupportedException
   extends /*@__PURE__*/ S.TaggedErrorClass<OperationNotSupportedException>()(
     "OperationNotSupportedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ProvisionedProductNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<ProvisionedProductNotFound>()(
     "ProvisionedProductNotFound",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "ValidationException",
       message: { includes: "Provisioned product not found" },
@@ -121,17 +121,17 @@ export class ProvisionedProductNotFound
 export class ResourceInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUseException>()(
     "ResourceInUseException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TagOptionNotMigratedException
   extends /*@__PURE__*/ S.TaggedErrorClass<TagOptionNotMigratedException>()(
     "TagOptionNotMigratedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type AcceptLanguage = string;
 export type Id = string;

--- a/packages/aws/src/services/service-quotas.ts
+++ b/packages/aws/src/services/service-quotas.ts
@@ -91,103 +91,103 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class AWSServiceAccessNotEnabledException
   extends /*@__PURE__*/ S.TaggedErrorClass<AWSServiceAccessNotEnabledException>()(
     "AWSServiceAccessNotEnabledException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class DependencyAccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<DependencyAccessDeniedException>()(
     "DependencyAccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class IllegalArgumentException
   extends /*@__PURE__*/ S.TaggedErrorClass<IllegalArgumentException>()(
     "IllegalArgumentException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidPaginationTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPaginationTokenException>()(
     "InvalidPaginationTokenException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidResourceStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidResourceStateException>()(
     "InvalidResourceStateException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(405),
   ).pipe(C.withBadRequestError) {}
 export class NoAvailableOrganizationException
   extends /*@__PURE__*/ S.TaggedErrorClass<NoAvailableOrganizationException>()(
     "NoAvailableOrganizationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class NoSuchResourceException
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchResourceException>()(
     "NoSuchResourceException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class OrganizationNotInAllFeaturesModeException
   extends /*@__PURE__*/ S.TaggedErrorClass<OrganizationNotInAllFeaturesModeException>()(
     "OrganizationNotInAllFeaturesModeException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class QuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<QuotaExceededException>()(
     "QuotaExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ResourceAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceAlreadyExistsException>()(
     "ResourceAlreadyExistsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError, C.withAlreadyExistsError) {}
 export class ServiceException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceException>()(
     "ServiceException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ServiceQuotaTemplateNotInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaTemplateNotInUseException>()(
     "ServiceQuotaTemplateNotInUseException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TagPolicyViolationException
   extends /*@__PURE__*/ S.TaggedErrorClass<TagPolicyViolationException>()(
     "TagPolicyViolationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export class TemplatesNotAvailableInRegionException
   extends /*@__PURE__*/ S.TaggedErrorClass<TemplatesNotAvailableInRegionException>()(
     "TemplatesNotAvailableInRegionException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export interface AssociateServiceQuotaTemplateRequest {}

--- a/packages/aws/src/services/servicediscovery.ts
+++ b/packages/aws/src/services/servicediscovery.ts
@@ -97,14 +97,14 @@ const rules = T.EndpointResolver((p, _) => {
 export class CustomHealthNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<CustomHealthNotFound>()(
     "CustomHealthNotFound",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class DuplicateRequest
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicateRequest>()(
     "DuplicateRequest",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       DuplicateOperationId: S.optional(S.String),
     },
     T.HttpError(409),
@@ -112,20 +112,20 @@ export class DuplicateRequest
 export class InstanceNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<InstanceNotFound>()(
     "InstanceNotFound",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class InvalidInput
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInput>()(
     "InvalidInput",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class NamespaceAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<NamespaceAlreadyExists>()(
     "NamespaceAlreadyExists",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       CreatorRequestId: S.optional(S.String),
       NamespaceId: S.optional(S.String),
     },
@@ -134,44 +134,44 @@ export class NamespaceAlreadyExists
 export class NamespaceNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<NamespaceNotFound>()(
     "NamespaceNotFound",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class OperationNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<OperationNotFound>()(
     "OperationNotFound",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class RequestLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<RequestLimitExceeded>()(
     "RequestLimitExceeded",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ResourceInUse
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUse>()(
     "ResourceInUse",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withDependencyViolationError) {}
 export class ResourceLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceLimitExceeded>()(
     "ResourceLimitExceeded",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError, C.withThrottlingError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceAlreadyExists>()(
     "ServiceAlreadyExists",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       CreatorRequestId: S.optional(S.String),
       ServiceId: S.optional(S.String),
       ServiceArn: S.optional(S.String),
@@ -181,19 +181,22 @@ export class ServiceAlreadyExists
 export class ServiceAttributesLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceAttributesLimitExceededException>()(
     "ServiceAttributesLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ServiceNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceNotFound>()(
     "ServiceNotFound",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { Message: S.optional(S.String), ResourceName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ResourceName: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type NamespaceNameHttp = string;

--- a/packages/aws/src/services/ses.ts
+++ b/packages/aws/src/services/ses.ts
@@ -89,7 +89,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccountSendingPausedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccountSendingPausedException>()(
     "AccountSendingPausedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "AccountSendingPausedException",
@@ -101,7 +101,10 @@ export class AccountSendingPausedException
 export class AlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<AlreadyExistsException>()(
     "AlreadyExistsException",
-    { Name: S.optional(S.String), message: S.optional(S.String) },
+    {
+      Name: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.all(
       T.AwsQueryError({ code: "AlreadyExists", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -110,7 +113,10 @@ export class AlreadyExistsException
 export class CannotDeleteException
   extends /*@__PURE__*/ S.TaggedErrorClass<CannotDeleteException>()(
     "CannotDeleteException",
-    { Name: S.optional(S.String), message: S.optional(S.String) },
+    {
+      Name: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.all(
       T.AwsQueryError({ code: "CannotDelete", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -121,7 +127,7 @@ export class ConfigurationSetAlreadyExistsException
     "ConfigurationSetAlreadyExistsException",
     {
       ConfigurationSetName: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.all(
       T.AwsQueryError({
@@ -136,7 +142,7 @@ export class ConfigurationSetDoesNotExistException
     "ConfigurationSetDoesNotExistException",
     {
       ConfigurationSetName: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.all(
       T.AwsQueryError({
@@ -151,7 +157,7 @@ export class ConfigurationSetSendingPausedException
     "ConfigurationSetSendingPausedException",
     {
       ConfigurationSetName: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.all(
       T.AwsQueryError({
@@ -164,7 +170,7 @@ export class ConfigurationSetSendingPausedException
 export class CustomVerificationEmailInvalidContentException
   extends /*@__PURE__*/ S.TaggedErrorClass<CustomVerificationEmailInvalidContentException>()(
     "CustomVerificationEmailInvalidContentException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "CustomVerificationEmailInvalidContent",
@@ -178,7 +184,7 @@ export class CustomVerificationEmailTemplateAlreadyExistsException
     "CustomVerificationEmailTemplateAlreadyExistsException",
     {
       CustomVerificationEmailTemplateName: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.all(
       T.AwsQueryError({
@@ -193,7 +199,7 @@ export class CustomVerificationEmailTemplateDoesNotExistException
     "CustomVerificationEmailTemplateDoesNotExistException",
     {
       CustomVerificationEmailTemplateName: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.all(
       T.AwsQueryError({
@@ -209,7 +215,7 @@ export class EventDestinationAlreadyExistsException
     {
       ConfigurationSetName: S.optional(S.String),
       EventDestinationName: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.all(
       T.AwsQueryError({
@@ -225,7 +231,7 @@ export class EventDestinationDoesNotExistException
     {
       ConfigurationSetName: S.optional(S.String),
       EventDestinationName: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.all(
       T.AwsQueryError({
@@ -238,7 +244,10 @@ export class EventDestinationDoesNotExistException
 export class FromEmailAddressNotVerifiedException
   extends /*@__PURE__*/ S.TaggedErrorClass<FromEmailAddressNotVerifiedException>()(
     "FromEmailAddressNotVerifiedException",
-    { FromEmailAddress: S.optional(S.String), message: S.optional(S.String) },
+    {
+      FromEmailAddress: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.all(
       T.AwsQueryError({
         code: "FromEmailAddressNotVerified",
@@ -250,7 +259,7 @@ export class FromEmailAddressNotVerifiedException
 export class IdentityNotVerified
   extends /*@__PURE__*/ S.TaggedErrorClass<IdentityNotVerified>()(
     "IdentityNotVerified",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "InvalidParameterValue",
       message: { includes: "Identity is not verified" },
@@ -262,7 +271,7 @@ export class InvalidCloudWatchDestinationException
     {
       ConfigurationSetName: S.optional(S.String),
       EventDestinationName: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.all(
       T.AwsQueryError({
@@ -275,7 +284,7 @@ export class InvalidCloudWatchDestinationException
 export class InvalidConfigurationSetException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidConfigurationSetException>()(
     "InvalidConfigurationSetException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidConfigurationSet",
@@ -287,7 +296,7 @@ export class InvalidConfigurationSetException
 export class InvalidDeliveryOptionsException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDeliveryOptionsException>()(
     "InvalidDeliveryOptionsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidDeliveryOptions",
@@ -302,7 +311,7 @@ export class InvalidFirehoseDestinationException
     {
       ConfigurationSetName: S.optional(S.String),
       EventDestinationName: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.all(
       T.AwsQueryError({
@@ -315,7 +324,10 @@ export class InvalidFirehoseDestinationException
 export class InvalidLambdaFunctionException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidLambdaFunctionException>()(
     "InvalidLambdaFunctionException",
-    { FunctionArn: S.optional(S.String), message: S.optional(S.String) },
+    {
+      FunctionArn: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.all(
       T.AwsQueryError({ code: "InvalidLambdaFunction", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -324,12 +336,12 @@ export class InvalidLambdaFunctionException
 export class InvalidParameterValue
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterValue>()(
     "InvalidParameterValue",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidPolicyException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPolicyException>()(
     "InvalidPolicyException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidPolicy", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -338,7 +350,10 @@ export class InvalidPolicyException
 export class InvalidRenderingParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRenderingParameterException>()(
     "InvalidRenderingParameterException",
-    { TemplateName: S.optional(S.String), message: S.optional(S.String) },
+    {
+      TemplateName: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.all(
       T.AwsQueryError({
         code: "InvalidRenderingParameter",
@@ -350,7 +365,10 @@ export class InvalidRenderingParameterException
 export class InvalidS3ConfigurationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidS3ConfigurationException>()(
     "InvalidS3ConfigurationException",
-    { Bucket: S.optional(S.String), message: S.optional(S.String) },
+    {
+      Bucket: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.all(
       T.AwsQueryError({
         code: "InvalidS3Configuration",
@@ -365,7 +383,7 @@ export class InvalidSNSDestinationException
     {
       ConfigurationSetName: S.optional(S.String),
       EventDestinationName: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.all(
       T.AwsQueryError({ code: "InvalidSNSDestination", httpResponseCode: 400 }),
@@ -375,7 +393,10 @@ export class InvalidSNSDestinationException
 export class InvalidSnsTopicException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSnsTopicException>()(
     "InvalidSnsTopicException",
-    { Topic: S.optional(S.String), message: S.optional(S.String) },
+    {
+      Topic: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.all(
       T.AwsQueryError({ code: "InvalidSnsTopic", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -384,7 +405,10 @@ export class InvalidSnsTopicException
 export class InvalidTemplateException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTemplateException>()(
     "InvalidTemplateException",
-    { TemplateName: S.optional(S.String), message: S.optional(S.String) },
+    {
+      TemplateName: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.all(
       T.AwsQueryError({ code: "InvalidTemplate", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -393,7 +417,7 @@ export class InvalidTemplateException
 export class InvalidTrackingOptionsException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTrackingOptionsException>()(
     "InvalidTrackingOptionsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidTrackingOptions",
@@ -405,7 +429,7 @@ export class InvalidTrackingOptionsException
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "LimitExceeded", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -414,7 +438,7 @@ export class LimitExceededException
 export class MailFromDomainNotVerifiedException
   extends /*@__PURE__*/ S.TaggedErrorClass<MailFromDomainNotVerifiedException>()(
     "MailFromDomainNotVerifiedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "MailFromDomainNotVerifiedException",
@@ -426,7 +450,7 @@ export class MailFromDomainNotVerifiedException
 export class MessageRejected
   extends /*@__PURE__*/ S.TaggedErrorClass<MessageRejected>()(
     "MessageRejected",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "MessageRejected", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -435,7 +459,10 @@ export class MessageRejected
 export class MissingRenderingAttributeException
   extends /*@__PURE__*/ S.TaggedErrorClass<MissingRenderingAttributeException>()(
     "MissingRenderingAttributeException",
-    { TemplateName: S.optional(S.String), message: S.optional(S.String) },
+    {
+      TemplateName: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.all(
       T.AwsQueryError({
         code: "MissingRenderingAttribute",
@@ -447,7 +474,7 @@ export class MissingRenderingAttributeException
 export class ProductionAccessNotGrantedException
   extends /*@__PURE__*/ S.TaggedErrorClass<ProductionAccessNotGrantedException>()(
     "ProductionAccessNotGrantedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ProductionAccessNotGranted",
@@ -459,7 +486,10 @@ export class ProductionAccessNotGrantedException
 export class RuleDoesNotExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<RuleDoesNotExistException>()(
     "RuleDoesNotExistException",
-    { Name: S.optional(S.String), message: S.optional(S.String) },
+    {
+      Name: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.all(
       T.AwsQueryError({ code: "RuleDoesNotExist", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -468,7 +498,10 @@ export class RuleDoesNotExistException
 export class RuleSetDoesNotExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<RuleSetDoesNotExistException>()(
     "RuleSetDoesNotExistException",
-    { Name: S.optional(S.String), message: S.optional(S.String) },
+    {
+      Name: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.all(
       T.AwsQueryError({ code: "RuleSetDoesNotExist", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -477,7 +510,10 @@ export class RuleSetDoesNotExistException
 export class TemplateDoesNotExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<TemplateDoesNotExistException>()(
     "TemplateDoesNotExistException",
-    { TemplateName: S.optional(S.String), message: S.optional(S.String) },
+    {
+      TemplateName: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.all(
       T.AwsQueryError({ code: "TemplateDoesNotExist", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -488,7 +524,7 @@ export class TrackingOptionsAlreadyExistsException
     "TrackingOptionsAlreadyExistsException",
     {
       ConfigurationSetName: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.all(
       T.AwsQueryError({
@@ -503,7 +539,7 @@ export class TrackingOptionsDoesNotExistException
     "TrackingOptionsDoesNotExistException",
     {
       ConfigurationSetName: S.optional(S.String),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.all(
       T.AwsQueryError({

--- a/packages/aws/src/services/sesv2.ts
+++ b/packages/aws/src/services/sesv2.ts
@@ -139,79 +139,79 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccountSuspendedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccountSuspendedException>()(
     "AccountSuspendedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class AlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<AlreadyExistsException>()(
     "AlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError, C.withAlreadyExistsError) {}
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ConcurrentModificationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentModificationException>()(
     "ConcurrentModificationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServiceErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServiceErrorException>()(
     "InternalServiceErrorException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidNextTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNextTokenException>()(
     "InvalidNextTokenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class MailFromDomainNotVerifiedException
   extends /*@__PURE__*/ S.TaggedErrorClass<MailFromDomainNotVerifiedException>()(
     "MailFromDomainNotVerifiedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class MessageRejected
   extends /*@__PURE__*/ S.TaggedErrorClass<MessageRejected>()(
     "MessageRejected",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class SendingPausedException
   extends /*@__PURE__*/ S.TaggedErrorClass<SendingPausedException>()(
     "SendingPausedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export type QueryIdentifier = string;

--- a/packages/aws/src/services/sfn.ts
+++ b/packages/aws/src/services/sfn.ts
@@ -109,94 +109,94 @@ const rules = T.EndpointResolver((p, _) => {
 export class ActivityAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<ActivityAlreadyExists>()(
     "ActivityAlreadyExists",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class ActivityDoesNotExist
   extends /*@__PURE__*/ S.TaggedErrorClass<ActivityDoesNotExist>()(
     "ActivityDoesNotExist",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ActivityLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<ActivityLimitExceeded>()(
     "ActivityLimitExceeded",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withThrottlingError) {}
 export class ActivityWorkerLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<ActivityWorkerLimitExceeded>()(
     "ActivityWorkerLimitExceeded",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withThrottlingError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ExecutionAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<ExecutionAlreadyExists>()(
     "ExecutionAlreadyExists",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class ExecutionDoesNotExist
   extends /*@__PURE__*/ S.TaggedErrorClass<ExecutionDoesNotExist>()(
     "ExecutionDoesNotExist",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ExecutionLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<ExecutionLimitExceeded>()(
     "ExecutionLimitExceeded",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withThrottlingError) {}
 export class ExecutionNotRedrivable
   extends /*@__PURE__*/ S.TaggedErrorClass<ExecutionNotRedrivable>()(
     "ExecutionNotRedrivable",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidArn
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidArn>()("InvalidArn", {
-    message: S.optional(S.String),
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
   }) {}
 export class InvalidDefinition
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDefinition>()(
     "InvalidDefinition",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidEncryptionConfiguration
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidEncryptionConfiguration>()(
     "InvalidEncryptionConfiguration",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidExecutionInput
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidExecutionInput>()(
     "InvalidExecutionInput",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidLoggingConfiguration
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidLoggingConfiguration>()(
     "InvalidLoggingConfiguration",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidName
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidName>()("InvalidName", {
-    message: S.optional(S.String),
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
   }) {}
 export class InvalidOutput
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidOutput>()("InvalidOutput", {
-    message: S.optional(S.String),
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
   }) {}
 export class InvalidToken
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidToken>()("InvalidToken", {
-    message: S.optional(S.String),
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
   }) {}
 export class InvalidTracingConfiguration
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTracingConfiguration>()(
     "InvalidTracingConfiguration",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class KmsAccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<KmsAccessDeniedException>()(
     "KmsAccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAuthError) {}
 export class KmsInvalidStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<KmsInvalidStateException>()(
@@ -205,76 +205,82 @@ export class KmsInvalidStateException
       kmsKeyState: S.optional(
         S.suspend(() => KmsKeyState).annotate({ identifier: "KmsKeyState" }),
       ),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
   ) {}
 export class KmsThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<KmsThrottlingException>()(
     "KmsThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MissingRequiredParameter
   extends /*@__PURE__*/ S.TaggedErrorClass<MissingRequiredParameter>()(
     "MissingRequiredParameter",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFound>()(
     "ResourceNotFound",
-    { message: S.optional(S.String), resourceName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      resourceName: S.optional(S.String),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class StateMachineAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<StateMachineAlreadyExists>()(
     "StateMachineAlreadyExists",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class StateMachineDeleting
   extends /*@__PURE__*/ S.TaggedErrorClass<StateMachineDeleting>()(
     "StateMachineDeleting",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class StateMachineDoesNotExist
   extends /*@__PURE__*/ S.TaggedErrorClass<StateMachineDoesNotExist>()(
     "StateMachineDoesNotExist",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class StateMachineLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<StateMachineLimitExceeded>()(
     "StateMachineLimitExceeded",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withThrottlingError) {}
 export class StateMachineTypeNotSupported
   extends /*@__PURE__*/ S.TaggedErrorClass<StateMachineTypeNotSupported>()(
     "StateMachineTypeNotSupported",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TaskDoesNotExist
   extends /*@__PURE__*/ S.TaggedErrorClass<TaskDoesNotExist>()(
     "TaskDoesNotExist",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TaskTimedOut
   extends /*@__PURE__*/ S.TaggedErrorClass<TaskTimedOut>()("TaskTimedOut", {
-    message: S.optional(S.String),
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
   }) {}
 export class TooManyTags
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTags>()(
     "TooManyTags",
-    { message: S.optional(S.String), resourceName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      resourceName: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       reason: S.optional(
         S.suspend(() => ValidationExceptionReason).annotate({
           identifier: "ValidationExceptionReason",

--- a/packages/aws/src/services/shield.ts
+++ b/packages/aws/src/services/shield.ts
@@ -108,33 +108,33 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAuthError) {}
 export class AccessDeniedForDependencyException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedForDependencyException>()(
     "AccessDeniedForDependencyException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAuthError) {}
 export class InternalErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalErrorException>()(
     "InternalErrorException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withServerError) {}
 export class InvalidOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidOperationException>()(
     "InvalidOperationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidPaginationTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPaginationTokenException>()(
     "InvalidPaginationTokenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterException>()(
     "InvalidParameterException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       reason: S.optional(
         S.suspend(() => ValidationExceptionReason).annotate({
           identifier: "ValidationExceptionReason",
@@ -150,13 +150,13 @@ export class InvalidParameterException
 export class InvalidResourceException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidResourceException>()(
     "InvalidResourceException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LimitsExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitsExceededException>()(
     "LimitsExceededException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Type: S.optional(S.String),
       Limit: S.optional(S.Number),
     },
@@ -164,32 +164,41 @@ export class LimitsExceededException
 export class LockedSubscriptionException
   extends /*@__PURE__*/ S.TaggedErrorClass<LockedSubscriptionException>()(
     "LockedSubscriptionException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NoAssociatedRoleException
   extends /*@__PURE__*/ S.TaggedErrorClass<NoAssociatedRoleException>()(
     "NoAssociatedRoleException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class OptimisticLockException
   extends /*@__PURE__*/ S.TaggedErrorClass<OptimisticLockException>()(
     "OptimisticLockException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceAlreadyExistsException>()(
     "ResourceAlreadyExistsException",
-    { message: S.optional(S.String), resourceType: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      resourceType: S.optional(S.String),
+    },
   ).pipe(C.withAlreadyExistsError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String), resourceType: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      resourceType: S.optional(S.String),
+    },
   ) {}
 export class SubscriptionNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<SubscriptionNotFound>()(
     "SubscriptionNotFound",
-    { message: S.optional(S.String), resourceType: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      resourceType: S.optional(S.String),
+    },
     T.SyntheticError({
       from: "ResourceNotFoundException",
       message: "The subscription does not exist.",

--- a/packages/aws/src/services/signer-data.ts
+++ b/packages/aws/src/services/signer-data.ts
@@ -57,25 +57,37 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String), code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      code: S.optional(S.String),
+    },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class InternalServiceErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServiceErrorException>()(
     "InternalServiceErrorException",
-    { message: S.optional(S.String), code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      code: S.optional(S.String),
+    },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { message: S.optional(S.String), code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      code: S.optional(S.String),
+    },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String), code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      code: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type PlatformId = string;

--- a/packages/aws/src/services/signer.ts
+++ b/packages/aws/src/services/signer.ts
@@ -88,49 +88,73 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String), code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      code: S.optional(S.String),
+    },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { message: S.optional(S.String), code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      code: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String), code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      code: S.optional(S.String),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServiceErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServiceErrorException>()(
     "InternalServiceErrorException",
-    { message: S.optional(S.String), code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      code: S.optional(S.String),
+    },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { message: S.optional(S.String), code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      code: S.optional(S.String),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String), code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      code: S.optional(S.String),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceLimitExceededException>()(
     "ServiceLimitExceededException",
-    { message: S.optional(S.String), code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      code: S.optional(S.String),
+    },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class SigningProfileAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<SigningProfileAlreadyExists>()(
     "SigningProfileAlreadyExists",
-    { message: S.optional(S.String), code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      code: S.optional(S.String),
+    },
     T.SyntheticError({
       from: "ValidationException",
       message: { includes: "already exists" },
@@ -139,19 +163,28 @@ export class SigningProfileAlreadyExists
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String), code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      code: S.optional(S.String),
+    },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { message: S.optional(S.String), code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      code: S.optional(S.String),
+    },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String), code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      code: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type ProfileName = string;

--- a/packages/aws/src/services/signin.ts
+++ b/packages/aws/src/services/signin.ts
@@ -299,7 +299,7 @@ export class AccessDeniedException
       error: S.suspend(() => OAuth2ErrorCode).annotate({
         identifier: "OAuth2ErrorCode",
       }),
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
     },
   ).pipe(C.withAuthError) {}
 export class ConflictException
@@ -309,7 +309,7 @@ export class ConflictException
       error: S.suspend(() => OAuth2ErrorCode).annotate({
         identifier: "OAuth2ErrorCode",
       }),
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
     },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
@@ -320,7 +320,7 @@ export class InternalServerException
       error: S.suspend(() => OAuth2ErrorCode).annotate({
         identifier: "OAuth2ErrorCode",
       }),
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
     },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
@@ -331,7 +331,7 @@ export class ResourceNotFoundException
       error: S.suspend(() => OAuth2ErrorCode).annotate({
         identifier: "OAuth2ErrorCode",
       }),
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
     },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
@@ -342,7 +342,7 @@ export class ServiceQuotaExceededException
       error: S.suspend(() => OAuth2ErrorCode).annotate({
         identifier: "OAuth2ErrorCode",
       }),
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
     },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
@@ -353,7 +353,7 @@ export class TooManyRequestsError
       error: S.suspend(() => OAuth2ErrorCode).annotate({
         identifier: "OAuth2ErrorCode",
       }),
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
     },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
@@ -364,7 +364,7 @@ export class ValidationException
       error: S.suspend(() => OAuth2ErrorCode).annotate({
         identifier: "OAuth2ErrorCode",
       }),
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
     },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}

--- a/packages/aws/src/services/simpledb.ts
+++ b/packages/aws/src/services/simpledb.ts
@@ -52,96 +52,147 @@ const rules = T.EndpointResolver((p, _) => {
 export class AttributeDoesNotExist
   extends /*@__PURE__*/ S.TaggedErrorClass<AttributeDoesNotExist>()(
     "AttributeDoesNotExist",
-    { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      BoxUsage: S.optional(S.String),
+    },
   ).pipe(C.withNotFoundError) {}
 export class DuplicateItemName
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicateItemName>()(
     "DuplicateItemName",
-    { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      BoxUsage: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidNextToken
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNextToken>()(
     "InvalidNextToken",
-    { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      BoxUsage: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidNumberPredicates
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNumberPredicates>()(
     "InvalidNumberPredicates",
-    { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      BoxUsage: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidNumberValueTests
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNumberValueTests>()(
     "InvalidNumberValueTests",
-    { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      BoxUsage: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidParameterValue
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterValue>()(
     "InvalidParameterValue",
-    { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      BoxUsage: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidQueryExpression
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidQueryExpression>()(
     "InvalidQueryExpression",
-    { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      BoxUsage: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class MissingParameter
   extends /*@__PURE__*/ S.TaggedErrorClass<MissingParameter>()(
     "MissingParameter",
-    { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      BoxUsage: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class NoSuchDomain
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchDomain>()(
     "NoSuchDomain",
-    { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      BoxUsage: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError, C.withNotFoundError) {}
 export class NumberDomainAttributesExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<NumberDomainAttributesExceeded>()(
     "NumberDomainAttributesExceeded",
-    { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      BoxUsage: S.optional(S.String),
+    },
   ).pipe(C.withQuotaError) {}
 export class NumberDomainBytesExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<NumberDomainBytesExceeded>()(
     "NumberDomainBytesExceeded",
-    { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      BoxUsage: S.optional(S.String),
+    },
   ).pipe(C.withQuotaError) {}
 export class NumberDomainsExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<NumberDomainsExceeded>()(
     "NumberDomainsExceeded",
-    { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      BoxUsage: S.optional(S.String),
+    },
   ).pipe(C.withQuotaError) {}
 export class NumberItemAttributesExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<NumberItemAttributesExceeded>()(
     "NumberItemAttributesExceeded",
-    { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      BoxUsage: S.optional(S.String),
+    },
   ).pipe(C.withQuotaError) {}
 export class NumberSubmittedAttributesExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<NumberSubmittedAttributesExceeded>()(
     "NumberSubmittedAttributesExceeded",
-    { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      BoxUsage: S.optional(S.String),
+    },
   ).pipe(C.withQuotaError) {}
 export class NumberSubmittedItemsExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<NumberSubmittedItemsExceeded>()(
     "NumberSubmittedItemsExceeded",
-    { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      BoxUsage: S.optional(S.String),
+    },
   ).pipe(C.withQuotaError) {}
 export class RequestTimeout
   extends /*@__PURE__*/ S.TaggedErrorClass<RequestTimeout>()(
     "RequestTimeout",
-    { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      BoxUsage: S.optional(S.String),
+    },
     T.HttpError(408),
   ).pipe(C.withTimeoutError) {}
 export class TooManyRequestedAttributes
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestedAttributes>()(
     "TooManyRequestedAttributes",
-    { message: S.optional(S.String), BoxUsage: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      BoxUsage: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type DomainName = string;

--- a/packages/aws/src/services/simpledbv2.ts
+++ b/packages/aws/src/services/simpledbv2.ts
@@ -95,43 +95,43 @@ const rules = T.EndpointResolver((p, _) => {
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidNextTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNextTokenException>()(
     "InvalidNextTokenException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidParameterCombinationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterCombinationException>()(
     "InvalidParameterCombinationException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidParameterValueException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterValueException>()(
     "InvalidParameterValueException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class NoSuchDomainException
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchDomainException>()(
     "NoSuchDomainException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class NoSuchExportException
   extends /*@__PURE__*/ S.TaggedErrorClass<NoSuchExportException>()(
     "NoSuchExportException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class NumberExportsLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<NumberExportsLimitExceeded>()(
     "NumberExportsLimitExceeded",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withThrottlingError) {}
 export type ExportArn = string;

--- a/packages/aws/src/services/simspaceweaver.ts
+++ b/packages/aws/src/services/simspaceweaver.ts
@@ -90,43 +90,43 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type SimSpaceWeaverResourceName = string;

--- a/packages/aws/src/services/snow-device-management.ts
+++ b/packages/aws/src/services/snow-device-management.ts
@@ -88,37 +88,37 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(429), T.Retryable({ throttling: true })),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type TaskId = string;

--- a/packages/aws/src/services/snowball.ts
+++ b/packages/aws/src/services/snowball.ts
@@ -90,57 +90,63 @@ const rules = T.EndpointResolver((p, _) => {
 export class ClusterLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ClusterLimitExceededException>()(
     "ClusterLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { ConflictResource: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      ConflictResource: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
   ) {}
 export class Ec2RequestFailedException
   extends /*@__PURE__*/ S.TaggedErrorClass<Ec2RequestFailedException>()(
     "Ec2RequestFailedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidAddressException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidAddressException>()(
     "InvalidAddressException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidInputCombinationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInputCombinationException>()(
     "InvalidInputCombinationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidJobStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidJobStateException>()(
     "InvalidJobStateException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidNextTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNextTokenException>()(
     "InvalidNextTokenException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidResourceException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidResourceException>()(
     "InvalidResourceException",
-    { Message: S.optional(S.String), ResourceType: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ResourceType: S.optional(S.String),
+    },
   ) {}
 export class KMSRequestFailedException
   extends /*@__PURE__*/ S.TaggedErrorClass<KMSRequestFailedException>()(
     "KMSRequestFailedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ReturnShippingLabelAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ReturnShippingLabelAlreadyExistsException>()(
     "ReturnShippingLabelAlreadyExistsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class UnsupportedAddressException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedAddressException>()(
     "UnsupportedAddressException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type ClusterId = string;
 export interface CancelClusterRequest {

--- a/packages/aws/src/services/sns.ts
+++ b/packages/aws/src/services/sns.ts
@@ -97,7 +97,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class AuthorizationErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<AuthorizationErrorException>()(
     "AuthorizationErrorException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "AuthorizationError", httpResponseCode: 403 }),
       T.HttpError(403),
@@ -106,7 +106,7 @@ export class AuthorizationErrorException
 export class BatchEntryIdsNotDistinctException
   extends /*@__PURE__*/ S.TaggedErrorClass<BatchEntryIdsNotDistinctException>()(
     "BatchEntryIdsNotDistinctException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "BatchEntryIdsNotDistinct",
@@ -118,7 +118,7 @@ export class BatchEntryIdsNotDistinctException
 export class BatchRequestTooLongException
   extends /*@__PURE__*/ S.TaggedErrorClass<BatchRequestTooLongException>()(
     "BatchRequestTooLongException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "BatchRequestTooLong", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -127,7 +127,7 @@ export class BatchRequestTooLongException
 export class ConcurrentAccessException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentAccessException>()(
     "ConcurrentAccessException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ConcurrentAccess", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -136,7 +136,7 @@ export class ConcurrentAccessException
 export class EmptyBatchRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<EmptyBatchRequestException>()(
     "EmptyBatchRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "EmptyBatchRequest", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -145,7 +145,7 @@ export class EmptyBatchRequestException
 export class EndpointDisabledException
   extends /*@__PURE__*/ S.TaggedErrorClass<EndpointDisabledException>()(
     "EndpointDisabledException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "EndpointDisabled", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -154,7 +154,7 @@ export class EndpointDisabledException
 export class FilterPolicyLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<FilterPolicyLimitExceededException>()(
     "FilterPolicyLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "FilterPolicyLimitExceeded",
@@ -166,7 +166,7 @@ export class FilterPolicyLimitExceededException
 export class InternalErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalErrorException>()(
     "InternalErrorException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InternalError", httpResponseCode: 500 }),
       T.HttpError(500),
@@ -175,7 +175,7 @@ export class InternalErrorException
 export class InvalidBatchEntryIdException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidBatchEntryIdException>()(
     "InvalidBatchEntryIdException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidBatchEntryId", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -184,12 +184,12 @@ export class InvalidBatchEntryIdException
 export class InvalidClientTokenId
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidClientTokenId>()(
     "InvalidClientTokenId",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAuthError) {}
 export class InvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterException>()(
     "InvalidParameterException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidParameter", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -198,7 +198,7 @@ export class InvalidParameterException
 export class InvalidParameterValueException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterValueException>()(
     "InvalidParameterValueException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ParameterValueInvalid", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -207,7 +207,7 @@ export class InvalidParameterValueException
 export class InvalidSecurityException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSecurityException>()(
     "InvalidSecurityException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidSecurity", httpResponseCode: 403 }),
       T.HttpError(403),
@@ -216,7 +216,7 @@ export class InvalidSecurityException
 export class InvalidStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidStateException>()(
     "InvalidStateException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidState", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -225,7 +225,7 @@ export class InvalidStateException
 export class KMSAccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<KMSAccessDeniedException>()(
     "KMSAccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "KMSAccessDenied", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -234,7 +234,7 @@ export class KMSAccessDeniedException
 export class KMSDisabledException
   extends /*@__PURE__*/ S.TaggedErrorClass<KMSDisabledException>()(
     "KMSDisabledException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "KMSDisabled", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -243,7 +243,7 @@ export class KMSDisabledException
 export class KMSInvalidStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<KMSInvalidStateException>()(
     "KMSInvalidStateException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "KMSInvalidState", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -252,7 +252,7 @@ export class KMSInvalidStateException
 export class KMSNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<KMSNotFoundException>()(
     "KMSNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "KMSNotFound", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -261,7 +261,7 @@ export class KMSNotFoundException
 export class KMSOptInRequired
   extends /*@__PURE__*/ S.TaggedErrorClass<KMSOptInRequired>()(
     "KMSOptInRequired",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "KMSOptInRequired", httpResponseCode: 403 }),
       T.HttpError(403),
@@ -270,7 +270,7 @@ export class KMSOptInRequired
 export class KMSThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<KMSThrottlingException>()(
     "KMSThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "KMSThrottling", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -279,7 +279,7 @@ export class KMSThrottlingException
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "NotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -288,7 +288,7 @@ export class NotFoundException
 export class OptedOutException
   extends /*@__PURE__*/ S.TaggedErrorClass<OptedOutException>()(
     "OptedOutException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "OptedOut", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -297,7 +297,7 @@ export class OptedOutException
 export class PlatformApplicationDisabledException
   extends /*@__PURE__*/ S.TaggedErrorClass<PlatformApplicationDisabledException>()(
     "PlatformApplicationDisabledException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "PlatformApplicationDisabled",
@@ -309,7 +309,7 @@ export class PlatformApplicationDisabledException
 export class ReplayLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ReplayLimitExceededException>()(
     "ReplayLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ReplayLimitExceeded", httpResponseCode: 403 }),
       T.HttpError(403),
@@ -318,12 +318,12 @@ export class ReplayLimitExceededException
 export class RequestLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<RequestLimitExceeded>()(
     "RequestLimitExceeded",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withThrottlingError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ResourceNotFound", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -332,7 +332,7 @@ export class ResourceNotFoundException
 export class StaleTagException
   extends /*@__PURE__*/ S.TaggedErrorClass<StaleTagException>()(
     "StaleTagException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "StaleTag", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -341,7 +341,7 @@ export class StaleTagException
 export class SubscriptionLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<SubscriptionLimitExceededException>()(
     "SubscriptionLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SubscriptionLimitExceeded",
@@ -353,7 +353,7 @@ export class SubscriptionLimitExceededException
 export class TagLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<TagLimitExceededException>()(
     "TagLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "TagLimitExceeded", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -362,7 +362,7 @@ export class TagLimitExceededException
 export class TagPolicyException
   extends /*@__PURE__*/ S.TaggedErrorClass<TagPolicyException>()(
     "TagPolicyException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "TagPolicy", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -371,7 +371,7 @@ export class TagPolicyException
 export class ThrottledException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottledException>()(
     "ThrottledException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "Throttled", httpResponseCode: 429 }),
       T.HttpError(429),
@@ -380,7 +380,7 @@ export class ThrottledException
 export class TooManyEntriesInBatchRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyEntriesInBatchRequestException>()(
     "TooManyEntriesInBatchRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "TooManyEntriesInBatchRequest",
@@ -392,7 +392,7 @@ export class TooManyEntriesInBatchRequestException
 export class TopicLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<TopicLimitExceededException>()(
     "TopicLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "TopicLimitExceeded", httpResponseCode: 403 }),
       T.HttpError(403),
@@ -401,7 +401,7 @@ export class TopicLimitExceededException
 export class UserErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<UserErrorException>()(
     "UserErrorException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "UserError", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -410,7 +410,7 @@ export class UserErrorException
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ValidationException", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -419,7 +419,7 @@ export class ValidationException
 export class VerificationException
   extends /*@__PURE__*/ S.TaggedErrorClass<VerificationException>()(
     "VerificationException",
-    { Message: S.String, Status: S.String },
+    { message: S.String.pipe(T.ErrorMessage()), Status: S.String },
   ) {}
 export type TopicARN = string;
 export type Label = string;

--- a/packages/aws/src/services/socialmessaging.ts
+++ b/packages/aws/src/services/socialmessaging.ts
@@ -90,43 +90,43 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedByMetaException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedByMetaException>()(
     "AccessDeniedByMetaException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class DependencyException
   extends /*@__PURE__*/ S.TaggedErrorClass<DependencyException>()(
     "DependencyException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(502), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class InternalServiceException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServiceException>()(
     "InternalServiceException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class InvalidParametersException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParametersException>()(
     "InvalidParametersException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ThrottledRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottledRequestException>()(
     "ThrottledRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(429), T.Retryable()),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export interface WhatsAppSignupCallback {

--- a/packages/aws/src/services/sqs.ts
+++ b/packages/aws/src/services/sqs.ts
@@ -88,7 +88,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class BatchEntryIdsNotDistinct
   extends /*@__PURE__*/ S.TaggedErrorClass<BatchEntryIdsNotDistinct>()(
     "BatchEntryIdsNotDistinct",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "AWS.SimpleQueueService.BatchEntryIdsNotDistinct",
@@ -100,7 +100,7 @@ export class BatchEntryIdsNotDistinct
 export class BatchRequestTooLong
   extends /*@__PURE__*/ S.TaggedErrorClass<BatchRequestTooLong>()(
     "BatchRequestTooLong",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "AWS.SimpleQueueService.BatchRequestTooLong",
@@ -112,12 +112,12 @@ export class BatchRequestTooLong
 export class CommonServiceException
   extends /*@__PURE__*/ S.TaggedErrorClass<CommonServiceException>()(
     "CommonServiceException",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withServerError) {}
 export class EmptyBatchRequest
   extends /*@__PURE__*/ S.TaggedErrorClass<EmptyBatchRequest>()(
     "EmptyBatchRequest",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "AWS.SimpleQueueService.EmptyBatchRequest",
@@ -129,7 +129,7 @@ export class EmptyBatchRequest
 export class InvalidAddress
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidAddress>()(
     "InvalidAddress",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidAddress", httpResponseCode: 404 }),
       T.HttpError(404),
@@ -138,17 +138,17 @@ export class InvalidAddress
 export class InvalidAttributeName
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidAttributeName>()(
     "InvalidAttributeName",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class InvalidAttributeValue
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidAttributeValue>()(
     "InvalidAttributeValue",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class InvalidBatchEntryId
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidBatchEntryId>()(
     "InvalidBatchEntryId",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "AWS.SimpleQueueService.InvalidBatchEntryId",
@@ -160,22 +160,22 @@ export class InvalidBatchEntryId
 export class InvalidIdFormat
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidIdFormat>()(
     "InvalidIdFormat",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class InvalidMessageContents
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidMessageContents>()(
     "InvalidMessageContents",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class InvalidParameterValueException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterValueException>()(
     "InvalidParameterValueException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class InvalidSecurity
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSecurity>()(
     "InvalidSecurity",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidSecurity", httpResponseCode: 403 }),
       T.HttpError(403),
@@ -184,7 +184,7 @@ export class InvalidSecurity
 export class KmsAccessDenied
   extends /*@__PURE__*/ S.TaggedErrorClass<KmsAccessDenied>()(
     "KmsAccessDenied",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "KMS.AccessDeniedException",
@@ -196,7 +196,7 @@ export class KmsAccessDenied
 export class KmsDisabled
   extends /*@__PURE__*/ S.TaggedErrorClass<KmsDisabled>()(
     "KmsDisabled",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "KMS.DisabledException", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -205,7 +205,7 @@ export class KmsDisabled
 export class KmsInvalidKeyUsage
   extends /*@__PURE__*/ S.TaggedErrorClass<KmsInvalidKeyUsage>()(
     "KmsInvalidKeyUsage",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "KMS.InvalidKeyUsageException",
@@ -217,7 +217,7 @@ export class KmsInvalidKeyUsage
 export class KmsInvalidState
   extends /*@__PURE__*/ S.TaggedErrorClass<KmsInvalidState>()(
     "KmsInvalidState",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "KMS.InvalidStateException",
@@ -229,7 +229,7 @@ export class KmsInvalidState
 export class KmsNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<KmsNotFound>()(
     "KmsNotFound",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "KMS.NotFoundException", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -238,7 +238,7 @@ export class KmsNotFound
 export class KmsOptInRequired
   extends /*@__PURE__*/ S.TaggedErrorClass<KmsOptInRequired>()(
     "KmsOptInRequired",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "KMS.OptInRequired", httpResponseCode: 403 }),
       T.HttpError(403),
@@ -247,7 +247,7 @@ export class KmsOptInRequired
 export class KmsThrottled
   extends /*@__PURE__*/ S.TaggedErrorClass<KmsThrottled>()(
     "KmsThrottled",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "KMS.ThrottlingException",
@@ -259,7 +259,7 @@ export class KmsThrottled
 export class MessageNotInflight
   extends /*@__PURE__*/ S.TaggedErrorClass<MessageNotInflight>()(
     "MessageNotInflight",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "AWS.SimpleQueueService.MessageNotInflight",
@@ -271,23 +271,25 @@ export class MessageNotInflight
 export class MissingRequiredParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<MissingRequiredParameterException>()(
     "MissingRequiredParameterException",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class OverLimit
   extends /*@__PURE__*/ S.TaggedErrorClass<OverLimit>()(
     "OverLimit",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "OverLimit", httpResponseCode: 403 }),
       T.HttpError(403),
     ),
   ).pipe(C.withAuthError, C.withQuotaError) {}
 export class ParseError
-  extends /*@__PURE__*/ S.TaggedErrorClass<ParseError>()("ParseError", {}) {}
+  extends /*@__PURE__*/ S.TaggedErrorClass<ParseError>()("ParseError", {
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
+  }) {}
 export class PurgeQueueInProgress
   extends /*@__PURE__*/ S.TaggedErrorClass<PurgeQueueInProgress>()(
     "PurgeQueueInProgress",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "AWS.SimpleQueueService.PurgeQueueInProgress",
@@ -299,7 +301,7 @@ export class PurgeQueueInProgress
 export class QueueDeletedRecently
   extends /*@__PURE__*/ S.TaggedErrorClass<QueueDeletedRecently>()(
     "QueueDeletedRecently",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "AWS.SimpleQueueService.QueueDeletedRecently",
@@ -311,7 +313,7 @@ export class QueueDeletedRecently
 export class QueueDoesNotExist
   extends /*@__PURE__*/ S.TaggedErrorClass<QueueDoesNotExist>()(
     "QueueDoesNotExist",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "AWS.SimpleQueueService.NonExistentQueue",
@@ -323,7 +325,7 @@ export class QueueDoesNotExist
 export class QueueNameExists
   extends /*@__PURE__*/ S.TaggedErrorClass<QueueNameExists>()(
     "QueueNameExists",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "QueueAlreadyExists", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -332,7 +334,7 @@ export class QueueNameExists
 export class ReceiptHandleIsInvalid
   extends /*@__PURE__*/ S.TaggedErrorClass<ReceiptHandleIsInvalid>()(
     "ReceiptHandleIsInvalid",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ReceiptHandleIsInvalid",
@@ -344,12 +346,12 @@ export class ReceiptHandleIsInvalid
 export class RequestLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<RequestLimitExceeded>()(
     "RequestLimitExceeded",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withThrottlingError) {}
 export class RequestThrottled
   extends /*@__PURE__*/ S.TaggedErrorClass<RequestThrottled>()(
     "RequestThrottled",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "RequestThrottled", httpResponseCode: 403 }),
       T.HttpError(403),
@@ -358,7 +360,7 @@ export class RequestThrottled
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ResourceNotFoundException",
@@ -370,7 +372,7 @@ export class ResourceNotFoundException
 export class TooManyEntriesInBatchRequest
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyEntriesInBatchRequest>()(
     "TooManyEntriesInBatchRequest",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "AWS.SimpleQueueService.TooManyEntriesInBatchRequest",
@@ -382,7 +384,7 @@ export class TooManyEntriesInBatchRequest
 export class UnsupportedOperation
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedOperation>()(
     "UnsupportedOperation",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "AWS.SimpleQueueService.UnsupportedOperation",

--- a/packages/aws/src/services/ssm-contacts.ts
+++ b/packages/aws/src/services/ssm-contacts.ts
@@ -88,14 +88,14 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       ResourceId: S.String,
       ResourceType: S.String,
       DependentEntities: S.optional(
@@ -109,14 +109,14 @@ export class ConflictException
 export class DataEncryptionException
   extends /*@__PURE__*/ S.TaggedErrorClass<DataEncryptionException>()(
     "DataEncryptionException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class IncidentManagerNotOnboarded
   extends /*@__PURE__*/ S.TaggedErrorClass<IncidentManagerNotOnboarded>()(
     "IncidentManagerNotOnboarded",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => ValidationExceptionReason).annotate({
           identifier: "ValidationExceptionReason",
@@ -137,7 +137,7 @@ export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       RetryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.HttpError(500),
@@ -146,7 +146,7 @@ export class InvalidRotationArn
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRotationArn>()(
     "InvalidRotationArn",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => ValidationExceptionReason).annotate({
           identifier: "ValidationExceptionReason",
@@ -166,14 +166,18 @@ export class InvalidRotationArn
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.String, ResourceId: S.String, ResourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      ResourceId: S.String,
+      ResourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       ResourceId: S.optional(S.String),
       ResourceType: S.optional(S.String),
       QuotaCode: S.String,
@@ -185,7 +189,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       QuotaCode: S.optional(S.String),
       ServiceCode: S.optional(S.String),
       RetryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
@@ -196,7 +200,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => ValidationExceptionReason).annotate({
           identifier: "ValidationExceptionReason",

--- a/packages/aws/src/services/ssm-guiconnect.ts
+++ b/packages/aws/src/services/ssm-guiconnect.ts
@@ -87,43 +87,43 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type ClientToken = string;

--- a/packages/aws/src/services/ssm-incidents.ts
+++ b/packages/aws/src/services/ssm-incidents.ts
@@ -88,14 +88,14 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceIdentifier: S.optional(S.String),
       resourceType: S.optional(S.String),
       retryAfter: S.optional(S.Date.pipe(T.TimestampFormat("epoch-seconds"))),
@@ -105,14 +105,14 @@ export class ConflictException
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceIdentifier: S.optional(S.String),
       resourceType: S.optional(S.String),
     },
@@ -122,7 +122,7 @@ export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceIdentifier: S.optional(S.String),
       resourceType: S.optional(S.String),
       serviceCode: S.String,
@@ -133,18 +133,22 @@ export class ServiceQuotaExceededException
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.String, serviceCode: S.String, quotaCode: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      serviceCode: S.String,
+      quotaCode: S.String,
+    },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class UnsupportedOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedOperationException>()(
     "UnsupportedOperationException",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withBadRequestError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type Arn = string;

--- a/packages/aws/src/services/ssm-quicksetup.ts
+++ b/packages/aws/src/services/ssm-quicksetup.ts
@@ -88,37 +88,37 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(429), T.Retryable()),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type ConfigurationParametersMap = { [key: string]: string | undefined };

--- a/packages/aws/src/services/ssm-sap.ts
+++ b/packages/aws/src/services/ssm-sap.ts
@@ -87,31 +87,31 @@ const rules = T.EndpointResolver((p, _) => {
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class UnauthorizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnauthorizedException>()(
     "UnauthorizedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type PermissionActionType = "RESTORE" | (string & {});

--- a/packages/aws/src/services/ssm.ts
+++ b/packages/aws/src/services/ssm.ts
@@ -91,24 +91,24 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
   ).pipe(C.withAuthError) {}
 export class AlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<AlreadyExistsException>()(
     "AlreadyExistsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "AlreadyExistsException", httpResponseCode: 400 }),
   ).pipe(C.withAlreadyExistsError) {}
 export class AssociatedInstances
   extends /*@__PURE__*/ S.TaggedErrorClass<AssociatedInstances>()(
     "AssociatedInstances",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "AssociatedInstances", httpResponseCode: 400 }),
   ) {}
 export class AssociationAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<AssociationAlreadyExists>()(
     "AssociationAlreadyExists",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "AssociationAlreadyExists",
       httpResponseCode: 400,
@@ -117,13 +117,13 @@ export class AssociationAlreadyExists
 export class AssociationDoesNotExist
   extends /*@__PURE__*/ S.TaggedErrorClass<AssociationDoesNotExist>()(
     "AssociationDoesNotExist",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "AssociationDoesNotExist", httpResponseCode: 404 }),
   ) {}
 export class AssociationExecutionDoesNotExist
   extends /*@__PURE__*/ S.TaggedErrorClass<AssociationExecutionDoesNotExist>()(
     "AssociationExecutionDoesNotExist",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "AssociationExecutionDoesNotExist",
       httpResponseCode: 404,
@@ -132,7 +132,7 @@ export class AssociationExecutionDoesNotExist
 export class AssociationLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<AssociationLimitExceeded>()(
     "AssociationLimitExceeded",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "AssociationLimitExceeded",
       httpResponseCode: 400,
@@ -141,7 +141,7 @@ export class AssociationLimitExceeded
 export class AssociationVersionLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<AssociationVersionLimitExceeded>()(
     "AssociationVersionLimitExceeded",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "AssociationVersionLimitExceeded",
       httpResponseCode: 400,
@@ -150,7 +150,7 @@ export class AssociationVersionLimitExceeded
 export class AutomationDefinitionNotApprovedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AutomationDefinitionNotApprovedException>()(
     "AutomationDefinitionNotApprovedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "AutomationDefinitionNotApproved",
       httpResponseCode: 400,
@@ -159,7 +159,7 @@ export class AutomationDefinitionNotApprovedException
 export class AutomationDefinitionNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<AutomationDefinitionNotFoundException>()(
     "AutomationDefinitionNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "AutomationDefinitionNotFound",
       httpResponseCode: 404,
@@ -168,7 +168,7 @@ export class AutomationDefinitionNotFoundException
 export class AutomationDefinitionVersionNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<AutomationDefinitionVersionNotFoundException>()(
     "AutomationDefinitionVersionNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "AutomationDefinitionVersionNotFound",
       httpResponseCode: 404,
@@ -177,7 +177,7 @@ export class AutomationDefinitionVersionNotFoundException
 export class AutomationExecutionLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<AutomationExecutionLimitExceededException>()(
     "AutomationExecutionLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "AutomationExecutionLimitExceeded",
       httpResponseCode: 429,
@@ -186,7 +186,7 @@ export class AutomationExecutionLimitExceededException
 export class AutomationExecutionNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<AutomationExecutionNotFoundException>()(
     "AutomationExecutionNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "AutomationExecutionNotFound",
       httpResponseCode: 404,
@@ -195,7 +195,7 @@ export class AutomationExecutionNotFoundException
 export class AutomationStepNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<AutomationStepNotFoundException>()(
     "AutomationStepNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "AutomationStepNotFoundException",
       httpResponseCode: 404,
@@ -204,7 +204,7 @@ export class AutomationStepNotFoundException
 export class ComplianceTypeCountLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ComplianceTypeCountLimitExceededException>()(
     "ComplianceTypeCountLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "ComplianceTypeCountLimitExceeded",
       httpResponseCode: 400,
@@ -213,7 +213,7 @@ export class ComplianceTypeCountLimitExceededException
 export class CustomSchemaCountLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<CustomSchemaCountLimitExceededException>()(
     "CustomSchemaCountLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "CustomSchemaCountLimitExceeded",
       httpResponseCode: 400,
@@ -222,25 +222,25 @@ export class CustomSchemaCountLimitExceededException
 export class DocumentAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<DocumentAlreadyExists>()(
     "DocumentAlreadyExists",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "DocumentAlreadyExists", httpResponseCode: 400 }),
   ).pipe(C.withAlreadyExistsError) {}
 export class DocumentLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<DocumentLimitExceeded>()(
     "DocumentLimitExceeded",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "DocumentLimitExceeded", httpResponseCode: 400 }),
   ).pipe(C.withThrottlingError) {}
 export class DocumentPermissionLimit
   extends /*@__PURE__*/ S.TaggedErrorClass<DocumentPermissionLimit>()(
     "DocumentPermissionLimit",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "DocumentPermissionLimit", httpResponseCode: 400 }),
   ) {}
 export class DocumentVersionLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<DocumentVersionLimitExceeded>()(
     "DocumentVersionLimitExceeded",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "DocumentVersionLimitExceeded",
       httpResponseCode: 400,
@@ -249,13 +249,13 @@ export class DocumentVersionLimitExceeded
 export class DoesNotExistException
   extends /*@__PURE__*/ S.TaggedErrorClass<DoesNotExistException>()(
     "DoesNotExistException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "DoesNotExistException", httpResponseCode: 404 }),
   ) {}
 export class DuplicateDocumentContent
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicateDocumentContent>()(
     "DuplicateDocumentContent",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "DuplicateDocumentContent",
       httpResponseCode: 400,
@@ -264,7 +264,7 @@ export class DuplicateDocumentContent
 export class DuplicateDocumentVersionName
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicateDocumentVersionName>()(
     "DuplicateDocumentVersionName",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "DuplicateDocumentVersionName",
       httpResponseCode: 400,
@@ -273,13 +273,13 @@ export class DuplicateDocumentVersionName
 export class DuplicateInstanceId
   extends /*@__PURE__*/ S.TaggedErrorClass<DuplicateInstanceId>()(
     "DuplicateInstanceId",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "DuplicateInstanceId", httpResponseCode: 404 }),
   ) {}
 export class FeatureNotAvailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<FeatureNotAvailableException>()(
     "FeatureNotAvailableException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "FeatureNotAvailableException",
       httpResponseCode: 400,
@@ -288,7 +288,7 @@ export class FeatureNotAvailableException
 export class HierarchyLevelLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<HierarchyLevelLimitExceededException>()(
     "HierarchyLevelLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "HierarchyLevelLimitExceededException",
       httpResponseCode: 400,
@@ -297,7 +297,7 @@ export class HierarchyLevelLimitExceededException
 export class HierarchyTypeMismatchException
   extends /*@__PURE__*/ S.TaggedErrorClass<HierarchyTypeMismatchException>()(
     "HierarchyTypeMismatchException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "HierarchyTypeMismatchException",
       httpResponseCode: 400,
@@ -306,7 +306,7 @@ export class HierarchyTypeMismatchException
 export class IdempotentParameterMismatch
   extends /*@__PURE__*/ S.TaggedErrorClass<IdempotentParameterMismatch>()(
     "IdempotentParameterMismatch",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "IdempotentParameterMismatch",
       httpResponseCode: 400,
@@ -315,7 +315,7 @@ export class IdempotentParameterMismatch
 export class IncompatiblePolicyException
   extends /*@__PURE__*/ S.TaggedErrorClass<IncompatiblePolicyException>()(
     "IncompatiblePolicyException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "IncompatiblePolicyException",
       httpResponseCode: 400,
@@ -324,31 +324,31 @@ export class IncompatiblePolicyException
 export class InternalServerError
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerError>()(
     "InternalServerError",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InternalServerError", httpResponseCode: 500 }),
   ) {}
 export class InvalidActivation
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidActivation>()(
     "InvalidActivation",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InvalidActivation", httpResponseCode: 404 }),
   ) {}
 export class InvalidActivationId
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidActivationId>()(
     "InvalidActivationId",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InvalidActivationId", httpResponseCode: 404 }),
   ) {}
 export class InvalidAggregatorException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidAggregatorException>()(
     "InvalidAggregatorException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InvalidAggregator", httpResponseCode: 400 }),
   ) {}
 export class InvalidAllowedPatternException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidAllowedPatternException>()(
     "InvalidAllowedPatternException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "InvalidAllowedPatternException",
       httpResponseCode: 400,
@@ -357,13 +357,13 @@ export class InvalidAllowedPatternException
 export class InvalidAssociation
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidAssociation>()(
     "InvalidAssociation",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InvalidAssociation", httpResponseCode: 400 }),
   ) {}
 export class InvalidAssociationVersion
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidAssociationVersion>()(
     "InvalidAssociationVersion",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "InvalidAssociationVersion",
       httpResponseCode: 400,
@@ -372,7 +372,7 @@ export class InvalidAssociationVersion
 export class InvalidAutomationExecutionParametersException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidAutomationExecutionParametersException>()(
     "InvalidAutomationExecutionParametersException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "InvalidAutomationExecutionParameters",
       httpResponseCode: 400,
@@ -381,7 +381,7 @@ export class InvalidAutomationExecutionParametersException
 export class InvalidAutomationSignalException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidAutomationSignalException>()(
     "InvalidAutomationSignalException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "InvalidAutomationSignalException",
       httpResponseCode: 400,
@@ -390,7 +390,7 @@ export class InvalidAutomationSignalException
 export class InvalidAutomationStatusUpdateException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidAutomationStatusUpdateException>()(
     "InvalidAutomationStatusUpdateException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "InvalidAutomationStatusUpdateException",
       httpResponseCode: 400,
@@ -399,13 +399,13 @@ export class InvalidAutomationStatusUpdateException
 export class InvalidCommandId
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCommandId>()(
     "InvalidCommandId",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InvalidCommandId", httpResponseCode: 404 }),
   ) {}
 export class InvalidDeleteInventoryParametersException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDeleteInventoryParametersException>()(
     "InvalidDeleteInventoryParametersException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "InvalidDeleteInventoryParameters",
       httpResponseCode: 400,
@@ -414,25 +414,25 @@ export class InvalidDeleteInventoryParametersException
 export class InvalidDeletionIdException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDeletionIdException>()(
     "InvalidDeletionIdException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InvalidDeletionId", httpResponseCode: 400 }),
   ) {}
 export class InvalidDocument
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDocument>()(
     "InvalidDocument",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InvalidDocument", httpResponseCode: 404 }),
   ) {}
 export class InvalidDocumentContent
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDocumentContent>()(
     "InvalidDocumentContent",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InvalidDocumentContent", httpResponseCode: 400 }),
   ) {}
 export class InvalidDocumentOperation
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDocumentOperation>()(
     "InvalidDocumentOperation",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "InvalidDocumentOperation",
       httpResponseCode: 403,
@@ -441,7 +441,7 @@ export class InvalidDocumentOperation
 export class InvalidDocumentSchemaVersion
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDocumentSchemaVersion>()(
     "InvalidDocumentSchemaVersion",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "InvalidDocumentSchemaVersion",
       httpResponseCode: 400,
@@ -450,49 +450,49 @@ export class InvalidDocumentSchemaVersion
 export class InvalidDocumentType
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDocumentType>()(
     "InvalidDocumentType",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InvalidDocumentType", httpResponseCode: 400 }),
   ) {}
 export class InvalidDocumentVersion
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidDocumentVersion>()(
     "InvalidDocumentVersion",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InvalidDocumentVersion", httpResponseCode: 400 }),
   ) {}
 export class InvalidFilter
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidFilter>()(
     "InvalidFilter",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InvalidFilter", httpResponseCode: 441 }),
   ) {}
 export class InvalidFilterKey
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidFilterKey>()(
     "InvalidFilterKey",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InvalidFilterKey", httpResponseCode: 400 }),
   ) {}
 export class InvalidFilterOption
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidFilterOption>()(
     "InvalidFilterOption",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InvalidFilterOption", httpResponseCode: 400 }),
   ) {}
 export class InvalidFilterValue
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidFilterValue>()(
     "InvalidFilterValue",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InvalidFilterValue", httpResponseCode: 400 }),
   ) {}
 export class InvalidInstanceId
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInstanceId>()(
     "InvalidInstanceId",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InvalidInstanceId", httpResponseCode: 404 }),
   ) {}
 export class InvalidInstanceInformationFilterValue
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInstanceInformationFilterValue>()(
     "InvalidInstanceInformationFilterValue",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "InvalidInstanceInformationFilterValue",
       httpResponseCode: 400,
@@ -501,7 +501,7 @@ export class InvalidInstanceInformationFilterValue
 export class InvalidInstancePropertyFilterValue
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInstancePropertyFilterValue>()(
     "InvalidInstancePropertyFilterValue",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "InvalidInstancePropertyFilterValue",
       httpResponseCode: 400,
@@ -510,13 +510,13 @@ export class InvalidInstancePropertyFilterValue
 export class InvalidInventoryGroupException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInventoryGroupException>()(
     "InvalidInventoryGroupException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InvalidInventoryGroup", httpResponseCode: 400 }),
   ) {}
 export class InvalidInventoryItemContextException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInventoryItemContextException>()(
     "InvalidInventoryItemContextException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "InvalidInventoryItemContext",
       httpResponseCode: 400,
@@ -525,31 +525,34 @@ export class InvalidInventoryItemContextException
 export class InvalidInventoryRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidInventoryRequestException>()(
     "InvalidInventoryRequestException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InvalidInventoryRequest", httpResponseCode: 400 }),
   ) {}
 export class InvalidItemContentException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidItemContentException>()(
     "InvalidItemContentException",
-    { TypeName: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      TypeName: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.AwsQueryError({ code: "InvalidItemContent", httpResponseCode: 400 }),
   ) {}
 export class InvalidKeyId
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidKeyId>()(
     "InvalidKeyId",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InvalidKeyId", httpResponseCode: 400 }),
   ) {}
 export class InvalidNextToken
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNextToken>()(
     "InvalidNextToken",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InvalidNextToken", httpResponseCode: 400 }),
   ) {}
 export class InvalidNotificationConfig
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNotificationConfig>()(
     "InvalidNotificationConfig",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "InvalidNotificationConfig",
       httpResponseCode: 400,
@@ -558,43 +561,43 @@ export class InvalidNotificationConfig
 export class InvalidOptionException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidOptionException>()(
     "InvalidOptionException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InvalidOption", httpResponseCode: 400 }),
   ) {}
 export class InvalidOutputFolder
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidOutputFolder>()(
     "InvalidOutputFolder",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InvalidOutputFolder", httpResponseCode: 400 }),
   ) {}
 export class InvalidOutputLocation
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidOutputLocation>()(
     "InvalidOutputLocation",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InvalidOutputLocation", httpResponseCode: 400 }),
   ) {}
 export class InvalidParameters
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameters>()(
     "InvalidParameters",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InvalidParameters", httpResponseCode: 400 }),
   ) {}
 export class InvalidPermissionType
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPermissionType>()(
     "InvalidPermissionType",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InvalidPermissionType", httpResponseCode: 400 }),
   ) {}
 export class InvalidPluginName
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPluginName>()(
     "InvalidPluginName",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InvalidPluginName", httpResponseCode: 404 }),
   ) {}
 export class InvalidPolicyAttributeException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPolicyAttributeException>()(
     "InvalidPolicyAttributeException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "InvalidPolicyAttributeException",
       httpResponseCode: 400,
@@ -603,7 +606,7 @@ export class InvalidPolicyAttributeException
 export class InvalidPolicyTypeException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPolicyTypeException>()(
     "InvalidPolicyTypeException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "InvalidPolicyTypeException",
       httpResponseCode: 400,
@@ -612,85 +615,91 @@ export class InvalidPolicyTypeException
 export class InvalidResourceId
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidResourceId>()(
     "InvalidResourceId",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InvalidResourceId", httpResponseCode: 400 }),
   ) {}
 export class InvalidResourceType
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidResourceType>()(
     "InvalidResourceType",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InvalidResourceType", httpResponseCode: 400 }),
   ) {}
 export class InvalidResultAttributeException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidResultAttributeException>()(
     "InvalidResultAttributeException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InvalidResultAttribute", httpResponseCode: 400 }),
   ) {}
 export class InvalidRole
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRole>()(
     "InvalidRole",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InvalidRole", httpResponseCode: 400 }),
   ) {}
 export class InvalidSchedule
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidSchedule>()(
     "InvalidSchedule",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InvalidSchedule", httpResponseCode: 400 }),
   ) {}
 export class InvalidTag
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTag>()(
     "InvalidTag",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InvalidTag", httpResponseCode: 400 }),
   ) {}
 export class InvalidTarget
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTarget>()(
     "InvalidTarget",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InvalidTarget", httpResponseCode: 400 }),
   ) {}
 export class InvalidTargetMaps
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTargetMaps>()(
     "InvalidTargetMaps",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InvalidTargetMaps", httpResponseCode: 400 }),
   ) {}
 export class InvalidTypeNameException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidTypeNameException>()(
     "InvalidTypeNameException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InvalidTypeName", httpResponseCode: 400 }),
   ) {}
 export class InvalidUpdate
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidUpdate>()(
     "InvalidUpdate",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InvalidUpdate", httpResponseCode: 400 }),
   ) {}
 export class InvocationDoesNotExist
   extends /*@__PURE__*/ S.TaggedErrorClass<InvocationDoesNotExist>()(
     "InvocationDoesNotExist",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "InvocationDoesNotExist", httpResponseCode: 400 }),
   ) {}
 export class ItemContentMismatchException
   extends /*@__PURE__*/ S.TaggedErrorClass<ItemContentMismatchException>()(
     "ItemContentMismatchException",
-    { TypeName: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      TypeName: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.AwsQueryError({ code: "ItemContentMismatch", httpResponseCode: 400 }),
   ) {}
 export class ItemSizeLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ItemSizeLimitExceededException>()(
     "ItemSizeLimitExceededException",
-    { TypeName: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      TypeName: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.AwsQueryError({ code: "ItemSizeLimitExceeded", httpResponseCode: 400 }),
   ) {}
 export class MalformedResourcePolicyDocumentException
   extends /*@__PURE__*/ S.TaggedErrorClass<MalformedResourcePolicyDocumentException>()(
     "MalformedResourcePolicyDocumentException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "MalformedResourcePolicyDocumentException",
       httpResponseCode: 400,
@@ -699,19 +708,19 @@ export class MalformedResourcePolicyDocumentException
 export class MaxDocumentSizeExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<MaxDocumentSizeExceeded>()(
     "MaxDocumentSizeExceeded",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "MaxDocumentSizeExceeded", httpResponseCode: 400 }),
   ) {}
 export class NoLongerSupportedException
   extends /*@__PURE__*/ S.TaggedErrorClass<NoLongerSupportedException>()(
     "NoLongerSupportedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "NoLongerSupported", httpResponseCode: 400 }),
   ) {}
 export class OpsItemAccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<OpsItemAccessDeniedException>()(
     "OpsItemAccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "OpsItemAccessDeniedException",
       httpResponseCode: 403,
@@ -720,7 +729,10 @@ export class OpsItemAccessDeniedException
 export class OpsItemAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<OpsItemAlreadyExistsException>()(
     "OpsItemAlreadyExistsException",
-    { Message: S.optional(S.String), OpsItemId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      OpsItemId: S.optional(S.String),
+    },
     T.AwsQueryError({
       code: "OpsItemAlreadyExistsException",
       httpResponseCode: 400,
@@ -729,7 +741,7 @@ export class OpsItemAlreadyExistsException
 export class OpsItemConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<OpsItemConflictException>()(
     "OpsItemConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "OpsItemConflictException",
       httpResponseCode: 409,
@@ -744,7 +756,7 @@ export class OpsItemInvalidParameterException
           identifier: "OpsItemParameterNamesList",
         }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.AwsQueryError({
       code: "OpsItemInvalidParameterException",
@@ -762,7 +774,7 @@ export class OpsItemLimitExceededException
       ),
       Limit: S.optional(S.Number),
       LimitType: S.optional(S.String),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.AwsQueryError({
       code: "OpsItemLimitExceededException",
@@ -772,7 +784,7 @@ export class OpsItemLimitExceededException
 export class OpsItemNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<OpsItemNotFoundException>()(
     "OpsItemNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "OpsItemNotFoundException",
       httpResponseCode: 400,
@@ -782,7 +794,7 @@ export class OpsItemRelatedItemAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<OpsItemRelatedItemAlreadyExistsException>()(
     "OpsItemRelatedItemAlreadyExistsException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       ResourceUri: S.optional(S.String),
       OpsItemId: S.optional(S.String),
     },
@@ -794,7 +806,7 @@ export class OpsItemRelatedItemAlreadyExistsException
 export class OpsItemRelatedItemAssociationNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<OpsItemRelatedItemAssociationNotFoundException>()(
     "OpsItemRelatedItemAssociationNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "OpsItemRelatedItemAssociationNotFoundException",
       httpResponseCode: 400,
@@ -803,7 +815,7 @@ export class OpsItemRelatedItemAssociationNotFoundException
 export class OpsMetadataAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<OpsMetadataAlreadyExistsException>()(
     "OpsMetadataAlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "OpsMetadataAlreadyExistsException",
       httpResponseCode: 400,
@@ -812,7 +824,7 @@ export class OpsMetadataAlreadyExistsException
 export class OpsMetadataInvalidArgumentException
   extends /*@__PURE__*/ S.TaggedErrorClass<OpsMetadataInvalidArgumentException>()(
     "OpsMetadataInvalidArgumentException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "OpsMetadataInvalidArgumentException",
       httpResponseCode: 400,
@@ -821,7 +833,7 @@ export class OpsMetadataInvalidArgumentException
 export class OpsMetadataKeyLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<OpsMetadataKeyLimitExceededException>()(
     "OpsMetadataKeyLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "OpsMetadataKeyLimitExceededException",
       httpResponseCode: 429,
@@ -830,7 +842,7 @@ export class OpsMetadataKeyLimitExceededException
 export class OpsMetadataLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<OpsMetadataLimitExceededException>()(
     "OpsMetadataLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "OpsMetadataLimitExceededException",
       httpResponseCode: 429,
@@ -839,7 +851,7 @@ export class OpsMetadataLimitExceededException
 export class OpsMetadataNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<OpsMetadataNotFoundException>()(
     "OpsMetadataNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "OpsMetadataNotFoundException",
       httpResponseCode: 404,
@@ -848,7 +860,7 @@ export class OpsMetadataNotFoundException
 export class OpsMetadataTooManyUpdatesException
   extends /*@__PURE__*/ S.TaggedErrorClass<OpsMetadataTooManyUpdatesException>()(
     "OpsMetadataTooManyUpdatesException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "OpsMetadataTooManyUpdatesException",
       httpResponseCode: 429,
@@ -857,19 +869,19 @@ export class OpsMetadataTooManyUpdatesException
 export class ParameterAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<ParameterAlreadyExists>()(
     "ParameterAlreadyExists",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "ParameterAlreadyExists", httpResponseCode: 400 }),
   ).pipe(C.withAlreadyExistsError) {}
 export class ParameterLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<ParameterLimitExceeded>()(
     "ParameterLimitExceeded",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "ParameterLimitExceeded", httpResponseCode: 429 }),
   ).pipe(C.withThrottlingError) {}
 export class ParameterMaxVersionLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<ParameterMaxVersionLimitExceeded>()(
     "ParameterMaxVersionLimitExceeded",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "ParameterMaxVersionLimitExceeded",
       httpResponseCode: 400,
@@ -878,13 +890,13 @@ export class ParameterMaxVersionLimitExceeded
 export class ParameterNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<ParameterNotFound>()(
     "ParameterNotFound",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "ParameterNotFound", httpResponseCode: 404 }),
   ) {}
 export class ParameterPatternMismatchException
   extends /*@__PURE__*/ S.TaggedErrorClass<ParameterPatternMismatchException>()(
     "ParameterPatternMismatchException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "ParameterPatternMismatchException",
       httpResponseCode: 400,
@@ -893,7 +905,7 @@ export class ParameterPatternMismatchException
 export class ParameterVersionLabelLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<ParameterVersionLabelLimitExceeded>()(
     "ParameterVersionLabelLimitExceeded",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "ParameterVersionLabelLimitExceeded",
       httpResponseCode: 400,
@@ -902,7 +914,7 @@ export class ParameterVersionLabelLimitExceeded
 export class ParameterVersionNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<ParameterVersionNotFound>()(
     "ParameterVersionNotFound",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "ParameterVersionNotFound",
       httpResponseCode: 400,
@@ -911,7 +923,7 @@ export class ParameterVersionNotFound
 export class PoliciesLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<PoliciesLimitExceededException>()(
     "PoliciesLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "PoliciesLimitExceededException",
       httpResponseCode: 400,
@@ -920,7 +932,10 @@ export class PoliciesLimitExceededException
 export class ResourceDataSyncAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceDataSyncAlreadyExistsException>()(
     "ResourceDataSyncAlreadyExistsException",
-    { SyncName: S.optional(S.String) },
+    {
+      SyncName: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.AwsQueryError({
       code: "ResourceDataSyncAlreadyExists",
       httpResponseCode: 400,
@@ -929,7 +944,7 @@ export class ResourceDataSyncAlreadyExistsException
 export class ResourceDataSyncConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceDataSyncConflictException>()(
     "ResourceDataSyncConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "ResourceDataSyncConflictException",
       httpResponseCode: 409,
@@ -938,7 +953,7 @@ export class ResourceDataSyncConflictException
 export class ResourceDataSyncCountExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceDataSyncCountExceededException>()(
     "ResourceDataSyncCountExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "ResourceDataSyncCountExceeded",
       httpResponseCode: 400,
@@ -947,7 +962,7 @@ export class ResourceDataSyncCountExceededException
 export class ResourceDataSyncInvalidConfigurationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceDataSyncInvalidConfigurationException>()(
     "ResourceDataSyncInvalidConfigurationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "ResourceDataSyncInvalidConfiguration",
       httpResponseCode: 400,
@@ -959,7 +974,7 @@ export class ResourceDataSyncNotFoundException
     {
       SyncName: S.optional(S.String),
       SyncType: S.optional(S.String),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.AwsQueryError({
       code: "ResourceDataSyncNotFound",
@@ -969,13 +984,13 @@ export class ResourceDataSyncNotFoundException
 export class ResourceInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUseException>()(
     "ResourceInUseException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "ResourceInUseException", httpResponseCode: 400 }),
   ) {}
 export class ResourceLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceLimitExceededException>()(
     "ResourceLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "ResourceLimitExceededException",
       httpResponseCode: 400,
@@ -984,7 +999,7 @@ export class ResourceLimitExceededException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "ResourceNotFoundException",
       httpResponseCode: 404,
@@ -993,7 +1008,7 @@ export class ResourceNotFoundException
 export class ResourcePolicyConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourcePolicyConflictException>()(
     "ResourcePolicyConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "ResourcePolicyConflictException",
       httpResponseCode: 400,
@@ -1008,7 +1023,7 @@ export class ResourcePolicyInvalidParameterException
           identifier: "ResourcePolicyParameterNamesList",
         }),
       ),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.AwsQueryError({
       code: "ResourcePolicyInvalidParameterException",
@@ -1021,7 +1036,7 @@ export class ResourcePolicyLimitExceededException
     {
       Limit: S.optional(S.Number),
       LimitType: S.optional(S.String),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.AwsQueryError({
       code: "ResourcePolicyLimitExceededException",
@@ -1031,7 +1046,7 @@ export class ResourcePolicyLimitExceededException
 export class ResourcePolicyNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourcePolicyNotFoundException>()(
     "ResourcePolicyNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "ResourcePolicyNotFoundException",
       httpResponseCode: 404,
@@ -1041,7 +1056,7 @@ export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       ResourceId: S.optional(S.String),
       ResourceType: S.optional(S.String),
       QuotaCode: S.String,
@@ -1051,19 +1066,19 @@ export class ServiceQuotaExceededException
 export class ServiceSettingNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceSettingNotFound>()(
     "ServiceSettingNotFound",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "ServiceSettingNotFound", httpResponseCode: 400 }),
   ) {}
 export class StatusUnchanged
   extends /*@__PURE__*/ S.TaggedErrorClass<StatusUnchanged>()(
     "StatusUnchanged",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "StatusUnchanged", httpResponseCode: 400 }),
   ) {}
 export class SubTypeCountLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<SubTypeCountLimitExceededException>()(
     "SubTypeCountLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "SubTypeCountLimitExceeded",
       httpResponseCode: 400,
@@ -1072,20 +1087,20 @@ export class SubTypeCountLimitExceededException
 export class TargetInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<TargetInUseException>()(
     "TargetInUseException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "TargetInUseException", httpResponseCode: 400 }),
   ) {}
 export class TargetNotConnected
   extends /*@__PURE__*/ S.TaggedErrorClass<TargetNotConnected>()(
     "TargetNotConnected",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "TargetNotConnected", httpResponseCode: 430 }),
   ) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       QuotaCode: S.optional(S.String),
       ServiceCode: S.optional(S.String),
     },
@@ -1093,25 +1108,25 @@ export class ThrottlingException
 export class TooManyTagsError
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsError>()(
     "TooManyTagsError",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "TooManyTagsError", httpResponseCode: 400 }),
   ) {}
 export class TooManyUpdates
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyUpdates>()(
     "TooManyUpdates",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "TooManyUpdates", httpResponseCode: 429 }),
   ) {}
 export class TotalSizeLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<TotalSizeLimitExceededException>()(
     "TotalSizeLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "TotalSizeLimitExceeded", httpResponseCode: 400 }),
   ) {}
 export class UnsupportedCalendarException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedCalendarException>()(
     "UnsupportedCalendarException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "UnsupportedCalendarException",
       httpResponseCode: 400,
@@ -1120,7 +1135,7 @@ export class UnsupportedCalendarException
 export class UnsupportedFeatureRequiredException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedFeatureRequiredException>()(
     "UnsupportedFeatureRequiredException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "UnsupportedFeatureRequiredException",
       httpResponseCode: 400,
@@ -1129,7 +1144,10 @@ export class UnsupportedFeatureRequiredException
 export class UnsupportedInventoryItemContextException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedInventoryItemContextException>()(
     "UnsupportedInventoryItemContextException",
-    { TypeName: S.optional(S.String), Message: S.optional(S.String) },
+    {
+      TypeName: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.AwsQueryError({
       code: "UnsupportedInventoryItemContext",
       httpResponseCode: 400,
@@ -1138,7 +1156,7 @@ export class UnsupportedInventoryItemContextException
 export class UnsupportedInventorySchemaVersionException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedInventorySchemaVersionException>()(
     "UnsupportedInventorySchemaVersionException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "UnsupportedInventorySchemaVersion",
       httpResponseCode: 400,
@@ -1147,7 +1165,7 @@ export class UnsupportedInventorySchemaVersionException
 export class UnsupportedOperatingSystem
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedOperatingSystem>()(
     "UnsupportedOperatingSystem",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "UnsupportedOperatingSystem",
       httpResponseCode: 400,
@@ -1156,13 +1174,13 @@ export class UnsupportedOperatingSystem
 export class UnsupportedOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedOperationException>()(
     "UnsupportedOperationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "UnsupportedOperation", httpResponseCode: 400 }),
   ) {}
 export class UnsupportedParameterType
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedParameterType>()(
     "UnsupportedParameterType",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({
       code: "UnsupportedParameterType",
       httpResponseCode: 400,
@@ -1171,13 +1189,16 @@ export class UnsupportedParameterType
 export class UnsupportedPlatformType
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedPlatformType>()(
     "UnsupportedPlatformType",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.AwsQueryError({ code: "UnsupportedPlatformType", httpResponseCode: 400 }),
   ) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String), ReasonCode: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ReasonCode: S.optional(S.String),
+    },
     T.AwsQueryError({ code: "ValidationException", httpResponseCode: 400 }),
   ) {}
 export type ResourceTypeForTagging =

--- a/packages/aws/src/services/sso-admin.ts
+++ b/packages/aws/src/services/sso-admin.ts
@@ -92,7 +92,7 @@ export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => AccessDeniedExceptionReason).annotate({
           identifier: "AccessDeniedExceptionReason",
@@ -104,20 +104,20 @@ export class AccessDeniedException
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => ResourceNotFoundExceptionReason).annotate({
           identifier: "ResourceNotFoundExceptionReason",
@@ -129,14 +129,14 @@ export class ResourceNotFoundException
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => ThrottlingExceptionReason).annotate({
           identifier: "ThrottlingExceptionReason",
@@ -149,7 +149,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => ValidationExceptionReason).annotate({
           identifier: "ValidationExceptionReason",

--- a/packages/aws/src/services/sso-oidc.ts
+++ b/packages/aws/src/services/sso-oidc.ts
@@ -100,49 +100,78 @@ export class AccessDeniedException
         }),
       ),
       error_description: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(400),
   ).pipe(C.withBadRequestError, C.withAuthError) {}
 export class AuthorizationPendingException
   extends /*@__PURE__*/ S.TaggedErrorClass<AuthorizationPendingException>()(
     "AuthorizationPendingException",
-    { error: S.optional(S.String), error_description: S.optional(S.String) },
+    {
+      error: S.optional(S.String),
+      error_description: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ExpiredTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<ExpiredTokenException>()(
     "ExpiredTokenException",
-    { error: S.optional(S.String), error_description: S.optional(S.String) },
+    {
+      error: S.optional(S.String),
+      error_description: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { error: S.optional(S.String), error_description: S.optional(S.String) },
+    {
+      error: S.optional(S.String),
+      error_description: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidClientException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidClientException>()(
     "InvalidClientException",
-    { error: S.optional(S.String), error_description: S.optional(S.String) },
+    {
+      error: S.optional(S.String),
+      error_description: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export class InvalidClientMetadataException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidClientMetadataException>()(
     "InvalidClientMetadataException",
-    { error: S.optional(S.String), error_description: S.optional(S.String) },
+    {
+      error: S.optional(S.String),
+      error_description: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidGrantException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidGrantException>()(
     "InvalidGrantException",
-    { error: S.optional(S.String), error_description: S.optional(S.String) },
+    {
+      error: S.optional(S.String),
+      error_description: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidRedirectUriException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRedirectUriException>()(
     "InvalidRedirectUriException",
-    { error: S.optional(S.String), error_description: S.optional(S.String) },
+    {
+      error: S.optional(S.String),
+      error_description: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidRequestException
@@ -156,6 +185,7 @@ export class InvalidRequestException
         }),
       ),
       error_description: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
@@ -167,31 +197,48 @@ export class InvalidRequestRegionException
       error_description: S.optional(S.String),
       endpoint: S.optional(S.String),
       region: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidScopeException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidScopeException>()(
     "InvalidScopeException",
-    { error: S.optional(S.String), error_description: S.optional(S.String) },
+    {
+      error: S.optional(S.String),
+      error_description: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class SlowDownException
   extends /*@__PURE__*/ S.TaggedErrorClass<SlowDownException>()(
     "SlowDownException",
-    { error: S.optional(S.String), error_description: S.optional(S.String) },
+    {
+      error: S.optional(S.String),
+      error_description: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class UnauthorizedClientException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnauthorizedClientException>()(
     "UnauthorizedClientException",
-    { error: S.optional(S.String), error_description: S.optional(S.String) },
+    {
+      error: S.optional(S.String),
+      error_description: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError, C.withAuthError) {}
 export class UnsupportedGrantTypeException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedGrantTypeException>()(
     "UnsupportedGrantTypeException",
-    { error: S.optional(S.String), error_description: S.optional(S.String) },
+    {
+      error: S.optional(S.String),
+      error_description: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type ClientId = string;

--- a/packages/aws/src/services/sso.ts
+++ b/packages/aws/src/services/sso.ts
@@ -93,25 +93,25 @@ const rules = T.EndpointResolver((p, _) => {
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class UnauthorizedException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnauthorizedException>()(
     "UnauthorizedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export type RoleNameType = string;

--- a/packages/aws/src/services/storage-gateway.ts
+++ b/packages/aws/src/services/storage-gateway.ts
@@ -92,7 +92,7 @@ export class InternalServerError
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerError>()(
     "InternalServerError",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       error: S.optional(
         S.suspend(() => StorageGatewayError).annotate({
           identifier: "StorageGatewayError",
@@ -105,7 +105,7 @@ export class InvalidGatewayRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidGatewayRequestException>()(
     "InvalidGatewayRequestException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       error: S.optional(
         S.suspend(() => StorageGatewayError).annotate({
           identifier: "StorageGatewayError",
@@ -118,7 +118,7 @@ export class ServiceUnavailableError
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableError>()(
     "ServiceUnavailableError",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       error: S.optional(
         S.suspend(() => StorageGatewayError).annotate({
           identifier: "StorageGatewayError",

--- a/packages/aws/src/services/sts.ts
+++ b/packages/aws/src/services/sts.ts
@@ -177,7 +177,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class ExpiredTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<ExpiredTokenException>()(
     "ExpiredTokenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ExpiredTokenException", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -186,7 +186,7 @@ export class ExpiredTokenException
 export class ExpiredTradeInTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<ExpiredTradeInTokenException>()(
     "ExpiredTradeInTokenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "ExpiredTradeInTokenException",
@@ -198,7 +198,7 @@ export class ExpiredTradeInTokenException
 export class IDPCommunicationErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<IDPCommunicationErrorException>()(
     "IDPCommunicationErrorException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "IDPCommunicationError", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -207,7 +207,7 @@ export class IDPCommunicationErrorException
 export class IDPRejectedClaimException
   extends /*@__PURE__*/ S.TaggedErrorClass<IDPRejectedClaimException>()(
     "IDPRejectedClaimException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "IDPRejectedClaim", httpResponseCode: 403 }),
       T.HttpError(403),
@@ -216,7 +216,7 @@ export class IDPRejectedClaimException
 export class InvalidAuthorizationMessageException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidAuthorizationMessageException>()(
     "InvalidAuthorizationMessageException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "InvalidAuthorizationMessageException",
@@ -228,7 +228,7 @@ export class InvalidAuthorizationMessageException
 export class InvalidIdentityTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidIdentityTokenException>()(
     "InvalidIdentityTokenException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "InvalidIdentityToken", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -237,7 +237,7 @@ export class InvalidIdentityTokenException
 export class JWTPayloadSizeExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<JWTPayloadSizeExceededException>()(
     "JWTPayloadSizeExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "JWTPayloadSizeExceededException",
@@ -249,7 +249,7 @@ export class JWTPayloadSizeExceededException
 export class MalformedPolicyDocumentException
   extends /*@__PURE__*/ S.TaggedErrorClass<MalformedPolicyDocumentException>()(
     "MalformedPolicyDocumentException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "MalformedPolicyDocument",
@@ -261,7 +261,7 @@ export class MalformedPolicyDocumentException
 export class OutboundWebIdentityFederationDisabledException
   extends /*@__PURE__*/ S.TaggedErrorClass<OutboundWebIdentityFederationDisabledException>()(
     "OutboundWebIdentityFederationDisabledException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "OutboundWebIdentityFederationDisabledException",
@@ -273,7 +273,7 @@ export class OutboundWebIdentityFederationDisabledException
 export class PackedPolicyTooLargeException
   extends /*@__PURE__*/ S.TaggedErrorClass<PackedPolicyTooLargeException>()(
     "PackedPolicyTooLargeException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "PackedPolicyTooLarge", httpResponseCode: 400 }),
       T.HttpError(400),
@@ -282,7 +282,7 @@ export class PackedPolicyTooLargeException
 export class RegionDisabledException
   extends /*@__PURE__*/ S.TaggedErrorClass<RegionDisabledException>()(
     "RegionDisabledException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "RegionDisabledException",
@@ -294,7 +294,7 @@ export class RegionDisabledException
 export class SessionDurationEscalationException
   extends /*@__PURE__*/ S.TaggedErrorClass<SessionDurationEscalationException>()(
     "SessionDurationEscalationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({
         code: "SessionDurationEscalationException",

--- a/packages/aws/src/services/supplychain.ts
+++ b/packages/aws/src/services/supplychain.ts
@@ -90,43 +90,43 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(429), T.Retryable({ throttling: true })),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type UUID = string;

--- a/packages/aws/src/services/support-app.ts
+++ b/packages/aws/src/services/support-app.ts
@@ -88,37 +88,37 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type TeamId = string;

--- a/packages/aws/src/services/support.ts
+++ b/packages/aws/src/services/support.ts
@@ -184,51 +184,51 @@ const rules = T.EndpointResolver((p, _) => {
 export class AttachmentIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<AttachmentIdNotFound>()(
     "AttachmentIdNotFound",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class AttachmentLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<AttachmentLimitExceeded>()(
     "AttachmentLimitExceeded",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withThrottlingError) {}
 export class AttachmentSetExpired
   extends /*@__PURE__*/ S.TaggedErrorClass<AttachmentSetExpired>()(
     "AttachmentSetExpired",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class AttachmentSetIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<AttachmentSetIdNotFound>()(
     "AttachmentSetIdNotFound",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class AttachmentSetSizeLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<AttachmentSetSizeLimitExceeded>()(
     "AttachmentSetSizeLimitExceeded",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withThrottlingError) {}
 export class CaseCreationLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<CaseCreationLimitExceeded>()(
     "CaseCreationLimitExceeded",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withThrottlingError) {}
 export class CaseIdNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<CaseIdNotFound>()("CaseIdNotFound", {
-    message: S.optional(S.String),
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
   }) {}
 export class DescribeAttachmentLimitExceeded
   extends /*@__PURE__*/ S.TaggedErrorClass<DescribeAttachmentLimitExceeded>()(
     "DescribeAttachmentLimitExceeded",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withThrottlingError) {}
 export class InternalServerError
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerError>()(
     "InternalServerError",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "Throttling", httpResponseCode: 400 }),
       T.HttpError(400),

--- a/packages/aws/src/services/sustainability.ts
+++ b/packages/aws/src/services/sustainability.ts
@@ -115,25 +115,25 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(429), T.Retryable()),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export interface TimePeriod {

--- a/packages/aws/src/services/swf.ts
+++ b/packages/aws/src/services/swf.ts
@@ -107,58 +107,58 @@ const rules = T.EndpointResolver((p, _) => {
 export class DefaultUndefinedFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DefaultUndefinedFault>()(
     "DefaultUndefinedFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class DomainAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DomainAlreadyExistsFault>()(
     "DomainAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class DomainDeprecatedFault
   extends /*@__PURE__*/ S.TaggedErrorClass<DomainDeprecatedFault>()(
     "DomainDeprecatedFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LimitExceededFault
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededFault>()(
     "LimitExceededFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class OperationNotPermittedFault
   extends /*@__PURE__*/ S.TaggedErrorClass<OperationNotPermittedFault>()(
     "OperationNotPermittedFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TooManyTagsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsFault>()(
     "TooManyTagsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TypeAlreadyExistsFault
   extends /*@__PURE__*/ S.TaggedErrorClass<TypeAlreadyExistsFault>()(
     "TypeAlreadyExistsFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class TypeDeprecatedFault
   extends /*@__PURE__*/ S.TaggedErrorClass<TypeDeprecatedFault>()(
     "TypeDeprecatedFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class TypeNotDeprecatedFault
   extends /*@__PURE__*/ S.TaggedErrorClass<TypeNotDeprecatedFault>()(
     "TypeNotDeprecatedFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class UnknownResourceFault
   extends /*@__PURE__*/ S.TaggedErrorClass<UnknownResourceFault>()(
     "UnknownResourceFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WorkflowExecutionAlreadyStartedFault
   extends /*@__PURE__*/ S.TaggedErrorClass<WorkflowExecutionAlreadyStartedFault>()(
     "WorkflowExecutionAlreadyStartedFault",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type DomainName = string;
 export interface ExecutionTimeFilter {

--- a/packages/aws/src/services/synthetics.ts
+++ b/packages/aws/src/services/synthetics.ts
@@ -88,67 +88,67 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalFailureException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalFailureException>()(
     "InternalFailureException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class RequestEntityTooLargeException
   extends /*@__PURE__*/ S.TaggedErrorClass<RequestEntityTooLargeException>()(
     "RequestEntityTooLargeException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(413),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type GroupIdentifier = string;

--- a/packages/aws/src/services/taxsettings.ts
+++ b/packages/aws/src/services/taxsettings.ts
@@ -106,44 +106,44 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: SensitiveString },
+    { message: SensitiveString.pipe(T.ErrorMessage()) },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export class AttachmentUploadException
   extends /*@__PURE__*/ S.TaggedErrorClass<AttachmentUploadException>()(
     "AttachmentUploadException",
-    { message: SensitiveString },
+    { message: SensitiveString.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class CaseCreationLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<CaseCreationLimitExceededException>()(
     "CaseCreationLimitExceededException",
-    { message: SensitiveString },
+    { message: SensitiveString.pipe(T.ErrorMessage()) },
     T.HttpError(413),
   ).pipe(C.withBadRequestError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: SensitiveString, errorCode: S.String },
+    { message: SensitiveString.pipe(T.ErrorMessage()), errorCode: S.String },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: SensitiveString, errorCode: S.String },
+    { message: SensitiveString.pipe(T.ErrorMessage()), errorCode: S.String },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: SensitiveString, errorCode: S.String },
+    { message: SensitiveString.pipe(T.ErrorMessage()), errorCode: S.String },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: SensitiveString,
+      message: SensitiveString.pipe(T.ErrorMessage()),
       errorCode: S.suspend(() => ValidationExceptionErrorCode).annotate({
         identifier: "ValidationExceptionErrorCode",
       }),

--- a/packages/aws/src/services/textract.ts
+++ b/packages/aws/src/services/textract.ts
@@ -88,22 +88,34 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String), Code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Code: S.optional(S.String),
+    },
   ).pipe(C.withAuthError) {}
 export class BadDocumentException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadDocumentException>()(
     "BadDocumentException",
-    { Message: S.optional(S.String), Code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Code: S.optional(S.String),
+    },
   ) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String), Code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Code: S.optional(S.String),
+    },
   ) {}
 export class DocumentTooLargeException
   extends /*@__PURE__*/ S.TaggedErrorClass<DocumentTooLargeException>()(
     "DocumentTooLargeException",
-    { Message: S.optional(S.String), Code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Code: S.optional(S.String),
+    },
   ) {}
 export class HumanLoopQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<HumanLoopQuotaExceededException>()(
@@ -112,7 +124,7 @@ export class HumanLoopQuotaExceededException
       ResourceType: S.optional(S.String),
       QuotaCode: S.optional(S.String),
       ServiceCode: S.optional(S.String),
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Code: S.optional(S.String),
     },
     T.HttpError(402),
@@ -120,67 +132,106 @@ export class HumanLoopQuotaExceededException
 export class IdempotentParameterMismatchException
   extends /*@__PURE__*/ S.TaggedErrorClass<IdempotentParameterMismatchException>()(
     "IdempotentParameterMismatchException",
-    { Message: S.optional(S.String), Code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Code: S.optional(S.String),
+    },
   ) {}
 export class InternalServerError
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerError>()(
     "InternalServerError",
-    { Message: S.optional(S.String), Code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Code: S.optional(S.String),
+    },
   ) {}
 export class InvalidJobIdException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidJobIdException>()(
     "InvalidJobIdException",
-    { Message: S.optional(S.String), Code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Code: S.optional(S.String),
+    },
   ) {}
 export class InvalidKMSKeyException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidKMSKeyException>()(
     "InvalidKMSKeyException",
-    { Message: S.optional(S.String), Code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Code: S.optional(S.String),
+    },
   ) {}
 export class InvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterException>()(
     "InvalidParameterException",
-    { Message: S.optional(S.String), Code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Code: S.optional(S.String),
+    },
   ) {}
 export class InvalidS3ObjectException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidS3ObjectException>()(
     "InvalidS3ObjectException",
-    { Message: S.optional(S.String), Code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Code: S.optional(S.String),
+    },
   ) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { Message: S.optional(S.String), Code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Code: S.optional(S.String),
+    },
   ) {}
 export class ProvisionedThroughputExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ProvisionedThroughputExceededException>()(
     "ProvisionedThroughputExceededException",
-    { Message: S.optional(S.String), Code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Code: S.optional(S.String),
+    },
   ) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String), Code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Code: S.optional(S.String),
+    },
   ) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.optional(S.String), Code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Code: S.optional(S.String),
+    },
   ) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String), Code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Code: S.optional(S.String),
+    },
   ) {}
 export class UnsupportedDocumentException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedDocumentException>()(
     "UnsupportedDocumentException",
-    { Message: S.optional(S.String), Code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Code: S.optional(S.String),
+    },
   ) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String), Code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Code: S.optional(S.String),
+    },
   ) {}
 export type ImageBlob = Uint8Array;
 export type S3Bucket = string;

--- a/packages/aws/src/services/timestream-influxdb.ts
+++ b/packages/aws/src/services/timestream-influxdb.ts
@@ -90,38 +90,46 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.all(T.HttpError(429), T.Retryable()),
@@ -130,7 +138,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.suspend(() => ValidationExceptionReason).annotate({
         identifier: "ValidationExceptionReason",
       }),

--- a/packages/aws/src/services/timestream-query.ts
+++ b/packages/aws/src/services/timestream-query.ts
@@ -105,7 +105,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "AccessDenied", httpResponseCode: 403 }),
       T.HttpError(403),
@@ -114,49 +114,52 @@ export class AccessDeniedException
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidEndpointException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidEndpointException>()(
     "InvalidEndpointException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(421),
   ) {}
 export class QueryExecutionException
   extends /*@__PURE__*/ S.TaggedErrorClass<QueryExecutionException>()(
     "QueryExecutionException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String), ScheduledQueryArn: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ScheduledQueryArn: S.optional(S.String),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class TimestreamNotOnboarded
   extends /*@__PURE__*/ S.TaggedErrorClass<TimestreamNotOnboarded>()(
     "TimestreamNotOnboarded",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "AccessDeniedException",
       message: {
@@ -167,7 +170,7 @@ export class TimestreamNotOnboarded
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type QueryId = string;

--- a/packages/aws/src/services/timestream-write.ts
+++ b/packages/aws/src/services/timestream-write.ts
@@ -105,32 +105,32 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidEndpointException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidEndpointException>()(
     "InvalidEndpointException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(421),
   ) {}
 export class RejectedRecordsException
   extends /*@__PURE__*/ S.TaggedErrorClass<RejectedRecordsException>()(
     "RejectedRecordsException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       RejectedRecords: S.optional(
         S.suspend(() => RejectedRecords).annotate({
           identifier: "RejectedRecords",
@@ -142,25 +142,25 @@ export class RejectedRecordsException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class TimestreamNotOnboarded
   extends /*@__PURE__*/ S.TaggedErrorClass<TimestreamNotOnboarded>()(
     "TimestreamNotOnboarded",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "AccessDeniedException",
       message: {
@@ -171,7 +171,7 @@ export class TimestreamNotOnboarded
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type ClientRequestToken = string | redacted.Redacted<string>;

--- a/packages/aws/src/services/tnb.ts
+++ b/packages/aws/src/services/tnb.ts
@@ -85,37 +85,37 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type NsLcmOpOccId = string;

--- a/packages/aws/src/services/transcribe-streaming.ts
+++ b/packages/aws/src/services/transcribe-streaming.ts
@@ -88,37 +88,37 @@ const rules = T.EndpointResolver((p, _) => {
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalFailureException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalFailureException>()(
     "InternalFailureException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export type SessionId = string;

--- a/packages/aws/src/services/transcribe.ts
+++ b/packages/aws/src/services/transcribe.ts
@@ -100,31 +100,31 @@ const rules = T.EndpointResolver((p, _) => {
 export class BadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestException>()(
     "BadRequestException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalFailureException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalFailureException>()(
     "InternalFailureException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class NotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<NotFoundException>()(
     "NotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export type CategoryName = string;

--- a/packages/aws/src/services/transfer.ts
+++ b/packages/aws/src/services/transfer.ts
@@ -90,7 +90,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "AccessDenied", httpResponseCode: 403 }),
       T.HttpError(403),
@@ -99,43 +99,51 @@ export class AccessDeniedException
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServiceError
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServiceError>()(
     "InternalServiceError",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class InvalidNextTokenException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidNextTokenException>()(
     "InvalidNextTokenException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceExistsException>()(
     "ResourceExistsException",
-    { Message: S.String, Resource: S.String, ResourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      Resource: S.String,
+      ResourceType: S.String,
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.String, Resource: S.String, ResourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      Resource: S.String,
+      ResourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(
       T.AwsQueryError({ code: "ServiceUnavailable", httpResponseCode: 503 }),
       T.HttpError(503),
@@ -146,6 +154,7 @@ export class ThrottlingException
     "ThrottlingException",
     {
       RetryAfterSeconds: S.optional(S.String).pipe(T.HttpHeader("Retry-After")),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}

--- a/packages/aws/src/services/translate.ts
+++ b/packages/aws/src/services/translate.ts
@@ -90,20 +90,20 @@ const rules = T.EndpointResolver((p, _) => {
 export class ConcurrentModificationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentModificationException>()(
     "ConcurrentModificationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class DetectedLanguageLowConfidenceException
   extends /*@__PURE__*/ S.TaggedErrorClass<DetectedLanguageLowConfidenceException>()(
     "DetectedLanguageLowConfidenceException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       DetectedLanguageCode: S.optional(S.String),
     },
     T.HttpError(400),
@@ -111,68 +111,71 @@ export class DetectedLanguageLowConfidenceException
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class InvalidFilterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidFilterException>()(
     "InvalidFilterException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidParameterValueException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterValueException>()(
     "InvalidParameterValueException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class TextSizeLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<TextSizeLimitExceededException>()(
     "TextSizeLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class TooManyRequestsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyRequestsException>()(
     "TooManyRequestsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { message: S.optional(S.String), ResourceArn: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ResourceArn: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class UnsupportedDisplayLanguageCodeException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedDisplayLanguageCodeException>()(
     "UnsupportedDisplayLanguageCodeException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       DisplayLanguageCode: S.optional(S.String),
     },
     T.HttpError(400),
@@ -181,7 +184,7 @@ export class UnsupportedLanguagePairException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedLanguagePairException>()(
     "UnsupportedLanguagePairException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       SourceLanguageCode: S.optional(S.String),
       TargetLanguageCode: S.optional(S.String),
     },

--- a/packages/aws/src/services/trustedadvisor.ts
+++ b/packages/aws/src/services/trustedadvisor.ts
@@ -90,37 +90,37 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(429), T.Retryable({ throttling: true })),
   ).pipe(C.withThrottlingError, C.withRetryableError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type RecommendationResourceArn = string;

--- a/packages/aws/src/services/uxc.ts
+++ b/packages/aws/src/services/uxc.ts
@@ -55,26 +55,26 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       fieldList: S.optional(
         S.suspend(() => ValidationExceptionFieldList).annotate({
           identifier: "ValidationExceptionFieldList",

--- a/packages/aws/src/services/verifiedpermissions.ts
+++ b/packages/aws/src/services/verifiedpermissions.ts
@@ -90,14 +90,14 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resources: S.suspend(() => ResourceConflictList).annotate({
         identifier: "ResourceConflictList",
       }),
@@ -107,20 +107,20 @@ export class ConflictException
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.all(T.HttpError(500), T.Retryable()),
   ).pipe(C.withServerError, C.withRetryableError) {}
 export class InvalidStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidStateException>()(
     "InvalidStateException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(406),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.String,
       resourceType: S.suspend(() => ResourceType).annotate({
         identifier: "ResourceType",
@@ -132,7 +132,7 @@ export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceType: S.suspend(() => ResourceType).annotate({
         identifier: "ResourceType",
@@ -146,7 +146,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       serviceCode: S.optional(S.String),
       quotaCode: S.optional(S.String),
     },
@@ -155,13 +155,16 @@ export class ThrottlingException
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { message: S.optional(S.String), resourceName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      resourceName: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type PolicyStoreId = string;
 export type PolicyId = string;

--- a/packages/aws/src/services/voice-id.ts
+++ b/packages/aws/src/services/voice-id.ts
@@ -87,43 +87,49 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.optional(S.String), ConflictType: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ConflictType: S.optional(S.String),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String), ResourceType: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ResourceType: S.optional(S.String),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type DomainId = string;

--- a/packages/aws/src/services/vpc-lattice.ts
+++ b/packages/aws/src/services/vpc-lattice.ts
@@ -88,20 +88,24 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.all(T.HttpError(500), T.Retryable()),
@@ -109,14 +113,18 @@ export class InternalServerException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.String, resourceId: S.String, resourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      resourceId: S.String,
+      resourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceType: S.String,
       serviceCode: S.String,
@@ -128,7 +136,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       serviceCode: S.optional(S.String),
       quotaCode: S.optional(S.String),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
@@ -139,7 +147,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       reason: S.String,
       fieldList: S.optional(
         S.suspend(() => ValidationExceptionFieldList).annotate({

--- a/packages/aws/src/services/waf-regional.ts
+++ b/packages/aws/src/services/waf-regional.ts
@@ -88,18 +88,18 @@ const rules = T.EndpointResolver((p, _) => {
 export class WAFBadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFBadRequestException>()(
     "WAFBadRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFDisallowedNameException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFDisallowedNameException>()(
     "WAFDisallowedNameException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFEntityMigrationException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFEntityMigrationException>()(
     "WAFEntityMigrationException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       MigrationErrorType: S.optional(
         S.suspend(() => MigrationErrorType).annotate({
           identifier: "MigrationErrorType",
@@ -111,17 +111,17 @@ export class WAFEntityMigrationException
 export class WAFInternalErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFInternalErrorException>()(
     "WAFInternalErrorException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withServerError) {}
 export class WAFInvalidAccountException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFInvalidAccountException>()(
     "WAFInvalidAccountException",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFInvalidOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFInvalidOperationException>()(
     "WAFInvalidOperationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFInvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFInvalidParameterException>()(
@@ -138,72 +138,73 @@ export class WAFInvalidParameterException
           identifier: "ParameterExceptionReason",
         }),
       ),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
   ) {}
 export class WAFInvalidPermissionPolicyException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFInvalidPermissionPolicyException>()(
     "WAFInvalidPermissionPolicyException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFInvalidRegexPatternException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFInvalidRegexPatternException>()(
     "WAFInvalidRegexPatternException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFLimitsExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFLimitsExceededException>()(
     "WAFLimitsExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFNonEmptyEntityException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFNonEmptyEntityException>()(
     "WAFNonEmptyEntityException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFNonexistentContainerException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFNonexistentContainerException>()(
     "WAFNonexistentContainerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFNonexistentItemException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFNonexistentItemException>()(
     "WAFNonexistentItemException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFReferencedItemException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFReferencedItemException>()(
     "WAFReferencedItemException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFServiceLinkedRoleErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFServiceLinkedRoleErrorException>()(
     "WAFServiceLinkedRoleErrorException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFStaleDataException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFStaleDataException>()(
     "WAFStaleDataException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFSubscriptionNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFSubscriptionNotFoundException>()(
     "WAFSubscriptionNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFTagOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFTagOperationException>()(
     "WAFTagOperationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFTagOperationInternalErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFTagOperationInternalErrorException>()(
     "WAFTagOperationInternalErrorException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withServerError) {}
 export class WAFUnavailableEntityException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFUnavailableEntityException>()(
     "WAFUnavailableEntityException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type ResourceId = string;
 export type ResourceArn = string;

--- a/packages/aws/src/services/waf.ts
+++ b/packages/aws/src/services/waf.ts
@@ -107,18 +107,18 @@ const rules = T.EndpointResolver((p, _) => {
 export class WAFBadRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFBadRequestException>()(
     "WAFBadRequestException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFDisallowedNameException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFDisallowedNameException>()(
     "WAFDisallowedNameException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFEntityMigrationException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFEntityMigrationException>()(
     "WAFEntityMigrationException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       MigrationErrorType: S.optional(
         S.suspend(() => MigrationErrorType).annotate({
           identifier: "MigrationErrorType",
@@ -130,17 +130,17 @@ export class WAFEntityMigrationException
 export class WAFInternalErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFInternalErrorException>()(
     "WAFInternalErrorException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withServerError) {}
 export class WAFInvalidAccountException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFInvalidAccountException>()(
     "WAFInvalidAccountException",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFInvalidOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFInvalidOperationException>()(
     "WAFInvalidOperationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFInvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFInvalidParameterException>()(
@@ -157,67 +157,68 @@ export class WAFInvalidParameterException
           identifier: "ParameterExceptionReason",
         }),
       ),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
   ) {}
 export class WAFInvalidPermissionPolicyException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFInvalidPermissionPolicyException>()(
     "WAFInvalidPermissionPolicyException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFInvalidRegexPatternException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFInvalidRegexPatternException>()(
     "WAFInvalidRegexPatternException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFLimitsExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFLimitsExceededException>()(
     "WAFLimitsExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFNonEmptyEntityException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFNonEmptyEntityException>()(
     "WAFNonEmptyEntityException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFNonexistentContainerException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFNonexistentContainerException>()(
     "WAFNonexistentContainerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFNonexistentItemException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFNonexistentItemException>()(
     "WAFNonexistentItemException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFReferencedItemException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFReferencedItemException>()(
     "WAFReferencedItemException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFServiceLinkedRoleErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFServiceLinkedRoleErrorException>()(
     "WAFServiceLinkedRoleErrorException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFStaleDataException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFStaleDataException>()(
     "WAFStaleDataException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFSubscriptionNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFSubscriptionNotFoundException>()(
     "WAFSubscriptionNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFTagOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFTagOperationException>()(
     "WAFTagOperationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFTagOperationInternalErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFTagOperationInternalErrorException>()(
     "WAFTagOperationInternalErrorException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withServerError) {}
 export type ResourceName = string;
 export type ChangeToken = string;

--- a/packages/aws/src/services/wafv2.ts
+++ b/packages/aws/src/services/wafv2.ts
@@ -88,28 +88,28 @@ const rules = T.EndpointResolver((p, _) => {
 export class WAFAssociatedItemException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFAssociatedItemException>()(
     "WAFAssociatedItemException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFConfigurationWarningException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFConfigurationWarningException>()(
     "WAFConfigurationWarningException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFDuplicateItemException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFDuplicateItemException>()(
     "WAFDuplicateItemException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFExpiredManagedRuleGroupVersionException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFExpiredManagedRuleGroupVersionException>()(
     "WAFExpiredManagedRuleGroupVersionException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFFeatureNotIncludedInPricingPlanException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFFeatureNotIncludedInPricingPlanException>()(
     "WAFFeatureNotIncludedInPricingPlanException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       DisallowedFeatures: S.optional(
         S.suspend(() => DisallowedFeatures).annotate({
           identifier: "DisallowedFeatures",
@@ -120,18 +120,18 @@ export class WAFFeatureNotIncludedInPricingPlanException
 export class WAFInternalErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFInternalErrorException>()(
     "WAFInternalErrorException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withServerError) {}
 export class WAFInvalidOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFInvalidOperationException>()(
     "WAFInvalidOperationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFInvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFInvalidParameterException>()(
     "WAFInvalidParameterException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Field: S.optional(
         S.suspend(() => ParameterExceptionField).annotate({
           identifier: "ParameterExceptionField",
@@ -144,62 +144,65 @@ export class WAFInvalidParameterException
 export class WAFInvalidPermissionPolicyException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFInvalidPermissionPolicyException>()(
     "WAFInvalidPermissionPolicyException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFInvalidResourceException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFInvalidResourceException>()(
     "WAFInvalidResourceException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFLimitsExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFLimitsExceededException>()(
     "WAFLimitsExceededException",
-    { Message: S.optional(S.String), SourceType: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      SourceType: S.optional(S.String),
+    },
   ) {}
 export class WAFLogDestinationPermissionIssueException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFLogDestinationPermissionIssueException>()(
     "WAFLogDestinationPermissionIssueException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFNonexistentItemException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFNonexistentItemException>()(
     "WAFNonexistentItemException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFOptimisticLockException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFOptimisticLockException>()(
     "WAFOptimisticLockException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFServiceLinkedRoleErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFServiceLinkedRoleErrorException>()(
     "WAFServiceLinkedRoleErrorException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFSubscriptionNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFSubscriptionNotFoundException>()(
     "WAFSubscriptionNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFTagOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFTagOperationException>()(
     "WAFTagOperationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFTagOperationInternalErrorException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFTagOperationInternalErrorException>()(
     "WAFTagOperationInternalErrorException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withServerError) {}
 export class WAFUnavailableEntityException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFUnavailableEntityException>()(
     "WAFUnavailableEntityException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WAFUnsupportedAggregateKeyTypeException
   extends /*@__PURE__*/ S.TaggedErrorClass<WAFUnsupportedAggregateKeyTypeException>()(
     "WAFUnsupportedAggregateKeyTypeException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type ResourceArn = string;
 export interface AssociateWebACLRequest {

--- a/packages/aws/src/services/wellarchitected.ts
+++ b/packages/aws/src/services/wellarchitected.ts
@@ -88,14 +88,14 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       ResourceId: S.optional(S.String),
       ResourceType: S.optional(S.String),
     },
@@ -104,14 +104,14 @@ export class ConflictException
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       ResourceId: S.optional(S.String),
       ResourceType: S.optional(S.String),
     },
@@ -121,7 +121,7 @@ export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       ResourceId: S.optional(S.String),
       ResourceType: S.optional(S.String),
       QuotaCode: S.optional(S.String),
@@ -133,7 +133,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       QuotaCode: S.optional(S.String),
       ServiceCode: S.optional(S.String),
     },
@@ -143,7 +143,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       Reason: S.optional(
         S.suspend(() => ValidationExceptionReason).annotate({
           identifier: "ValidationExceptionReason",

--- a/packages/aws/src/services/wickr.ts
+++ b/packages/aws/src/services/wickr.ts
@@ -90,37 +90,37 @@ const rules = T.EndpointResolver((p, _) => {
 export class BadRequestError
   extends /*@__PURE__*/ S.TaggedErrorClass<BadRequestError>()(
     "BadRequestError",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ForbiddenError
   extends /*@__PURE__*/ S.TaggedErrorClass<ForbiddenError>()(
     "ForbiddenError",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class InternalServerError
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerError>()(
     "InternalServerError",
-    { message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(500),
   ).pipe(C.withServerError) {}
 export class RateLimitError
   extends /*@__PURE__*/ S.TaggedErrorClass<RateLimitError>()(
     "RateLimitError",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class ResourceNotFoundError
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundError>()(
     "ResourceNotFoundError",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class UnauthorizedError
   extends /*@__PURE__*/ S.TaggedErrorClass<UnauthorizedError>()(
     "UnauthorizedError",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export class ValidationError
@@ -132,7 +132,7 @@ export class ValidationError
           identifier: "ErrorDetailList",
         }),
       ),
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
     },
     T.HttpError(422),
   ).pipe(C.withBadRequestError) {}

--- a/packages/aws/src/services/wisdom.ts
+++ b/packages/aws/src/services/wisdom.ts
@@ -90,49 +90,55 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class PreconditionFailedException
   extends /*@__PURE__*/ S.TaggedErrorClass<PreconditionFailedException>()(
     "PreconditionFailedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(412),
   ) {}
 export class RequestTimeoutException
   extends /*@__PURE__*/ S.TaggedErrorClass<RequestTimeoutException>()(
     "RequestTimeoutException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.all(T.HttpError(408), T.Retryable()),
   ).pipe(C.withTimeoutError, C.withRetryableError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String), resourceName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      resourceName: S.optional(S.String),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(402),
   ).pipe(C.withQuotaError) {}
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { message: S.optional(S.String), resourceName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      resourceName: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type ClientToken = string;

--- a/packages/aws/src/services/workdocs.ts
+++ b/packages/aws/src/services/workdocs.ts
@@ -91,50 +91,53 @@ const rules = T.EndpointResolver((p, _) => {
 export class ConcurrentModificationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConcurrentModificationException>()(
     "ConcurrentModificationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ConflictingOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictingOperationException>()(
     "ConflictingOperationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class CustomMetadataLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<CustomMetadataLimitExceededException>()(
     "CustomMetadataLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class DeactivatingLastSystemUserException
   extends /*@__PURE__*/ S.TaggedErrorClass<DeactivatingLastSystemUserException>()(
     "DeactivatingLastSystemUserException",
-    { Message: S.optional(S.String), Code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Code: S.optional(S.String),
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class DocumentLockedForCommentsException
   extends /*@__PURE__*/ S.TaggedErrorClass<DocumentLockedForCommentsException>()(
     "DocumentLockedForCommentsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class DraftUploadOutOfSyncException
   extends /*@__PURE__*/ S.TaggedErrorClass<DraftUploadOutOfSyncException>()(
     "DraftUploadOutOfSyncException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class EntityAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<EntityAlreadyExistsException>()(
     "EntityAlreadyExistsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError, C.withAlreadyExistsError) {}
 export class EntityNotExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<EntityNotExistsException>()(
     "EntityNotExistsException",
     {
-      Message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       EntityIds: S.optional(
         S.suspend(() => EntityIdList).annotate({ identifier: "EntityIdList" }),
       ),
@@ -144,103 +147,106 @@ export class EntityNotExistsException
 export class FailedDependencyException
   extends /*@__PURE__*/ S.TaggedErrorClass<FailedDependencyException>()(
     "FailedDependencyException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(424),
   ) {}
 export class IllegalUserStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<IllegalUserStateException>()(
     "IllegalUserStateException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InvalidArgumentException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidArgumentException>()(
     "InvalidArgumentException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidCommentOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCommentOperationException>()(
     "InvalidCommentOperationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InvalidOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidOperationException>()(
     "InvalidOperationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(405),
   ).pipe(C.withBadRequestError) {}
 export class InvalidPasswordException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPasswordException>()(
     "InvalidPasswordException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(401),
   ).pipe(C.withAuthError) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ProhibitedStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<ProhibitedStateException>()(
     "ProhibitedStateException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class RequestedEntityTooLargeException
   extends /*@__PURE__*/ S.TaggedErrorClass<RequestedEntityTooLargeException>()(
     "RequestedEntityTooLargeException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(413),
   ).pipe(C.withBadRequestError) {}
 export class ResourceAlreadyCheckedOutException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceAlreadyCheckedOutException>()(
     "ResourceAlreadyCheckedOutException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class ServiceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceUnavailableException>()(
     "ServiceUnavailableException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(503),
   ).pipe(C.withServerError) {}
 export class StorageLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<StorageLimitExceededException>()(
     "StorageLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class StorageLimitWillExceedException
   extends /*@__PURE__*/ S.TaggedErrorClass<StorageLimitWillExceedException>()(
     "StorageLimitWillExceedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(413),
   ).pipe(C.withBadRequestError) {}
 export class TooManyLabelsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyLabelsException>()(
     "TooManyLabelsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class TooManySubscriptionsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManySubscriptionsException>()(
     "TooManySubscriptionsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class UnauthorizedOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnauthorizedOperationException>()(
     "UnauthorizedOperationException",
-    { Message: S.optional(S.String), Code: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      Code: S.optional(S.String),
+    },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class UnauthorizedResourceAccessException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnauthorizedResourceAccessException>()(
     "UnauthorizedResourceAccessException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError, C.withAuthError) {}
 export type AuthenticationHeaderType = string | redacted.Redacted<string>;

--- a/packages/aws/src/services/workmail.ts
+++ b/packages/aws/src/services/workmail.ts
@@ -90,114 +90,114 @@ const rules = T.EndpointResolver((p, _) => {
 export class DirectoryInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<DirectoryInUseException>()(
     "DirectoryInUseException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class DirectoryServiceAuthenticationFailedException
   extends /*@__PURE__*/ S.TaggedErrorClass<DirectoryServiceAuthenticationFailedException>()(
     "DirectoryServiceAuthenticationFailedException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class DirectoryUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<DirectoryUnavailableException>()(
     "DirectoryUnavailableException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class EmailAddressInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<EmailAddressInUseException>()(
     "EmailAddressInUseException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class EntityAlreadyRegisteredException
   extends /*@__PURE__*/ S.TaggedErrorClass<EntityAlreadyRegisteredException>()(
     "EntityAlreadyRegisteredException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class EntityNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<EntityNotFoundException>()(
     "EntityNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class EntityStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<EntityStateException>()(
     "EntityStateException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidConfigurationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidConfigurationException>()(
     "InvalidConfigurationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidCustomSesConfigurationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidCustomSesConfigurationException>()(
     "InvalidCustomSesConfigurationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidParameterException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterException>()(
     "InvalidParameterException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidPasswordException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPasswordException>()(
     "InvalidPasswordException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<LimitExceededException>()(
     "LimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MailDomainInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<MailDomainInUseException>()(
     "MailDomainInUseException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MailDomainNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<MailDomainNotFoundException>()(
     "MailDomainNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MailDomainStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<MailDomainStateException>()(
     "MailDomainStateException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class NameAvailabilityException
   extends /*@__PURE__*/ S.TaggedErrorClass<NameAvailabilityException>()(
     "NameAvailabilityException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class OrganizationNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<OrganizationNotFoundException>()(
     "OrganizationNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class OrganizationStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<OrganizationStateException>()(
     "OrganizationStateException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ReservedNameException
   extends /*@__PURE__*/ S.TaggedErrorClass<ReservedNameException>()(
     "ReservedNameException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class UnsupportedOperationException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedOperationException>()(
     "UnsupportedOperationException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type OrganizationId = string;
 export type EntityIdentifier = string;

--- a/packages/aws/src/services/workmailmessageflow.ts
+++ b/packages/aws/src/services/workmailmessageflow.ts
@@ -87,21 +87,21 @@ const rules = T.EndpointResolver((p, _) => {
 export class InvalidContentLocation
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidContentLocation>()(
     "InvalidContentLocation",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class MessageFrozen
   extends /*@__PURE__*/ S.TaggedErrorClass<MessageFrozen>()("MessageFrozen", {
-    message: S.optional(S.String),
+    message: S.optional(S.String).pipe(T.ErrorMessage()),
   }) {}
 export class MessageRejected
   extends /*@__PURE__*/ S.TaggedErrorClass<MessageRejected>()(
     "MessageRejected",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export type MessageIdType = string;

--- a/packages/aws/src/services/workspaces-instances.ts
+++ b/packages/aws/src/services/workspaces-instances.ts
@@ -57,20 +57,24 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { Message: S.String },
+    { message: S.String.pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { Message: S.String, ResourceId: S.String, ResourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      ResourceId: S.String,
+      ResourceType: S.String,
+    },
     T.HttpError(409),
   ).pipe(C.withConflictError) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       RetryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.all(T.HttpError(500), T.Retryable()),
@@ -78,14 +82,18 @@ export class InternalServerException
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.String, ResourceId: S.String, ResourceType: S.String },
+    {
+      message: S.String.pipe(T.ErrorMessage()),
+      ResourceId: S.String,
+      ResourceType: S.String,
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       ResourceId: S.String,
       ResourceType: S.String,
       ServiceCode: S.String,
@@ -97,7 +105,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       ServiceCode: S.optional(S.String),
       QuotaCode: S.optional(S.String),
       RetryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
@@ -108,7 +116,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      Message: S.String,
+      message: S.String.pipe(T.ErrorMessage()),
       Reason: S.suspend(() => ValidationExceptionReason).annotate({
         identifier: "ValidationExceptionReason",
       }),

--- a/packages/aws/src/services/workspaces-thin-client.ts
+++ b/packages/aws/src/services/workspaces-thin-client.ts
@@ -90,14 +90,14 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceType: S.optional(S.String),
     },
@@ -107,7 +107,7 @@ export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.HttpError(500),
@@ -116,7 +116,7 @@ export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceType: S.optional(S.String),
     },
@@ -126,7 +126,7 @@ export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceType: S.optional(S.String),
       serviceCode: S.optional(S.String),
@@ -138,7 +138,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       serviceCode: S.optional(S.String),
       quotaCode: S.optional(S.String),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
@@ -149,7 +149,7 @@ export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       reason: S.optional(
         S.suspend(() => ValidationExceptionReason).annotate({
           identifier: "ValidationExceptionReason",

--- a/packages/aws/src/services/workspaces-web.ts
+++ b/packages/aws/src/services/workspaces-web.ts
@@ -90,14 +90,14 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(403),
   ).pipe(C.withAuthError) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceType: S.optional(S.String),
     },
@@ -107,7 +107,7 @@ export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
     },
     T.HttpError(500),
@@ -116,7 +116,7 @@ export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceType: S.optional(S.String),
     },
@@ -126,7 +126,7 @@ export class ServiceQuotaExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ServiceQuotaExceededException>()(
     "ServiceQuotaExceededException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       resourceId: S.optional(S.String),
       resourceType: S.optional(S.String),
       serviceCode: S.optional(S.String),
@@ -138,7 +138,7 @@ export class ThrottlingException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottlingException>()(
     "ThrottlingException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       serviceCode: S.optional(S.String),
       quotaCode: S.optional(S.String),
       retryAfterSeconds: S.optional(S.Number).pipe(T.HttpHeader("Retry-After")),
@@ -148,14 +148,17 @@ export class ThrottlingException
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { message: S.optional(S.String), resourceName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      resourceName: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
     {
-      message: S.optional(S.String),
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
       reason: S.optional(S.String),
       fieldList: S.optional(
         S.suspend(() => ValidationExceptionFieldList).annotate({

--- a/packages/aws/src/services/workspaces.ts
+++ b/packages/aws/src/services/workspaces.ts
@@ -89,117 +89,129 @@ const rules = T.EndpointResolver((p, _) => {
 export class AccessDeniedException
   extends /*@__PURE__*/ S.TaggedErrorClass<AccessDeniedException>()(
     "AccessDeniedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAuthError) {}
 export class ApplicationNotSupportedException
   extends /*@__PURE__*/ S.TaggedErrorClass<ApplicationNotSupportedException>()(
     "ApplicationNotSupportedException",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ComputeNotCompatibleException
   extends /*@__PURE__*/ S.TaggedErrorClass<ComputeNotCompatibleException>()(
     "ComputeNotCompatibleException",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ConflictException
   extends /*@__PURE__*/ S.TaggedErrorClass<ConflictException>()(
     "ConflictException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class IncompatibleApplicationsException
   extends /*@__PURE__*/ S.TaggedErrorClass<IncompatibleApplicationsException>()(
     "IncompatibleApplicationsException",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InternalServerException
   extends /*@__PURE__*/ S.TaggedErrorClass<InternalServerException>()(
     "InternalServerException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidParameterCombinationException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterCombinationException>()(
     "InvalidParameterCombinationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidParameterValuesException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidParameterValuesException>()(
     "InvalidParameterValuesException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class InvalidResourceStateException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidResourceStateException>()(
     "InvalidResourceStateException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class OperatingSystemNotCompatibleException
   extends /*@__PURE__*/ S.TaggedErrorClass<OperatingSystemNotCompatibleException>()(
     "OperatingSystemNotCompatibleException",
-    {},
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class OperationInProgressException
   extends /*@__PURE__*/ S.TaggedErrorClass<OperationInProgressException>()(
     "OperationInProgressException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class OperationNotSupportedException
   extends /*@__PURE__*/ S.TaggedErrorClass<OperationNotSupportedException>()(
     "OperationNotSupportedException",
-    { message: S.optional(S.String), reason: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      reason: S.optional(S.String),
+    },
   ) {}
 export class ResourceAlreadyExistsException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceAlreadyExistsException>()(
     "ResourceAlreadyExistsException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ).pipe(C.withAlreadyExistsError) {}
 export class ResourceAssociatedException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceAssociatedException>()(
     "ResourceAssociatedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceCreationFailedException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceCreationFailedException>()(
     "ResourceCreationFailedException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceInUseException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceInUseException>()(
     "ResourceInUseException",
-    { message: S.optional(S.String), ResourceId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ResourceId: S.optional(S.String),
+    },
   ) {}
 export class ResourceLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceLimitExceededException>()(
     "ResourceLimitExceededException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { message: S.optional(S.String), ResourceId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ResourceId: S.optional(S.String),
+    },
   ) {}
 export class ResourceUnavailableException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceUnavailableException>()(
     "ResourceUnavailableException",
-    { message: S.optional(S.String), ResourceId: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ResourceId: S.optional(S.String),
+    },
   ) {}
 export class UnsupportedNetworkConfigurationException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedNetworkConfigurationException>()(
     "UnsupportedNetworkConfigurationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class UnsupportedWorkspaceConfigurationException
   extends /*@__PURE__*/ S.TaggedErrorClass<UnsupportedWorkspaceConfigurationException>()(
     "UnsupportedWorkspaceConfigurationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedErrorClass<ValidationException>()(
     "ValidationException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class WorkspacesDefaultRoleNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<WorkspacesDefaultRoleNotFoundException>()(
     "WorkspacesDefaultRoleNotFoundException",
-    { message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export type LinkId = string;
 export type ClientToken = string;

--- a/packages/aws/src/services/xray.ts
+++ b/packages/aws/src/services/xray.ts
@@ -85,7 +85,7 @@ const rules = T.EndpointResolver((p, _) => {
 export class GroupAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<GroupAlreadyExists>()(
     "GroupAlreadyExists",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "InvalidRequestException",
       message: { matches: " already exists$" },
@@ -94,7 +94,7 @@ export class GroupAlreadyExists
 export class GroupNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<GroupNotFound>()(
     "GroupNotFound",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "InvalidRequestException",
       message: "Group not found",
@@ -103,53 +103,56 @@ export class GroupNotFound
 export class InvalidPolicyRevisionIdException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidPolicyRevisionIdException>()(
     "InvalidPolicyRevisionIdException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class InvalidRequestException
   extends /*@__PURE__*/ S.TaggedErrorClass<InvalidRequestException>()(
     "InvalidRequestException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class LockoutPreventionException
   extends /*@__PURE__*/ S.TaggedErrorClass<LockoutPreventionException>()(
     "LockoutPreventionException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class MalformedPolicyDocumentException
   extends /*@__PURE__*/ S.TaggedErrorClass<MalformedPolicyDocumentException>()(
     "MalformedPolicyDocumentException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class PolicyCountLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<PolicyCountLimitExceededException>()(
     "PolicyCountLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class PolicySizeLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<PolicySizeLimitExceededException>()(
     "PolicySizeLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export class ResourceNotFoundException
   extends /*@__PURE__*/ S.TaggedErrorClass<ResourceNotFoundException>()(
     "ResourceNotFoundException",
-    { Message: S.optional(S.String), ResourceName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ResourceName: S.optional(S.String),
+    },
     T.HttpError(404),
   ).pipe(C.withBadRequestError) {}
 export class RuleLimitExceededException
   extends /*@__PURE__*/ S.TaggedErrorClass<RuleLimitExceededException>()(
     "RuleLimitExceededException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
   ) {}
 export class SamplingRuleAlreadyExists
   extends /*@__PURE__*/ S.TaggedErrorClass<SamplingRuleAlreadyExists>()(
     "SamplingRuleAlreadyExists",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "InvalidRequestException",
       message: "Sampling rule already exists",
@@ -158,7 +161,7 @@ export class SamplingRuleAlreadyExists
 export class SamplingRuleNotFound
   extends /*@__PURE__*/ S.TaggedErrorClass<SamplingRuleNotFound>()(
     "SamplingRuleNotFound",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.SyntheticError({
       from: "InvalidRequestException",
       message: "Sampling rule does not exist",
@@ -167,13 +170,16 @@ export class SamplingRuleNotFound
 export class ThrottledException
   extends /*@__PURE__*/ S.TaggedErrorClass<ThrottledException>()(
     "ThrottledException",
-    { Message: S.optional(S.String) },
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
     T.HttpError(429),
   ).pipe(C.withThrottlingError) {}
 export class TooManyTagsException
   extends /*@__PURE__*/ S.TaggedErrorClass<TooManyTagsException>()(
     "TooManyTagsException",
-    { Message: S.optional(S.String), ResourceName: S.optional(S.String) },
+    {
+      message: S.optional(S.String).pipe(T.ErrorMessage()),
+      ResourceName: S.optional(S.String),
+    },
     T.HttpError(400),
   ).pipe(C.withBadRequestError) {}
 export type TraceId = string;

--- a/packages/aws/src/traits.ts
+++ b/packages/aws/src/traits.ts
@@ -3,6 +3,7 @@ import * as S from "effect/Schema";
 import * as AST from "effect/SchemaAST";
 import * as SchemaTransformation from "effect/SchemaTransformation";
 import * as Stream from "effect/Stream";
+import { ErrorMessage, errorMessageSymbol } from "./error-message.ts";
 import type { Protocol } from "./client/protocol.ts";
 import type { Request as ProtocolRequest } from "./client/request.ts";
 import { applyHttpChecksum } from "./middleware/checksum.ts";
@@ -33,6 +34,10 @@ import {
 // objects, the `all` combinator) is core's; this module supplies the AWS
 // trait vocabulary on top of it.
 export { all, type Annotation };
+
+// The canonical-message trait is defined in a leaf module so `errors.ts` can
+// reach it without importing this one — see its header for the cycle.
+export { ErrorMessage, errorMessageSymbol };
 
 /**
  * Any type that has an .annotate() method returning itself.
@@ -1130,6 +1135,10 @@ export const getSyntheticError = (
   ast: AST.AST,
 ): SyntheticErrorTrait | undefined =>
   getAnnotationUnwrap<SyntheticErrorTrait>(ast, syntheticErrorSymbol);
+
+/** True when this member is the error shape's canonical message. */
+export const hasErrorMessage = (prop: AST.PropertySignature): boolean =>
+  hasPropAnnotation(prop, errorMessageSymbol);
 
 export const getTimestampFormat = (
   prop: AST.PropertySignature,

--- a/packages/aws/test/__snapshots__/json-schema.test.ts.snap
+++ b/packages/aws/test/__snapshots__/json-schema.test.ts.snap
@@ -9349,6 +9349,16 @@ exports[`JSON Schema Generation > Error Schemas (TaggedError) > BucketAlreadyExi
           ],
           "type": "string",
         },
+        "message": {
+          "anyOf": [
+            {
+              "type": "string",
+            },
+            {
+              "type": "null",
+            },
+          ],
+        },
       },
       "required": [
         "_tag",

--- a/packages/aws/test/error-message.test.ts
+++ b/packages/aws/test/error-message.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Every AWS error class exposes the service's failure text as `Error.message`.
+ *
+ * AWS spells the member `message` in most models, `Message` in the XML-era
+ * ones, and omits it entirely from others — every ec2 error shape declares no
+ * members at all. Because the response parser decodes error payloads through
+ * the class schema, and a struct decode drops any key the schema doesn't
+ * declare, an undeclared message was silently discarded: `runInstances` with a
+ * bad IAM instance profile produced an `InvalidParameterValue` carrying
+ * nothing, strictly less useful than the `UnknownAwsError` it replaced, which
+ * at least printed the text (distilled #160).
+ *
+ * The generator now emits exactly one `T.ErrorMessage`-tagged `message` member
+ * per error class. These tests pin both halves of that contract: the schema
+ * shape the generator must keep emitting, and the decoded result callers see.
+ */
+import { it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as S from "effect/Schema";
+import { describe, expect } from "vitest";
+import { makeResponseParser } from "../src/client/response-parser.ts";
+import type { Response } from "../src/client/response.ts";
+import { AccessDeniedException } from "../src/errors.ts";
+import { ec2QueryProtocol } from "../src/protocols/ec2-query.ts";
+import { hasErrorMessage } from "../src/traits.ts";
+import { getPropertySignatures } from "../src/util/ast.ts";
+import { BackupInUseException } from "../src/services/dynamodb.ts";
+import {
+  InvalidParameterValue,
+  RunInstancesRequest,
+} from "../src/services/ec2.ts";
+
+const parseError = (response: Response, errors: S.Top[]) =>
+  makeResponseParser<unknown>(
+    { input: RunInstancesRequest, output: RunInstancesRequest, errors },
+    { protocol: ec2QueryProtocol } as never,
+  )(response);
+
+const wire = (code: string, message: string): Response => ({
+  status: 400,
+  statusText: "Bad Request",
+  headers: {},
+  body: `<?xml version="1.0" encoding="UTF-8"?>
+<Response><Errors><Error><Code>${code}</Code><Message>${message}</Message></Error></Errors><RequestID>req-160</RequestID></Response>`,
+});
+
+/** The exact message EC2 returns for the issue #160 repro. */
+const IAM_MSG =
+  "Value (not a valid profile name!!) for parameter iamInstanceProfile.name is invalid. Invalid IAM Instance Profile name";
+
+describe("canonical error message", () => {
+  describe("schema contract", () => {
+    // One tagged member, named `message`, on every error class — whatever the
+    // source model declared. Left untested, the generator could quietly go
+    // back to emitting `{}` and the message would vanish again.
+    for (const [label, schema] of [
+      ["declared no members (ec2)", InvalidParameterValue],
+      ["declared capital Message", AccessDeniedException],
+      ["declared lowercase message", BackupInUseException],
+    ] as const) {
+      it(`${label} -> single tagged \`message\` member`, () => {
+        const props = getPropertySignatures((schema as S.Top).ast);
+        const tagged = props.filter(hasErrorMessage);
+
+        expect(tagged).toHaveLength(1);
+        expect(String(tagged[0]!.name)).toBe("message");
+        expect(props.map((p) => String(p.name))).not.toContain("Message");
+      });
+    }
+  });
+
+  describe("decoded result", () => {
+    it.effect("ec2 InvalidParameterValue keeps the message (#160)", () =>
+      Effect.gen(function* () {
+        const e = yield* parseError(wire("InvalidParameterValue", IAM_MSG), [
+          InvalidParameterValue,
+        ]).pipe(Effect.flip);
+
+        expect(e).toBeInstanceOf(InvalidParameterValue);
+        expect((e as InvalidParameterValue).message).toBe(IAM_MSG);
+        // What lands in a log or an unhandled rejection. A bare tag here is
+        // the regression that made the typed error worse than the untyped one.
+        expect(String(e)).toContain(IAM_MSG);
+      }),
+    );
+
+    it.effect("a renamed capital-Message class is not duplicated", () =>
+      Effect.gen(function* () {
+        const msg = "User is not authorized to perform ec2:RunInstances";
+        const e = yield* parseError(
+          wire("AccessDeniedException", msg),
+          [],
+        ).pipe(Effect.flip);
+
+        expect(e).toBeInstanceOf(AccessDeniedException);
+        expect((e as AccessDeniedException).message).toBe(msg);
+        // Carrying the same text on two properties is what forced the parser
+        // to guess by spelling before the trait existed.
+        expect((e as Record<string, unknown>).Message).toBeUndefined();
+      }),
+    );
+
+    it.effect("an unmatched wire code still reports its message", () =>
+      Effect.gen(function* () {
+        const e = yield* parseError(
+          wire("SomeUnmodelledEc2Error", "an internal error occurred"),
+          [],
+        ).pipe(Effect.flip);
+
+        expect((e as Error).message).toBe("an internal error occurred");
+      }),
+    );
+  });
+});


### PR DESCRIPTION
Closes #160.

## The bug behind the bug

#160 reported `UnknownAwsError` for an ec2 `runInstances` call with a malformed IAM instance profile name. The typing half was already fixed by the v0→v1 model regeneration — `InvalidParameterValue` is a real class now. But that fix exposed a second problem, and I ran the original repro against EC2 to check it.

Before this PR, live:

```
_tag:      InvalidParameterValue
message:   ""
own keys:  ["_tag"]
String(e): InvalidParameterValue
```

That is the whole error. AWS sent `Value (...) for parameter iamInstanceProfile.name is invalid. Invalid IAM Instance Profile name` — the part that tells you what to fix — and the client dropped it. Catching the typed error gave you strictly less than the `UnknownAwsError` it replaced, which at least printed the text.

The cause: the response parser decodes error payloads through the error class's own schema, and a struct decode drops any key the schema doesn't declare. AWS declares no members at all on many error shapes, so there was nowhere for the message to land.

After:

```
_tag:      InvalidParameterValue
message:   "Value (not a valid profile name!!) for parameter iamInstanceProfile.name is invalid. Invalid IAM Instance Profile name"
String(e): InvalidParameterValue: Value (not a valid profile name!!) for parameter ...
```

## Scale

Measured across all 6021 generated error classes:

| source shape declares | count | `.message` before |
|---|---|---|
| `message` | 3332 | worked |
| `Message` | 2241 | worked, duplicated onto both properties |
| neither | 448 | **lost entirely** |

The 448 is 369 field-less (all 233 of ec2, 46 of s3) plus 79 with other fields but no message member. On ec2 this was every single error.

The `Message` group worked only by accident of an untagged heuristic — the parser copied `Message` onto `message` in the raw data, then reached for `decoded.Message` after the decode. Same text on two properties, nothing marking either canonical.

## Approach

A `T.ErrorMessage` trait marks the member carrying the service's failure text. The generator guarantees exactly one per error class, named `message` — tag it where the model declares `message`, rename where it declares `Message`, synthesize where it declares neither. The parser finds the message by trait instead of by spelling.

`Message` is renamed rather than duplicated; carrying the text twice is what made the heuristics necessary.

The trait lives in its own leaf module (`src/error-message.ts`) rather than `traits.ts`: `errors.ts` needs it at module-init time, and `traits.ts` imports every protocol, each of which imports `errors.ts`. Reaching for it there leaves the annotation undefined — it took out six protocol suites before I moved it.

## ⚠️ Breaking

`err.Message` is now `undefined` on the 2241 classes that declared it. `err.message` always holds the text, and lands as the native non-enumerable `Error.message`, so `String(err)` and stack traces carry it while `Object.keys` stays clean.

## Verification

- Original #160 repro run live against EC2, before and after. Wire code confirmed as exactly `InvalidParameterValue` via the AWS CLI.
- Invariant scan: all 6021 error classes carry exactly one `T.ErrorMessage()`, all named `message`, zero capital `Message` remaining.
- `tsc -b` clean.
- Offline suite: 8551 passing.
- New regression test pins both the schema shape the generator must keep emitting and the decoded result, across all three source shapes.

## Note on pre-existing failures

Ten tests in `packages/aws` already fail on `main` — six stale json-schema snapshots, an S3 checksum-algorithm count, two aws-query required-field assertions, and a redshift-serverless redaction case. I verified they fail identically with this branch's changes stashed, and left them alone rather than fold unrelated re-baselining in here. The only snapshot updated is `BucketAlreadyExists - S3 error`, whose diff is exactly the added `message` field.

## Known gap

52 classes declare `exceptionMessage` or `detailedMessage` and no `message`. They get a synthesized `message` alongside those, so nothing is lost, but if a service puts its text under those keys on the wire it lands there rather than on `.message`. Left for follow-up — adding spelling heuristics to the layer the trait exists to de-heuristic seemed like the wrong trade.
